### PR TITLE
Add gift writing status to characters, etc.

### DIFF
--- a/app/Http/Controllers/BrowseController.php
+++ b/app/Http/Controllers/BrowseController.php
@@ -144,6 +144,18 @@ class BrowseController extends Controller
                 $query->where('is_gift_art_allowed', 1)->orWhere('is_gift_art_allowed', 2);
             break;
         }
+        if($request->get('is_gift_writing_allowed')) switch($request->get('is_gift_writing_allowed')) {
+            case 1:
+                $query->where('is_gift_writing_allowed', 1);
+            break;
+            case 2:
+                $query->where('is_gift_writing_allowed', 2);
+            break;
+            case 3:
+                $query->where('is_gift_writing_allowed', 1)->orWhere('is_gift_writing_allowed', 2);
+            break;
+        }
+        
         if($request->get('is_sellable')) $query->where('is_sellable', 1);
         if($request->get('is_tradeable')) $query->where('is_tradeable', 1);
         if($request->get('is_giftable')) $query->where('is_giftable', 1);

--- a/app/Http/Controllers/Characters/CharacterController.php
+++ b/app/Http/Controllers/Characters/CharacterController.php
@@ -115,7 +115,7 @@ class CharacterController extends Controller
         $isOwner = ($this->character->user_id == Auth::user()->id);
         if(!$isMod && !$isOwner) abort(404);
         
