### PR TITLE
Add open/closed toggle, delayed comments, and bumping to sales posts

### DIFF
--- a/app/Http/Controllers/Admin/SalesController.php
+++ b/app/Http/Controllers/Admin/SalesController.php
@@ -64,7 +64,7 @@ class SalesController extends Controller
     {
         $id ? $request->validate(Sales::$updateRules) : $request->validate(Sales::$createRules);
         $data = $request->only([
-            'title', 'text', 'post_at', 'is_visible'
+            'title', 'text', 'post_at', 'is_visible', 'is_open', 'comments_open_at'
         ]);
         if($id && $service->updateSales(Sales::find($id), $data, Auth::user())) {
             flash('Sales updated successfully.')->success();

--- a/app/Http/Controllers/Admin/SalesController.php
+++ b/app/Http/Controllers/Admin/SalesController.php
@@ -64,7 +64,7 @@ class SalesController extends Controller
     {
         $id ? $request->validate(Sales::$updateRules) : $request->validate(Sales::$createRules);
         $data = $request->only([
-            'title', 'text', 'post_at', 'is_visible', 'is_open', 'comments_open_at'
+            'title', 'text', 'post_at', 'is_visible', 'bump', 'is_open', 'comments_open_at'
         ]);
         if($id && $service->updateSales(Sales::find($id), $data, Auth::user())) {
             flash('Sales updated successfully.')->success();

--- a/app/Models/Sales.php
+++ b/app/Models/Sales.php
@@ -16,7 +16,8 @@ class Sales extends Model
      * @var array
      */
     protected $fillable = [
-        'user_id', 'text', 'parsed_text', 'title', 'is_visible', 'post_at'
+        'user_id', 'text', 'parsed_text', 'title', 'is_visible', 'post_at', 
+        'is_open', 'comments_open_at'
     ];
 
     /**
@@ -38,7 +39,7 @@ class Sales extends Model
      *
      * @var array
      */
-    public $dates = ['post_at'];
+    public $dates = ['post_at', 'comments_open_at'];
 
     /**
      * Validation rules for creation.
@@ -125,7 +126,7 @@ class Sales extends Model
      */
     public function getDisplayNameAttribute()
     {
-        return '<a href="'.$this->url.'">'.$this->title.'</a>';
+        return '<a href="'.$this->url.'"> ['.($this->is_open ? (isset($this->comments_open_at) && $this->comments_open_at > Carbon::now() ? 'Preview' : 'Open') : 'Closed').'] '.$this->title.'</a>';
     }
 
     /**

--- a/app/Services/SalesService.php
+++ b/app/Services/SalesService.php
@@ -34,6 +34,7 @@ class SalesService extends Service
             $data['parsed_text'] = parse($data['text']);
             $data['user_id'] = $user->id;
             if(!isset($data['is_visible'])) $data['is_visible'] = 0;
+            if(!isset($data['is_open'])) $data['is_open'] = 0;
 
             $sales = Sales::create($data);
 
@@ -62,6 +63,7 @@ class SalesService extends Service
             $data['parsed_text'] = parse($data['text']);
             $data['user_id'] = $user->id;
             if(!isset($data['is_visible'])) $data['is_visible'] = 0;
+            if(!isset($data['is_open'])) $data['is_open'] = 0;
 
             $sales->update($data);
 

--- a/app/Services/SalesService.php
+++ b/app/Services/SalesService.php
@@ -65,6 +65,8 @@ class SalesService extends Service
             if(!isset($data['is_visible'])) $data['is_visible'] = 0;
             if(!isset($data['is_open'])) $data['is_open'] = 0;
 
+            if(isset($data['bump']) && $data['is_visible'] == 1 && $data['bump'] == 1) $this->alertUsers();
+
             $sales->update($data);
 
             return $this->commitReturn($sales);

--- a/database/migrations/2020_11_02_204925_add_delayed_comments_to_sales.php
+++ b/database/migrations/2020_11_02_204925_add_delayed_comments_to_sales.php
@@ -14,13 +14,8 @@ class AddDelayedCommentsToSales extends Migration
     public function up()
     {
         Schema::table('sales', function (Blueprint $table) {
-            // Time at which comments should open to members
             $table->timestamp('comments_open_at')->nullable()->default(null);
-            
-            // Bools
             $table->boolean('is_open')->default(1);
-            $table->boolean('hide_comments_before_start')->default(0);
-            $table->boolean('disable_commenting_after_close')->default(0);
         });
     }
 
@@ -35,8 +30,6 @@ class AddDelayedCommentsToSales extends Migration
             //
             $table->dropColumn('is_open');
             $table->dropColumn('comments_open_at');
-            $table->dropColumn('hide_comments_before_start');
-            $table->dropColumn('disable_commenting_after_close');
         });
     }
 }

--- a/database/migrations/2020_11_02_204925_add_delayed_comments_to_sales.php
+++ b/database/migrations/2020_11_02_204925_add_delayed_comments_to_sales.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddDelayedCommentsToSales extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('sales', function (Blueprint $table) {
+            // Time at which comments should open to members
+            $table->timestamp('comments_open_at')->nullable()->default(null);
+            
+            // Bools
+            $table->boolean('is_open')->default(1);
+            $table->boolean('hide_comments_before_start')->default(0);
+            $table->boolean('disable_commenting_after_close')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('sales', function (Blueprint $table) {
+            //
+            $table->dropColumn('is_open');
+            $table->dropColumn('comments_open_at');
+            $table->dropColumn('hide_comments_before_start');
+            $table->dropColumn('disable_commenting_after_close');
+        });
+    }
+}

--- a/resources/views/admin/sales/create_edit_sales.blade.php
+++ b/resources/views/admin/sales/create_edit_sales.blade.php
@@ -43,6 +43,14 @@
             {!! Form::label('is_visible', 'Is Viewable', ['class' => 'form-check-label ml-3']) !!} {!! add_help('If this is turned off, the post will not be visible. If the post time is set, it will automatically become visible at/after the given post time, so make sure the post time is empty if you want it to be completely hidden.') !!}
         </div>
     </div>
+    @if($sales->id && $sales->is_visible)
+        <div class="col-md">
+            <div class="form-group">
+                {!! Form::checkbox('bump', 1, null, ['class' => 'form-check-input', 'data-toggle' => 'toggle']) !!}
+                {!! Form::label('bump', 'Bump Sale', ['class' => 'form-check-label ml-3']) !!} {!! add_help('If toggled on, this will alert users that there is a new sale. Best in conjunction with a clear notification of changes!') !!}
+            </div>
+        </div>
+    @endif
     <div class="col-md">
         <div class="form-group">
             {!! Form::checkbox('is_open', 1, $sales->id ? $sales->is_open : 1, ['class' => 'form-check-input', 'data-toggle' => 'toggle']) !!}

--- a/resources/views/admin/sales/create_edit_sales.blade.php
+++ b/resources/views/admin/sales/create_edit_sales.blade.php
@@ -26,7 +26,7 @@
     <div class="col-md-6">
         <div class="form-group">
             {!! Form::label('Post Time (Optional)') !!} {!! add_help('This is the time that the sales post should be posted. Make sure the Is Viewable switch is off.') !!}
-            {!! Form::text('post_at', $sales->post_at, ['class' => 'form-control', 'id' => 'datepicker']) !!}
+            {!! Form::text('post_at', $sales->post_at, ['class' => 'form-control datepicker']) !!}
         </div>
     </div>
 </div>
@@ -36,9 +36,25 @@
     {!! Form::textarea('text', $sales->text, ['class' => 'form-control wysiwyg']) !!}
 </div>
 
-<div class="form-group">
-    {!! Form::checkbox('is_visible', 1, $sales->id ? $sales->is_visible : 1, ['class' => 'form-check-input', 'data-toggle' => 'toggle']) !!}
-    {!! Form::label('is_visible', 'Is Viewable', ['class' => 'form-check-label ml-3']) !!} {!! add_help('If this is turned off, the post will not be visible. If the post time is set, it will automatically become visible at/after the given post time, so make sure the post time is empty if you want it to be completely hidden.') !!}
+<div class="row">
+    <div class="col-md">
+        <div class="form-group">
+            {!! Form::checkbox('is_visible', 1, $sales->id ? $sales->is_visible : 1, ['class' => 'form-check-input', 'data-toggle' => 'toggle']) !!}
+            {!! Form::label('is_visible', 'Is Viewable', ['class' => 'form-check-label ml-3']) !!} {!! add_help('If this is turned off, the post will not be visible. If the post time is set, it will automatically become visible at/after the given post time, so make sure the post time is empty if you want it to be completely hidden.') !!}
+        </div>
+    </div>
+    <div class="col-md">
+        <div class="form-group">
+            {!! Form::checkbox('is_open', 1, $sales->id ? $sales->is_open : 1, ['class' => 'form-check-input', 'data-toggle' => 'toggle']) !!}
+            {!! Form::label('is_open', 'Is Open', ['class' => 'form-check-label ml-3']) !!} {!! add_help('Whether or not the sale is open; used to label the post in the title. This should be on unless the sale is finished; if a time is set for comments to open, the sale will be labeled as \'Preview\' instead.') !!}
+        </div>
+    </div>
+    <div class="col-md">
+        <div class="form-group">
+            {!! Form::label('comments_open_at', 'Comments Open At (Optional)') !!} {!! add_help('The time at which comments open to members. Staff can post comments before this time.') !!}
+            {!! Form::text('comments_open_at', $sales->comments_open_at, ['class' => 'form-control datepicker']) !!}
+        </div>
+    </div>
 </div>
 
 <div class="text-right">
@@ -57,11 +73,11 @@ $( document ).ready(function() {
         e.preventDefault();
         loadModal("{{ url('admin/sales/delete') }}/{{ $sales->id }}", 'Delete Post');
     });
-    $( "#datepicker" ).datetimepicker({
+
+    $( ".datepicker" ).datetimepicker({
         dateFormat: "yy-mm-dd",
         timeFormat: 'HH:mm:ss',
     });
-});
-    
+}); 
 </script>
 @endsection

--- a/resources/views/sales/_sales.blade.php
+++ b/resources/views/sales/_sales.blade.php
@@ -10,14 +10,18 @@
             {!! $sales->parsed_text !!}
         </div>
     </div>
-    <?php $commentCount = App\Models\Comment::where('commentable_type', 'App\Models\Sales')->where('commentable_id', $sales->id)->count(); ?>
-    @if(!$page)
-        <div class="text-right mb-2 mr-2">
-            <a class="btn" href="{{ $sales->url }}"><i class="fas fa-comment"></i> {{ $commentCount }} Comment{{ $commentCount != 1 ? 's' : ''}}</a>
-        </div>
-    @else
-        <div class="text-right mb-2 mr-2">
-            <span class="btn"><i class="fas fa-comment"></i> {{ $commentCount }} Comment{{ $commentCount != 1 ? 's' : ''}}</span>
-        </div>
+    @if((isset($sales->comments_open_at) && $sales->comments_open_at < Carbon\Carbon::now() || 
+    (Auth::check() && Auth::user()->hasPower('edit_pages'))) || 
+    !isset($sales->comments_open_at))
+        <?php $commentCount = App\Models\Comment::where('commentable_type', 'App\Models\Sales')->where('commentable_id', $sales->id)->count(); ?>
+        @if(!$page)
+            <div class="text-right mb-2 mr-2">
+                <a class="btn" href="{{ $sales->url }}"><i class="fas fa-comment"></i> {{ $commentCount }} Comment{{ $commentCount != 1 ? 's' : ''}}</a>
+            </div>
+        @else
+            <div class="text-right mb-2 mr-2">
+                <span class="btn"><i class="fas fa-comment"></i> {{ $commentCount }} Comment{{ $commentCount != 1 ? 's' : ''}}</span>
+            </div>
+        @endif
     @endif
 </div>

--- a/resources/views/sales/sales.blade.php
+++ b/resources/views/sales/sales.blade.php
@@ -5,11 +5,19 @@
 @section('content')
     {!! breadcrumbs(['Site Sales' => 'sales', $sales->title => $sales->url]) !!}
     @include('sales._sales', ['sales' => $sales, 'page' => TRUE])
-    <hr>
-<br><br>
 
-@comments(['model' => $sales,
-        'perPage' => 5
-    ])
+@if((isset($sales->comments_open_at) && $sales->comments_open_at < Carbon\Carbon::now() || 
+    (Auth::check() && Auth::user()->hasPower('edit_pages'))) || 
+    !isset($sales->comments_open_at))
+        <hr>
+        <br><br>
+        @comments(['model' => $sales,
+                'perPage' => 5
+            ])
+@else
+    <div class="alert alert-warning text-center">
+        <p>Comments for this sale aren't open yet! They will open {!! pretty_date($sales->comments_open_at) !!}.</p>
+    </div>
+@endif
 
 @endsection


### PR DESCRIPTION
- Adds a toggle (open/closed) to sales posts; mostly just impacts display (the result is displayed in the post title)
- Adds a 'comments open at' time/date field; if this is set (and in the future), comments won't be displayed for the post until that point. (A message is instead displayed beneath it on the post's page itself saying that comments aren't open yet, and will open at (x ) time; uses the pretty_date helper).
- If a post is set to 'open' and there is a set future 'comments open at' time, the title will display 'preview' instead of 'open'
- Staff with permissions to edit sales posts are still able to see the comments interface, so that if any set-up needs to be done before a sale opens, it can be done without any need to scramble
- Add the ability to 'bump' extant sales posts

Requires migration : Tested locally and live