### PR TITLE
Feature/Toggle prompt submission visibility

### DIFF
--- a/app/Http/Controllers/Admin/Data/PromptController.php
+++ b/app/Http/Controllers/Admin/Data/PromptController.php
@@ -221,7 +221,7 @@ class PromptController extends Controller
     {
         $id ? $request->validate(Prompt::$updateRules) : $request->validate(Prompt::$createRules);
         $data = $request->only([
-            'name', 'prompt_category_id', 'summary', 'description', 'start_at', 'end_at', 'hide_before_start', 'hide_after_end', 'is_active', 'rewardable_type', 'rewardable_id', 'quantity', 'image', 'remove_image'
+            'name', 'prompt_category_id', 'summary', 'description', 'start_at', 'end_at', 'hide_before_start', 'hide_after_end', 'is_active', 'rewardable_type', 'rewardable_id', 'quantity', 'image', 'remove_image', 'hide_submissions'
         ]);
         if($id && $service->updatePrompt(Prompt::find($id), $data, Auth::user())) {
             flash('Prompt updated successfully.')->success();

--- a/app/Http/Controllers/Users/UserController.php
+++ b/app/Http/Controllers/Users/UserController.php
@@ -193,7 +193,7 @@ class UserController extends Controller
     {
         return view('user.submission_logs', [
             'user' => $this->user,
-            'logs' => $this->user->getSubmissions()
+            'logs' => $this->user->getSubmissions(Auth::check() ? Auth::user() : null)
         ]);
     }
 }

--- a/app/Models/Prompt/Prompt.php
+++ b/app/Models/Prompt/Prompt.php
@@ -17,7 +17,8 @@ class Prompt extends Model
      */
     protected $fillable = [
         'prompt_category_id', 'name', 'summary', 'description', 'parsed_description', 'is_active',
-        'start_at', 'end_at', 'hide_before_start', 'hide_after_end', 'has_image'
+        'start_at', 'end_at', 'hide_before_start', 'hide_after_end', 'has_image', 
+        'hide_submissions', 'hide_submissions_until_end'
     ];
 
     /**

--- a/app/Models/Prompt/Prompt.php
+++ b/app/Models/Prompt/Prompt.php
@@ -18,7 +18,7 @@ class Prompt extends Model
     protected $fillable = [
         'prompt_category_id', 'name', 'summary', 'description', 'parsed_description', 'is_active',
         'start_at', 'end_at', 'hide_before_start', 'hide_after_end', 'has_image', 
-        'hide_submissions', 'hide_submissions_until_end'
+        'hide_submissions'
     ];
 
     /**

--- a/app/Models/Submission/Submission.php
+++ b/app/Models/Submission/Submission.php
@@ -5,6 +5,7 @@ namespace App\Models\Submission;
 use Config;
 use DB;
 use Carbon\Carbon;
+use App\Models\Prompt\Prompt;
 use App\Models\Model;
 
 class Submission extends Model
@@ -114,11 +115,20 @@ class Submission extends Model
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeViewable($query, $user)
-    {
+    {    
+        $forbiddenSubmissions = $this
+        ->whereHas('prompt', function($q) {
+            $q->where('hide_submissions', 1)->whereNotNull('end_at')->where('end_at', '>', Carbon::now());
+        })
+        ->orWhereHas('prompt', function($q) {
+            $q->where('hide_submissions', 2);
+        })
+        ->orWhere('status', '!=', 'Approved')->pluck('id')->toArray();
+        
         if($user && $user->hasPower('manage_submissions')) return $query;
-        return $query->where(function($query) use ($user) {
-            if($user) $query->where('user_id', $user->id)->orWhere('status', 'Approved');
-            else $query->where('status', 'Approved');
+        else return $query->where(function($query) use ($user, $forbiddenSubmissions) {
+            if($user) $query->whereNotIn('id', $forbiddenSubmissions)->orWhere('user_id', $user->id);
+            else $query->whereNotIn('id', $forbiddenSubmissions);
         });
     }
 

--- a/app/Models/Submission/Submission.php
+++ b/app/Models/Submission/Submission.php
@@ -5,7 +5,6 @@ namespace App\Models\Submission;
 use Config;
 use DB;
 use Carbon\Carbon;
-use App\Models\Prompt\Prompt;
 use App\Models\Model;
 
 class Submission extends Model

--- a/app/Models/User/User.php
+++ b/app/Models/User/User.php
@@ -450,9 +450,9 @@ class User extends Authenticatable implements MustVerifyEmail
      *
      * @return \Illuminate\Pagination\LengthAwarePaginator
      */
-    public function getSubmissions()
+    public function getSubmissions($user = null)
     {
-        return Submission::with('user')->with('prompt')->where('status', 'Approved')->where('user_id', $this->id)->orderBy('id', 'DESC')->paginate(30);
+        return Submission::with('user')->with('prompt')->viewable($user ? $user : null)->where('user_id', $this->id)->orderBy('id', 'DESC')->paginate(30);
     }
 
     /**

--- a/app/Services/PromptService.php
+++ b/app/Services/PromptService.php
@@ -202,7 +202,9 @@ class PromptService extends Service
             }
             else $data['has_image'] = 0;
 
-            $prompt = Prompt::create(array_only($data, ['prompt_category_id', 'name', 'summary', 'description', 'parsed_description', 'is_active', 'start_at', 'end_at', 'hide_before_start', 'hide_after_end', 'has_image']));
+            if(!isset($data['hide_submissions']) && !$data['hide_submissions']) $data['hide_submissions'] = 0;
+
+            $prompt = Prompt::create(array_only($data, ['prompt_category_id', 'name', 'summary', 'description', 'parsed_description', 'is_active', 'start_at', 'end_at', 'hide_before_start', 'hide_after_end', 'has_image', 'hide_submissions']));
 
             if ($image) $this->handleImage($image, $prompt->imagePath, $prompt->imageFileName);
 
@@ -243,7 +245,9 @@ class PromptService extends Service
                 unset($data['image']);
             }
 
-            $prompt->update(array_only($data, ['prompt_category_id', 'name', 'summary', 'description', 'parsed_description', 'is_active', 'start_at', 'end_at', 'hide_before_start', 'hide_after_end', 'has_image']));
+            if(!isset($data['hide_submissions']) && !$data['hide_submissions']) $data['hide_submissions'] = 0;
+
+            $prompt->update(array_only($data, ['prompt_category_id', 'name', 'summary', 'description', 'parsed_description', 'is_active', 'start_at', 'end_at', 'hide_before_start', 'hide_after_end', 'has_image', 'hide_submissions']));
 
             if ($prompt) $this->handleImage($image, $prompt->imagePath, $prompt->imageFileName);
 

--- a/database/migrations/2020_11_18_011215_add_visibility_toggles_to_prompts.php
+++ b/database/migrations/2020_11_18_011215_add_visibility_toggles_to_prompts.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddVisibilityTogglesToPrompts extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('prompts', function (Blueprint $table) {
+            //
+            $table->integer('hide_submissions')->unsigned()->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('prompts', function (Blueprint $table) {
+            //
+            $table->dropColumn('hide_submissions');
+        });
+    }
+}

--- a/resources/views/admin/prompts/create_edit_prompt.blade.php
+++ b/resources/views/admin/prompts/create_edit_prompt.blade.php
@@ -82,6 +82,11 @@
     {!! Form::label('is_active', 'Is Active', ['class' => 'form-check-label ml-3']) !!} {!! add_help('Prompts that are not active will be hidden from the prompt list. The start/end time hide settings override this setting, i.e. if this is set to active, it will still be hidden outside of the start/end times.') !!}
 </div>
 
+<div class="form-group">
+    {!! Form::label('Hide Submissions (Optional)') !!} {!! add_help('Hide submissions to this prompt until the prompt ends, or forever. <strong>Hiding until the prompt ends requires a set end time.</strong>') !!}
+    {!! Form::select('hide_submissions', [0 => 'Submissions Visible After Approval', 1 => 'Hide Submissions Until Prompt Ends', 2 => 'Hide Submissions Always'], $prompt->hide_submissions, ['class' => 'form-control']) !!}
+</div>
+
 <h3>Rewards</h3>
 <p>Rewards are credited on a per-user basis. Mods are able to modify the specific rewards granted at approval time.</p>
 <p>You can add loot tables containing any kind of currencies (both user- and character-attached), but be sure to keep track of which are being distributed! Character-only currencies cannot be given to users.</p>

--- a/resources/views/world/_prompt_entry.blade.php
+++ b/resources/views/world/_prompt_entry.blade.php
@@ -25,6 +25,11 @@
                 @else 
                     <p>No further details.</p>
                 @endif
+                @if($prompt->hide_submissions == 1 && isset($prompt->end_at) && $prompt->end_at > Carbon\Carbon::now())
+                    <p class="text-info">Submissions to this prompt are hidden until this prompt ends.</p>
+                @elseif($prompt->hide_submissions == 2)
+                    <p class="text-info">Submissions to this prompt are hidden.</p>
+                @endif
             </div>
             <h4>Rewards</h4>
             @if(!count($prompt->rewards))


### PR DESCRIPTION
- Adds a 'hide prompt submissions [never/until prompt ends/forever]' option to prompt creation/editing
- Alters the viewable() submission scope to hide submissions (viewable neither in users' submission logs nor via link) associated with a prompt which either hides submissions forever or (if a prompt has a set future end + is set to hide submissions until end) hides them until the prompt concludes. Staff with the 'manage submissions' permission can, as before, always view all submissions.
- Adds a line to prompt entries in the 'more details' collapse which notes that submissions to the prompt are hidden/hidden until the prompt's end.

Tested locally - Requires migrate