### PR TITLE
Change staff comments to rich text, restrict dA api request scope

### DIFF
--- a/app/Models/Submission/Submission.php
+++ b/app/Models/Submission/Submission.php
@@ -16,7 +16,7 @@ class Submission extends Model
      */
     protected $fillable = [
         'prompt_id', 'user_id', 'staff_id', 'url',
-        'comments', 'staff_comments', 
+        'comments', 'staff_comments', 'parsed_staff_comments',
         'status', 'data'
     ];
 

--- a/app/Services/DeviantArtService.php
+++ b/app/Services/DeviantArtService.php
@@ -23,7 +23,6 @@ class DeviantArtService extends Service
 
         $this->deviantart  = null;
         $this->scopes = [
-            'basic',
             'user',
         ];
 

--- a/app/Services/SubmissionManager.php
+++ b/app/Services/SubmissionManager.php
@@ -187,6 +187,8 @@ class SubmissionManager extends Service
             elseif($data['submission']->status == 'Pending') $submission = $data['submission'];
             else $submission = null;
             if(!$submission) throw new \Exception("Invalid submission.");
+			
+			if(isset($data['staff_comments']) && $data['staff_comments']) $data['parsed_staff_comments'] = parse($data['staff_comments']);
 
             // The only things we need to set are: 
             // 1. staff comment
@@ -194,6 +196,7 @@ class SubmissionManager extends Service
             // 3. status
             $submission->update([
                 'staff_comments' => $data['staff_comments'],
+				'parsed_staff_comments' => $data['parsed_staff_comments'],
                 'staff_id' => $user->id,
                 'status' => 'Rejected'
             ]);
@@ -282,6 +285,8 @@ class SubmissionManager extends Service
                 $user->settings->submission_count++;
                 $user->settings->save();
             }
+			
+			if(isset($data['staff_comments']) && $data['staff_comments']) $data['parsed_staff_comments'] = parse($data['staff_comments']);
 
             // Finally, set: 
 			// 1. staff comments