-        if($service->updateCharacterProfile($request->only(['name', 'text', 'is_gift_art_allowed', 'is_trading', 'alert_user']), $this->character, Auth::user(), !$isOwner)) {
+        if($service->updateCharacterProfile($request->only(['name', 'text', 'is_gift_art_allowed', 'is_gift_writing_allowed', 'is_trading', 'alert_user']), $this->character, Auth::user(), !$isOwner)) {
             flash('Profile edited successfully.')->success();
         }
         else {

--- a/app/Http/Controllers/Users/BookmarkController.php
+++ b/app/Http/Controllers/Users/BookmarkController.php
@@ -73,7 +73,7 @@ class BookmarkController extends Controller
     {
         $id ? $request->validate(CharacterBookmark::$updateRules) : $request->validate(CharacterBookmark::$createRules);
         $data = $request->only([
-            'character_id', 'notify_on_trade_status', 'notify_on_gift_art_status', 'notify_on_transfer', 'notify_on_image', 'comment'
+            'character_id', 'notify_on_trade_status', 'notify_on_gift_art_status', 'notify_on_gift_writing_status', 'notify_on_transfer', 'notify_on_image', 'comment'
         ]);
         if($id && $service->updateBookmark($data + ['bookmark_id' => $id], Auth::user())) {
             flash('Bookmark updated successfully.')->success();

--- a/app/Models/Character/Character.php
+++ b/app/Models/Character/Character.php
@@ -35,7 +35,7 @@ class Character extends Model
         'owner_alias', 'number', 'slug', 'description', 'parsed_description', 
         'is_sellable', 'is_tradeable', 'is_giftable',
         'sale_value', 'transferrable_at', 'is_visible',
-        'is_gift_art_allowed', 'is_trading', 'sort',
+        'is_gift_art_allowed', 'is_gift_writing_allowed', 'is_trading', 'sort',
         'is_myo_slot', 'name', 'trade_id'
     ];
 
@@ -474,6 +474,9 @@ class Character extends Model
                     break;
                 case 'BOOKMARK_GIFTS':
                     $column = 'notify_on_gift_art_status';
+                    break;
+                case 'BOOKMARK_GIFT_WRITING':
+                    $column = 'notify_on_gift_writing_status';
                     break;
                 case 'BOOKMARK_OWNER':
                     $column = 'notify_on_transfer';

--- a/app/Models/Character/CharacterBookmark.php
+++ b/app/Models/Character/CharacterBookmark.php
@@ -13,7 +13,7 @@ class CharacterBookmark extends Model
      * @var array
      */
     protected $fillable = [
-        'user_id', 'character_id', 'notify_on_trade_status', 'notify_on_gift_art_status', 'notify_on_transfer', 'notify_on_image', 'comment'
+        'user_id', 'character_id', 'notify_on_trade_status', 'notify_on_gift_art_status', 'notify_on_gift_writing_status', 'notify_on_transfer', 'notify_on_image', 'comment'
     ];
     
     /**

--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -141,4 +141,5 @@ class Notification extends Model
     const BOOKMARK_OWNER                  = 36;
     const BOOKMARK_IMAGE                  = 37;
     const CHARACTER_TRANSFER_ACCEPTABLE   = 38;
+    const BOOKMARK_GIFT_WRITING           = 39;
 }

--- a/app/Services/BookmarkManager.php
+++ b/app/Services/BookmarkManager.php
@@ -41,7 +41,8 @@ class BookmarkManager extends Service
                 'user_id' => $user->id,
                 'sort' => 0,
                 'notify_on_trade_status' => isset($data['notify_on_trade_status']) ? $data['notify_on_trade_status'] : 0, 
-                'notify_on_gift_art_status' => isset($data['notify_on_gift_art_status']) ? $data['notify_on_gift_art_status'] : 0, 
+                'notify_on_gift_art_status' => isset($data['notify_on_gift_art_status']) ? $data['notify_on_gift_art_status'] : 0,
+                'notify_on_gift_writing_status' => isset($data['notify_on_gift_writing_status']) ? $data['notify_on_gift_writing_status'] : 0, 
                 'notify_on_transfer' => isset($data['notify_on_transfer']) ? $data['notify_on_transfer'] : 0, 
                 'notify_on_image' => isset($data['notify_on_image']) ? $data['notify_on_image'] : 0, 
                 'comment' => $data['comment']
@@ -72,7 +73,8 @@ class BookmarkManager extends Service
 
             $bookmark->update([
                 'notify_on_trade_status' => isset($data['notify_on_trade_status']) ? $data['notify_on_trade_status'] : 0, 
-                'notify_on_gift_art_status' => isset($data['notify_on_gift_art_status']) ? $data['notify_on_gift_art_status'] : 0, 
+                'notify_on_gift_art_status' => isset($data['notify_on_gift_art_status']) ? $data['notify_on_gift_art_status'] : 0,
+                'notify_on_gift_writing_status' => isset($data['notify_on_gift_writing_status']) ? $data['notify_on_gift_writing_status'] : 0, 
                 'notify_on_transfer' => isset($data['notify_on_transfer']) ? $data['notify_on_transfer'] : 0,
                 'notify_on_image' => isset($data['notify_on_image']) ? $data['notify_on_image'] : 0,  
                 'comment' => $data['comment']

--- a/app/Services/CharacterManager.php
+++ b/app/Services/CharacterManager.php
@@ -1402,14 +1402,18 @@ class CharacterManager extends Service
         // Notify bookmarkers
         $character->notifyBookmarkers('BOOKMARK_OWNER');
 
-        if(Config::get('lorekeeper.settings.reset_character_info_on_transfer')) {
-            // Reset name, trading status, gift art status, and writing status
+        if(Config::get('lorekeeper.settings.reset_character_status_on_transfer')) {
+            // Reset trading status, gift art status, and writing status
             $character->update([
-                'name'                    => null,
                 'is_gift_art_allowed'     => 0,
                 'is_gift_writing_allowed' => 0,
                 'is_trading'              => 0,
             ]);
+        }
+
+        if(Config::get('lorekeeper.settings.reset_character_profile_on_transfer')) {
+            // Reset name and profile
+            $character->update(['name' => null]);
             
             // Reset profile
             $character->profile->update([

--- a/app/Services/CharacterManager.php
+++ b/app/Services/CharacterManager.php
@@ -200,6 +200,7 @@ class CharacterManager extends Service
             $characterData['is_visible'] = isset($data['is_visible']);
             $characterData['sale_value'] = isset($data['sale_value']) ? $data['sale_value'] : 0;
             $characterData['is_gift_art_allowed'] = 0;
+            $characterData['is_gift_writing_allowed'] = 0;
             $characterData['is_trading'] = 0;
             $characterData['parsed_description'] = parse($data['description']);
             if($isMyo) $characterData['is_myo_slot'] = 1;

--- a/app/Services/CharacterManager.php
+++ b/app/Services/CharacterManager.php
@@ -971,6 +971,7 @@ class CharacterManager extends Service
         try {
             $notifyTrading = false;
             $notifyGiftArt = false;
+            $notifyGiftWriting = false;
 
             // Allow updating the gift art/trading options if the editing
             // user owns the character
@@ -979,9 +980,11 @@ class CharacterManager extends Service
                 if($character->user_id != $user->id) throw new \Exception("You cannot edit this character.");
 
                 if($character->is_trading != isset($data['is_trading'])) $notifyTrading = true;
-                if($character->is_gift_art_allowed != isset($data['is_gift_art_allowed'])) $notifyGiftArt = true;
+                if(isset($data['is_gift_art_allowed']) && $character->is_gift_art_allowed != $data['is_gift_art_allowed']) $notifyGiftArt = true;
+                if(isset($data['is_gift_writing_allowed']) && $character->is_gift_writing_allowed != $data['is_gift_writing_allowed']) $notifyGiftWriting = true;
 
                 $character->is_gift_art_allowed = isset($data['is_gift_art_allowed']) && $data['is_gift_art_allowed'] <= 2 ? $data['is_gift_art_allowed'] : 0;
+                $character->is_gift_writing_allowed = isset($data['is_gift_writing_allowed']) && $data['is_gift_writing_allowed'] <= 2 ? $data['is_gift_writing_allowed'] : 0;
                 $character->is_trading = isset($data['is_trading']);
                 $character->save();
             }
@@ -1006,6 +1009,7 @@ class CharacterManager extends Service
 
             if($notifyTrading) $character->notifyBookmarkers('BOOKMARK_TRADING');
             if($notifyGiftArt) $character->notifyBookmarkers('BOOKMARK_GIFTS');
+            if($notifyGiftWriting) $character->notifyBookmarkers('BOOKMARK_GIFT_WRITING');
 
             return $this->commitReturn(true);
         } catch(\Exception $e) { 

--- a/app/Services/CharacterManager.php
+++ b/app/Services/CharacterManager.php
@@ -1402,6 +1402,20 @@ class CharacterManager extends Service
         // Notify bookmarkers
         $character->notifyBookmarkers('BOOKMARK_OWNER');
 
+        // Reset name, trading status, gift art status, and writing status
+        $character->update([
+            'name'                    => null,
+            'is_gift_art_allowed'     => 0,
+            'is_gift_writing_allowed' => 0,
+            'is_trading'              => 0,
+        ]);
+        
+        // Reset profile
+        $character->profile->update([
+            'text'        => null,
+            'parsed_text' => null
+        ]);
+
         // Add a log for the ownership change
         $this->createLog(
             $sender ? $sender->id : null, 

--- a/app/Services/CharacterManager.php
+++ b/app/Services/CharacterManager.php
@@ -1402,19 +1402,21 @@ class CharacterManager extends Service
         // Notify bookmarkers
         $character->notifyBookmarkers('BOOKMARK_OWNER');
 
-        // Reset name, trading status, gift art status, and writing status
-        $character->update([
-            'name'                    => null,
-            'is_gift_art_allowed'     => 0,
-            'is_gift_writing_allowed' => 0,
-            'is_trading'              => 0,
-        ]);
-        
-        // Reset profile
-        $character->profile->update([
-            'text'        => null,
-            'parsed_text' => null
-        ]);
+        if(Config::get('lorekeeper.settings.reset_character_info_on_transfer')) {
+            // Reset name, trading status, gift art status, and writing status
+            $character->update([
+                'name'                    => null,
+                'is_gift_art_allowed'     => 0,
+                'is_gift_writing_allowed' => 0,
+                'is_trading'              => 0,
+            ]);
+            
+            // Reset profile
+            $character->profile->update([
+                'text'        => null,
+                'parsed_text' => null
+            ]);
+        }
 
         // Add a log for the ownership change
         $this->createLog(
@@ -1907,7 +1909,7 @@ class CharacterManager extends Service
             // and clear the character's name
             if($request->character->is_myo_slot)
             {
-                $request->character->name = null;
+                if(Config::get('lorekeeper.settings.clear_myo_name_on_approval')) $request->character->name = null;
                 $request->character->is_myo_slot = 0;
                 $request->user->settings->is_fto = 0;
                 $request->user->settings->save();

--- a/app/Services/CharacterManager.php
+++ b/app/Services/CharacterManager.php
@@ -1904,8 +1904,10 @@ class CharacterManager extends Service
             $this->createLog($user->id, null, $request->character->user_id, $request->character->user->alias, $request->character->id, $request->update_type == 'MYO' ? 'MYO Design Approved' : 'Character Design Updated', '[#'.$image->id.']', 'user');
             
             // If this is for a MYO, set user's FTO status and the MYO status of the slot
+            // and clear the character's name
             if($request->character->is_myo_slot)
             {
+                $request->character->name = null;
                 $request->character->is_myo_slot = 0;
                 $request->user->settings->is_fto = 0;
                 $request->user->settings->save();

--- a/config/lorekeeper/notifications.php
+++ b/config/lorekeeper/notifications.php
@@ -245,4 +245,10 @@ return [
         'message' => 'The transfer for <a href="{character_url}">{character_name}</a> was approved by <a href="{sender_url}">{sender_name}</a>. (<a href="{url}">View Transfers</a>)',
         'url' => 'characters/transfers/incoming'
     ],
+
+    // BOOKMARK_GIFT_WRITING
+    39 => [
+        'message' => 'A character you have bookmarked (<a href="{character_url}">{character_name}</a>) has had its Gift Writing Allowed status changed. (<a href="{url}">View Bookmarks</a>)',
+        'url' => 'account/bookmarks'
+    ],
 ];

--- a/config/lorekeeper/settings.php
+++ b/config/lorekeeper/settings.php
@@ -78,10 +78,22 @@ return [
     |           The next number pulled for STD will be 004.
     |           The next number pulled for MYO will be 003. 
     |
+    | reset_character_info_on_transfer:
+    |       This determines whether owner-set character info--
+    |       name, trading status, gift art status, gift writing status, and profile--
+    |       should be cleared when the character is transferred to a new owner.
+    |
+    | clear_myo_slot_name_on_approval:
+    |       Whether the "name" given to a MYO slot should be cleared when a design update for it is approved/
+    |       the slot becomes a full character.
+    |
     */
     'character_codes' => '{category}-{number}',
     'character_number_digits' => 3,
     'character_pull_number' => 'all',
+
+    'reset_character_info_on_transfer' => 0,
+    'clear_myo_slot_name_on_approval' => 0,
 
     /*
     |--------------------------------------------------------------------------

--- a/config/lorekeeper/settings.php
+++ b/config/lorekeeper/settings.php
@@ -78,10 +78,13 @@ return [
     |           The next number pulled for STD will be 004.
     |           The next number pulled for MYO will be 003. 
     |
-    | reset_character_info_on_transfer:
-    |       This determines whether owner-set character info--
-    |       name, trading status, gift art status, gift writing status, and profile--
+    | reset_character_status_on_transfer:
+    |       This determines whether owner-set character status--
+    |       trading, gift art, and gift writing--
     |       should be cleared when the character is transferred to a new owner.
+    | reset_character_profile_on_transfer:
+    |       This determines whether character name and profile should be cleared
+    |       when the character is transferred to a new owner.
     |
     | clear_myo_slot_name_on_approval:
     |       Whether the "name" given to a MYO slot should be cleared when a design update for it is approved/
@@ -92,7 +95,8 @@ return [
     'character_number_digits' => 3,
     'character_pull_number' => 'all',
 
-    'reset_character_info_on_transfer' => 0,
+    'reset_character_status_on_transfer' => 0,
+    'reset_character_profile_on_transfer' => 0,
     'clear_myo_slot_name_on_approval' => 0,
 
     /*

--- a/config/lorekeeper/settings.php
+++ b/config/lorekeeper/settings.php
@@ -82,13 +82,17 @@ return [
     |       This determines whether owner-set character status--
     |       trading, gift art, and gift writing--
     |       should be cleared when the character is transferred to a new owner.
+    |       Default: 0/Disabled, 1 to enable.
+    |
     | reset_character_profile_on_transfer:
     |       This determines whether character name and profile should be cleared
     |       when the character is transferred to a new owner.
+    |       Default: 0/Disabled, 1 to enable.
     |
     | clear_myo_slot_name_on_approval:
     |       Whether the "name" given to a MYO slot should be cleared when a design update for it is approved/
     |       the slot becomes a full character.
+    |       Default: 0/Disabled, 1 to enable.
     |
     */
     'character_codes' => '{category}-{number}',

--- a/database/migrations/2020_10_30_170108_add_gift_writing_status_to_characters.php
+++ b/database/migrations/2020_10_30_170108_add_gift_writing_status_to_characters.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddGiftWritingStatusToCharacters extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('characters', function (Blueprint $table) {
+            //
+            $table->boolean('is_gift_writing_allowed')->default(0);
+        });
+
+        Schema::table('character_bookmarks', function (Blueprint $table) {
+            //
+            $table->boolean('notify_on_gift_writing_status')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('characters', function (Blueprint $table) {
+            //
+            $table->dropColumn('is_gift_writing_allowed');
+        });
+
+        Schema::table('character_bookmarks', function (Blueprint $table) {
+            //
+            $table->dropColumn('notify_on_gift_writing_status');
+        });
+    }
+}

--- a/resources/views/account/bookmarks.blade.php
+++ b/resources/views/account/bookmarks.blade.php
@@ -43,6 +43,9 @@
                         @if($bookmark->character->is_gift_art_allowed && !$bookmark->character->is_myo_slot)
                             <div><i class="text-success far fa-circle fa-fw mr-2"></i> Gift art is allowed</div>
                         @endif
+                        @if($bookmark->character->is_gift_writing_allowed && !$bookmark->character->is_myo_slot)
+                            <div><i class="text-success far fa-circle fa-fw mr-2"></i> Gift writing is allowed</div>
+                        @endif
                         @if($bookmark->character->is_trading)
                             <div><i class="text-success far fa-circle fa-fw mr-2"></i> Open for trades</div>
                         @endif
@@ -53,6 +56,7 @@
                     <td>
                         <i class="fas fa-exchange-alt fa-lg fa-fw mr-2 {{ $bookmark->notify_on_trade_status ? 'text-success' : 'text-danger' }}" data-toggle="tooltip" title="Open For Trade status changes"></i>
                         <i class="fas fa-gift fa-lg fa-fw mr-2 {{ $bookmark->notify_on_gift_art_status ? 'text-success' : 'text-danger' }}" data-toggle="tooltip" title="Gift Art Allowed status changes"></i>
+                        <i class="fas fa-pen-square fa-lg fa-fw mr-2 {{ $bookmark->notify_on_gift_writing_status ? 'text-success' : 'text-danger' }}" data-toggle="tooltip" title="Gift Writing Allowed status changes"></i>
                         <i class="fas fa-user fa-lg fa-fw mr-2 {{ $bookmark->notify_on_transfer ? 'text-success' : 'text-danger' }}" data-toggle="tooltip" title="Character's owner changes"></i>
                         <i class="far fa-image fa-lg fa-fw mr-2 {{ $bookmark->notify_on_image ? 'text-success' : 'text-danger' }}" data-toggle="tooltip" title="A new image is uploaded"></i>
 

--- a/resources/views/account/bookmarks/_create_edit_bookmark.blade.php
+++ b/resources/views/account/bookmarks/_create_edit_bookmark.blade.php
@@ -15,6 +15,10 @@
             {!! Form::label('notifyGiftArt', 'Gift Art Allowed status changes', ['class' => 'form-check-label']) !!}
         </div>
         <div class="form-check">
+            {!! Form::checkbox('notify_on_gift_writing_status', 1, $bookmark->notify_on_gift_writing_status, ['class' => 'form-check-input', 'id' => 'notifyGiftArt']) !!}
+            {!! Form::label('notifyGiftWriting', 'Gift Writing Allowed status changes', ['class' => 'form-check-label']) !!}
+        </div>
+        <div class="form-check">
             {!! Form::checkbox('notify_on_transfer', 1, $bookmark->notify_on_transfer, ['class' => 'form-check-input', 'id' => 'notifyTransfer']) !!}
             {!! Form::label('notifyTransfer', 'Character\'s owner changes', ['class' => 'form-check-label']) !!}
         </div>

--- a/resources/views/browse/_masterlist_content.blade.php
+++ b/resources/views/browse/_masterlist_content.blade.php
@@ -51,6 +51,10 @@
                         {!! Form::label('is_gift_art_allowed', 'Gift Art Status: ') !!}
                         {!! Form::select('is_gift_art_allowed', [0 => 'Any', 2 => 'Ask First', 1 => 'Yes', 3 => 'Yes OR Ask First'], Request::get('is_gift_art_allowed'), ['class' => 'form-control']) !!}
                     </div>
+                    <div class="masterlist-search-field">
+                        {!! Form::label('is_gift_writing_allowed', 'Gift Writing Status: ') !!}
+                        {!! Form::select('is_gift_writing_allowed', [0 => 'Any', 2 => 'Ask First', 1 => 'Yes', 3 => 'Yes OR Ask First'], Request::get('is_gift_writing_allowed'), ['class' => 'form-control']) !!}
+                    </div>
                 @endif
                 <br />
                 {{-- Setting the width and height on the toggles as they don't seem to calculate correctly if the div is collapsed. --}}

--- a/resources/views/character/edit_profile.blade.php
+++ b/resources/views/character/edit_profile.blade.php
@@ -29,9 +29,15 @@
 
 @if($character->user_id == Auth::user()->id)
     @if(!$character->is_myo_slot)
-        <div class="form-group">
-            {!! Form::label('is_gift_art_allowed', 'Allow Gift Art', ['class' => 'form-check-label mb-3']) !!} {!! add_help('This will place the character on the list of characters that can be drawn for gift art. This does not have any other functionality, but allow users looking for characters to draw to find your character easily.') !!}
-            {!! Form::select('is_gift_art_allowed', [0 => 'No', 1 => 'Yes', 2 => 'Ask First'], $character->is_gift_art_allowed, ['class' => 'form-control user-select']) !!}
+        <div class="row">
+            <div class="col-md form-group">
+                {!! Form::label('is_gift_art_allowed', 'Allow Gift Art', ['class' => 'form-check-label mb-3']) !!} {!! add_help('This will place the character on the list of characters that can be drawn for gift art. This does not have any other functionality, but allow users looking for characters to draw to find your character easily.') !!}
+                {!! Form::select('is_gift_art_allowed', [0 => 'No', 1 => 'Yes', 2 => 'Ask First'], $character->is_gift_art_allowed, ['class' => 'form-control user-select']) !!}
+            </div>
+            <div class="col-md form-group">
+                {!! Form::label('is_gift_writing_allowed', 'Allow Gift Writing', ['class' => 'form-check-label mb-3']) !!} {!! add_help('This will place the character on the list of characters that can be written about for gift writing. This does not have any other functionality, but allow users looking for characters to write about to find your character easily.') !!}
+                {!! Form::select('is_gift_writing_allowed', [0 => 'No', 1 => 'Yes', 2 => 'Ask First'], $character->is_gift_writing_allowed, ['class' => 'form-control user-select']) !!}
+            </div>
         </div>
     @endif
     @if($character->is_tradeable ||  $character->is_sellable)

--- a/resources/views/character/profile.blade.php
+++ b/resources/views/character/profile.blade.php
@@ -29,18 +29,19 @@
     </div>
 @endif
 
-@if($character->is_trading || $character->is_gift_art_allowed)
+@if($character->is_trading || $character->is_gift_art_allowed || $character->is_gift_writing_allowed)
     <div class="card mb-3">
-        @if($character->is_trading || $character->is_gift_art_allowed)
-            <ul class="list-group list-group-flush">
-                @if($character->is_gift_art_allowed >= 1 && !$character->is_myo_slot)
-                    <li class="list-group-item"><h5 class="mb-0"><i class="{{ $character->is_gift_art_allowed == 1 ? 'text-success' : 'text-secondary' }} far fa-circle fa-fw mr-2"></i> {{ $character->is_gift_art_allowed == 1 ? 'Gift art is allowed' : 'Please ask before gift art' }}</h5></li>
-                @endif
-                @if($character->is_trading)
-                    <li class="list-group-item"><h5 class="mb-0"><i class="text-success far fa-circle fa-fw mr-2"></i> Open for trades</h5></li>
-                @endif
-            </ul>
-        @endif
+        <ul class="list-group list-group-flush">
+            @if($character->is_gift_art_allowed >= 1 && !$character->is_myo_slot)
+                <li class="list-group-item"><h5 class="mb-0"><i class="{{ $character->is_gift_art_allowed == 1 ? 'text-success' : 'text-secondary' }} far fa-circle fa-fw mr-2"></i> {{ $character->is_gift_art_allowed == 1 ? 'Gift art is allowed' : 'Please ask before gift art' }}</h5></li>
+            @endif
+            @if($character->is_gift_writing_allowed >= 1 && !$character->is_myo_slot)
+                <li class="list-group-item"><h5 class="mb-0"><i class="{{ $character->is_gift_writing_allowed == 1 ? 'text-success' : 'text-secondary' }} far fa-circle fa-fw mr-2"></i> {{ $character->is_gift_writing_allowed == 1 ? 'Gift writing is allowed' : 'Please ask before gift writing' }}</h5></li>
+            @endif
+            @if($character->is_trading)
+                <li class="list-group-item"><h5 class="mb-0"><i class="text-success far fa-circle fa-fw mr-2"></i> Open for trades</h5></li>
+            @endif
+        </ul>
     </div>
 @endif
 @endsection


### PR DESCRIPTION
- Add gift writing status to characters (yes/no/ask first)
- Add gift writing status to bookmarks and add accompanying notification
- Add gift writing status search to masterlist
- Fix bug with gift art status notification
- Add settings for:
- Resetting character trading status, gift art status, and gift writing status on transfer (enable/disable, defaults to disabled)
- Resetting character name and profile on transfer (enable/disable, defaults to disabled)
- Clearing MYO slot name on MYO submission approval (enable/disable, defaults to disabled)

Requires migration, have tested locally -- settings in config/lorekeeper/settings.php