@@ -290,6 +295,7 @@ class SubmissionManager extends Service
             // 4. final rewards
             $submission->update([
 			    'staff_comments' => $data['staff_comments'],
+				'parsed_staff_comments' => $data['parsed_staff_comments'],
                 'staff_id' => $user->id,
                 'status' => 'Approved',
                 'data' => json_encode(getDataReadyAssets($rewards))

--- a/app/Services/SubmissionManager.php
+++ b/app/Services/SubmissionManager.php
@@ -189,6 +189,7 @@ class SubmissionManager extends Service
             if(!$submission) throw new \Exception("Invalid submission.");
 			
 			if(isset($data['staff_comments']) && $data['staff_comments']) $data['parsed_staff_comments'] = parse($data['staff_comments']);
+			else $data['parsed_staff_comments'] = null;
 
             // The only things we need to set are: 
             // 1. staff comment
@@ -287,6 +288,7 @@ class SubmissionManager extends Service
             }
 			
 			if(isset($data['staff_comments']) && $data['staff_comments']) $data['parsed_staff_comments'] = parse($data['staff_comments']);
+			else $data['parsed_staff_comments'] = null;
 
             // Finally, set: 
 			// 1. staff comments

--- a/database/migrations/2020_06_01_124250_add_parsed_submission_comments.php
+++ b/database/migrations/2020_06_01_124250_add_parsed_submission_comments.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddParsedSubmissionComments extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('submissions', function (Blueprint $table) {
+            //
+            $table->text('parsed_staff_comments')->nullable()->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('submissions', function (Blueprint $table) {
+            //
+            $table->dropColumn('parsed_staff_comments');
+        });
+    }
+}

--- a/resources/views/admin/submissions/submission.blade.php
+++ b/resources/views/admin/submissions/submission.blade.php
@@ -43,8 +43,14 @@
     <h2>Comments</h2>
     <div class="card mb-3"><div class="card-body">{!! nl2br(htmlentities($submission->comments)) !!}</div></div>
     @if(Auth::check() && $submission->staff_comments && ($submission->user_id == Auth::user()->id || Auth::user()->hasPower('manage_submissions')))
-        <h5 class="text-danger">Staff Comments ({!! $submission->staff->displayName !!})</h5>
-        <div class="card border-danger mb-3"><div class="card-body">{!! nl2br(htmlentities($submission->staff_comments)) !!}</div></div>
+        <h2>Staff Comments ({!! $submission->staff->displayName !!})</h2>
+        <div class="card mb-3"><div class="card-body">
+		    @if(isset($submission->parsed_staff_comments))
+                {!! $submission->parsed_staff_comments !!}
+            @else
+                {!! $submission->staff_comments !!}
+            @endif
+		</div></div>
     @endif
 
     {!! Form::open(['url' => url()->current(), 'id' => 'submissionForm']) !!}
@@ -67,10 +73,9 @@
             <a href="#" class="btn btn-outline-info" id="addCharacter">Add Character</a>
         </div>
 		<div class="form-group">
-            {!! Form::label('staff_comments', 'Staff Comments') !!}
-            {!! Form::textarea('', null, ['class' => 'form-control', 'id' =>  'modalStaffComments']) !!}
+            {!! Form::label('staff_comments', 'Staff Comments (Optional)') !!}
+			{!! Form::textarea('staff_comments', $submission->staffComments, ['class' => 'form-control wysiwyg']) !!}
         </div>
-        {!! Form::hidden('staff_comments', null, ['id' => 'staffComments']) !!}
         <div class="text-right">
             <a href="#" class="btn btn-danger mr-2" id="rejectionButton">Reject</a>
             <a href="#" class="btn btn-success" id="approvalButton">Approve</a>
@@ -175,8 +180,6 @@
         $(document).ready(function() {
             var $confirmationModal = $('#confirmationModal');
             var $submissionForm = $('#submissionForm');
-            var $staffComments = $('#staffComments');
-            var $modalStaffComments = $('#modalStaffComments');
 
             var $approvalButton = $('#approvalButton');
             var $approvalContent = $('#approvalContent');
@@ -202,14 +205,12 @@
 
             $approvalSubmit.on('click', function(e) {
                 e.preventDefault();
-                $staffComments.val($modalStaffComments.val());
                 $submissionForm.attr('action', '{{ url()->current() }}/approve');
                 $submissionForm.submit();
             });
 
             $rejectionSubmit.on('click', function(e) {
                 e.preventDefault();
-                $staffComments.val($modalStaffComments.val());
                 $submissionForm.attr('action', '{{ url()->current() }}/reject');
                 $submissionForm.submit();
             });

--- a/resources/views/home/_submission_content.blade.php
+++ b/resources/views/home/_submission_content.blade.php
@@ -10,7 +10,7 @@
     </div>
     @if($submission->prompt_id)
         <div class="row">
-            <div class="col-md-2 col-4"><h5>Prompt</h5></div>
+            <div class="col-md-2 col-4"><h5>Submission Type</h5></div>
             <div class="col-md-10 col-8">{!! $submission->prompt->displayName !!}</div>
         </div>
     @endif
@@ -33,7 +33,13 @@
 <div class="card mb-3"><div class="card-body">{!! nl2br(htmlentities($submission->comments)) !!}</div></div>
 @if(Auth::check() && $submission->staff_comments && ($submission->user_id == Auth::user()->id || Auth::user()->hasPower('manage_submissions')))
     <h2>Staff Comments</h2>
-    <div class="card mb-3"><div class="card-body">{!! nl2br(htmlentities($submission->staff_comments)) !!}</div></div>
+    <div class="card mb-3"><div class="card-body">
+	    @if(isset($submission->parsed_staff_comments))
+            {!! $submission->parsed_staff_comments !!}
+        @else
+            {!! $submission->staff_comments !!}
+        @endif
+		</div></div>
 @endif
 
 <h2>Rewards</h2>

--- a/resources/views/home/_submission_content.blade.php
+++ b/resources/views/home/_submission_content.blade.php
@@ -10,7 +10,7 @@
     </div>
     @if($submission->prompt_id)
         <div class="row">
-            <div class="col-md-2 col-4"><h5>Submission Type</h5></div>
+            <div class="col-md-2 col-4"><h5>Prompt</h5></div>
             <div class="col-md-10 col-8">{!! $submission->prompt->displayName !!}</div>
         </div>
     @endif


### PR DESCRIPTION
Bugs fixed:
- dA api request scope unnecessarily large

Misc:
- Staff comment entry on submissions now uses Tiny editor and is parsed in accordance with this
- Note: Displays parsed staff comments if present and non-parsed if only those are present for backwards compat

Requires php artisan migrate!