### PR TITLE
Automate image process to make images and thumbnails square

### DIFF
--- a/app/Services/CharacterManager.php
+++ b/app/Services/CharacterManager.php
@@ -332,6 +332,24 @@ class CharacterManager extends Service
         // Trim transparent parts of image.
         $image = Image::make($characterImage->imagePath . '/' . $characterImage->imageFileName)->trim('transparent');
 
+		if (Config::get('lorekeeper.settings.masterlist_image_automation') == 1)
+		{
+	        // Make the image be square
+			$imageWidth = $image->width();
+			$imageHeight = $image->height();
+
+			if( $imageWidth > $imageHeight) {
+				// Landscape
+				$canvas = Image::canvas($image->width(), $image->width());
+				$image = $canvas->insert($image, 'center');
+			}
+			else {
+				// Portrait
+				$canvas = Image::canvas($image->height(), $image->height());
+				$image = $canvas->insert($image, 'center');
+			}
+		}
+
         if(Config::get('lorekeeper.settings.masterlist_image_format') != 'png' && Config::get('lorekeeper.settings.masterlist_image_format') != null && Config::get('lorekeeper.settings.masterlist_image_background') != null) {
             $canvas = Image::canvas($image->width(), $image->height(), Config::get('lorekeeper.settings.masterlist_image_background'));
             $image = $canvas->insert($image, 'center');
@@ -423,6 +441,24 @@ class CharacterManager extends Service
             // Trim transparent parts of image.
             $image->trim(isset($trimColor) && $trimColor ? 'top-left' : 'transparent');
 
+			if (Config::get('lorekeeper.settings.masterlist_image_automation') == 1)
+			{
+				// Make the image be square
+				$imageWidth = $image->width();
+				$imageHeight = $image->height();
+
+				if( $imageWidth > $imageHeight) {
+					// Landscape
+					$canvas = Image::canvas($image->width(), $image->width());
+					$image = $canvas->insert($image, 'center');
+				}
+				else {
+					// Portrait
+					$canvas = Image::canvas($image->height(), $image->height());
+					$image = $canvas->insert($image, 'center');
+				}
+			}
+
             $cropWidth = Config::get('lorekeeper.settings.masterlist_thumbnails.width');
             $cropHeight = Config::get('lorekeeper.settings.masterlist_thumbnails.height');
 
@@ -477,22 +513,28 @@ class CharacterManager extends Service
                     });
                 }
             }
-            $xOffset = 0 + (($points['x0'] - $trimOffsetX) > 0 ? ($points['x0'] - $trimOffsetX) : 0);
-            if(($xOffset + $cropWidth) > $image->width()) $xOffsetNew = $cropWidth - ($image->width() - $xOffset);
-            if(isset($xOffsetNew)) if(($xOffsetNew + $cropWidth) > $image->width()) $xOffsetNew = $image->width() - $cropWidth;
-            $yOffset = 0 + (($points['y0'] - $trimOffsetY) > 0 ? ($points['y0'] - $trimOffsetY) : 0);
-            if(($yOffset + $cropHeight) > $image->height()) $yOffsetNew = $cropHeight - ($image->height() - $yOffset);
-            if(isset($yOffsetNew)) if(($yOffsetNew + $cropHeight) > $image->height()) $yOffsetNew = $image->height() - $cropHeight;
+			if (Config::get('lorekeeper.settings.masterlist_image_automation') == 0)
+			{
+				$xOffset = 0 + (($points['x0'] - $trimOffsetX) > 0 ? ($points['x0'] - $trimOffsetX) : 0);
+				if(($xOffset + $cropWidth) > $image->width()) $xOffsetNew = $cropWidth - ($image->width() - $xOffset);
+				if(isset($xOffsetNew)) if(($xOffsetNew + $cropWidth) > $image->width()) $xOffsetNew = $image->width() - $cropWidth;
+				$yOffset = 0 + (($points['y0'] - $trimOffsetY) > 0 ? ($points['y0'] - $trimOffsetY) : 0);
+				if(($yOffset + $cropHeight) > $image->height()) $yOffsetNew = $cropHeight - ($image->height() - $yOffset);
+				if(isset($yOffsetNew)) if(($yOffsetNew + $cropHeight) > $image->height()) $yOffsetNew = $image->height() - $cropHeight;
 
-            // Crop according to the selected area
-            $image->crop($cropWidth, $cropHeight, isset($xOffsetNew) ? $xOffsetNew : $xOffset, isset($yOffsetNew) ? $yOffsetNew : $yOffset);
+				// Crop according to the selected area
+				$image->crop($cropWidth, $cropHeight, isset($xOffsetNew) ? $xOffsetNew : $xOffset, isset($yOffsetNew) ? $yOffsetNew : $yOffset);
+			}
         }
         else {
             $cropWidth = $points['x1'] - $points['x0'];
             $cropHeight = $points['y1'] - $points['y0'];
 
-            // Crop according to the selected area
-            $image->crop($cropWidth, $cropHeight, $points['x0'], $points['y0']);
+			if (Config::get('lorekeeper.settings.masterlist_image_automation') == 0)
+			{
+				// Crop according to the selected area
+				$image->crop($cropWidth, $cropHeight, $points['x0'], $points['y0']);
+			}
 
             // Resize to fit the thumbnail size
             $image->resize(Config::get('lorekeeper.settings.masterlist_thumbnails.width'), Config::get('lorekeeper.settings.masterlist_thumbnails.height'));

--- a/app/Services/CharacterManager.php
+++ b/app/Services/CharacterManager.php
@@ -332,23 +332,23 @@ class CharacterManager extends Service
         // Trim transparent parts of image.
         $image = Image::make($characterImage->imagePath . '/' . $characterImage->imageFileName)->trim('transparent');
 
-		if (Config::get('lorekeeper.settings.masterlist_image_automation') == 1)
-		{
-	        // Make the image be square
-			$imageWidth = $image->width();
-			$imageHeight = $image->height();
+        if (Config::get('lorekeeper.settings.masterlist_image_automation') == 1)
+        {
+            // Make the image be square
+            $imageWidth = $image->width();
+            $imageHeight = $image->height();
 
-			if( $imageWidth > $imageHeight) {
-				// Landscape
-				$canvas = Image::canvas($image->width(), $image->width());
-				$image = $canvas->insert($image, 'center');
-			}
-			else {
-				// Portrait
-				$canvas = Image::canvas($image->height(), $image->height());
-				$image = $canvas->insert($image, 'center');
-			}
-		}
+            if( $imageWidth > $imageHeight) {
+                // Landscape
+                $canvas = Image::canvas($image->width(), $image->width());
+                $image = $canvas->insert($image, 'center');
+            }
+            else {
+                // Portrait
+                $canvas = Image::canvas($image->height(), $image->height());
+                $image = $canvas->insert($image, 'center');
+            }
+        }
 
         if(Config::get('lorekeeper.settings.masterlist_image_format') != 'png' && Config::get('lorekeeper.settings.masterlist_image_format') != null && Config::get('lorekeeper.settings.masterlist_image_background') != null) {
             $canvas = Image::canvas($image->width(), $image->height(), Config::get('lorekeeper.settings.masterlist_image_background'));
@@ -441,23 +441,23 @@ class CharacterManager extends Service
             // Trim transparent parts of image.
             $image->trim(isset($trimColor) && $trimColor ? 'top-left' : 'transparent');
 
-			if (Config::get('lorekeeper.settings.masterlist_image_automation') == 1)
-			{
-				// Make the image be square
-				$imageWidth = $image->width();
-				$imageHeight = $image->height();
+            if (Config::get('lorekeeper.settings.masterlist_image_automation') == 1)
+            {
+                // Make the image be square
+                $imageWidth = $image->width();
+                $imageHeight = $image->height();
 
-				if( $imageWidth > $imageHeight) {
-					// Landscape
-					$canvas = Image::canvas($image->width(), $image->width());
-					$image = $canvas->insert($image, 'center');
-				}
-				else {
-					// Portrait
-					$canvas = Image::canvas($image->height(), $image->height());
-					$image = $canvas->insert($image, 'center');
-				}
-			}
+                if( $imageWidth > $imageHeight) {
+                    // Landscape
+                    $canvas = Image::canvas($image->width(), $image->width());
+                    $image = $canvas->insert($image, 'center');
+                }
+                else {
+                    // Portrait
+                    $canvas = Image::canvas($image->height(), $image->height());
+                    $image = $canvas->insert($image, 'center');
+                }
+            }
 
             $cropWidth = Config::get('lorekeeper.settings.masterlist_thumbnails.width');
             $cropHeight = Config::get('lorekeeper.settings.masterlist_thumbnails.height');
@@ -513,28 +513,28 @@ class CharacterManager extends Service
                     });
                 }
             }
-			if (Config::get('lorekeeper.settings.masterlist_image_automation') == 0)
-			{
-				$xOffset = 0 + (($points['x0'] - $trimOffsetX) > 0 ? ($points['x0'] - $trimOffsetX) : 0);
-				if(($xOffset + $cropWidth) > $image->width()) $xOffsetNew = $cropWidth - ($image->width() - $xOffset);
-				if(isset($xOffsetNew)) if(($xOffsetNew + $cropWidth) > $image->width()) $xOffsetNew = $image->width() - $cropWidth;
-				$yOffset = 0 + (($points['y0'] - $trimOffsetY) > 0 ? ($points['y0'] - $trimOffsetY) : 0);
-				if(($yOffset + $cropHeight) > $image->height()) $yOffsetNew = $cropHeight - ($image->height() - $yOffset);
-				if(isset($yOffsetNew)) if(($yOffsetNew + $cropHeight) > $image->height()) $yOffsetNew = $image->height() - $cropHeight;
+            if (Config::get('lorekeeper.settings.masterlist_image_automation') == 0)
+            {
+                $xOffset = 0 + (($points['x0'] - $trimOffsetX) > 0 ? ($points['x0'] - $trimOffsetX) : 0);
+                if(($xOffset + $cropWidth) > $image->width()) $xOffsetNew = $cropWidth - ($image->width() - $xOffset);
+                if(isset($xOffsetNew)) if(($xOffsetNew + $cropWidth) > $image->width()) $xOffsetNew = $image->width() - $cropWidth;
+                $yOffset = 0 + (($points['y0'] - $trimOffsetY) > 0 ? ($points['y0'] - $trimOffsetY) : 0);
+                if(($yOffset + $cropHeight) > $image->height()) $yOffsetNew = $cropHeight - ($image->height() - $yOffset);
+                if(isset($yOffsetNew)) if(($yOffsetNew + $cropHeight) > $image->height()) $yOffsetNew = $image->height() - $cropHeight;
 
-				// Crop according to the selected area
-				$image->crop($cropWidth, $cropHeight, isset($xOffsetNew) ? $xOffsetNew : $xOffset, isset($yOffsetNew) ? $yOffsetNew : $yOffset);
-			}
+                // Crop according to the selected area
+                $image->crop($cropWidth, $cropHeight, isset($xOffsetNew) ? $xOffsetNew : $xOffset, isset($yOffsetNew) ? $yOffsetNew : $yOffset);
+            }
         }
         else {
             $cropWidth = $points['x1'] - $points['x0'];
             $cropHeight = $points['y1'] - $points['y0'];
 
-			if (Config::get('lorekeeper.settings.masterlist_image_automation') == 0)
-			{
-				// Crop according to the selected area
-				$image->crop($cropWidth, $cropHeight, $points['x0'], $points['y0']);
-			}
+            if (Config::get('lorekeeper.settings.masterlist_image_automation') == 0)
+            {
+                // Crop according to the selected area
+                $image->crop($cropWidth, $cropHeight, $points['x0'], $points['y0']);
+            }
 
             // Resize to fit the thumbnail size
             $image->resize(Config::get('lorekeeper.settings.masterlist_thumbnails.width'), Config::get('lorekeeper.settings.masterlist_thumbnails.height'));
@@ -628,8 +628,8 @@ class CharacterManager extends Service
                 Notifications::create('IMAGE_UPLOAD', $character->user, [
                     'character_url' => $character->url,
                     'character_slug' => $character->slug,
-					'character_name' => $character->name,
-					'sender_url' => $user->url,
+                    'character_name' => $character->name,
+                    'sender_url' => $user->url,
                     'sender_name' => $user->name
                 ]);
             }

--- a/config/lorekeeper/settings.php
+++ b/config/lorekeeper/settings.php
@@ -164,6 +164,22 @@ return [
     ],
     'watermark_masterlist_thumbnails' => 0,
 
+	/*
+    |--------------------------------------------------------------------------
+    | Masterlist Image Automation Replacing Cropper
+    |--------------------------------------------------------------------------
+    |
+	| This feature will replace the thumbnail cropper as option at image uploads.
+	| It will automatically add transparent borders to the images to make them square,
+	| based on the bigger dimension (between width/height).
+	| Thumbnails will effectively be small previews of the full masterlist images.
+	| This feature will not replace the manual uploading of thumbnails.
+	|
+	| Simply change to "1" to enable, or keep at "0" to disable.
+	|
+    */
+	'masterlist_image_automation' => 0,
+
     /*
     |--------------------------------------------------------------------------
     | Trade Asset Limit

--- a/config/lorekeeper/settings.php
+++ b/config/lorekeeper/settings.php
@@ -164,21 +164,21 @@ return [
     ],
     'watermark_masterlist_thumbnails' => 0,
 
-	/*
+    /*
     |--------------------------------------------------------------------------
     | Masterlist Image Automation Replacing Cropper
     |--------------------------------------------------------------------------
     |
-	| This feature will replace the thumbnail cropper as option at image uploads.
-	| It will automatically add transparent borders to the images to make them square,
-	| based on the bigger dimension (between width/height).
-	| Thumbnails will effectively be small previews of the full masterlist images.
-	| This feature will not replace the manual uploading of thumbnails.
-	|
-	| Simply change to "1" to enable, or keep at "0" to disable.
-	|
+    | This feature will replace the thumbnail cropper as option at image uploads.
+    | It will automatically add transparent borders to the images to make them square,
+    | based on the bigger dimension (between width/height).
+    | Thumbnails will effectively be small previews of the full masterlist images.
+    | This feature will not replace the manual uploading of thumbnails.
+    |
+    | Simply change to "1" to enable, or keep at "0" to disable.
+    |
     */
-	'masterlist_image_automation' => 0,
+    'masterlist_image_automation' => 0,
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/views/admin/masterlist/create_character.blade.php
+++ b/resources/views/admin/masterlist/create_character.blade.php
@@ -153,11 +153,11 @@
     <div class="card mb-3" id="thumbnailCrop">
         <div class="card-body">
             <div id="cropSelect">Select an image to use the thumbnail cropper.</div>
-			<img src="#" id="cropper" class="hide" />
-			{!! Form::hidden('x0', null, ['id' => 'cropX0']) !!}
-			{!! Form::hidden('x1', null, ['id' => 'cropX1']) !!}
-			{!! Form::hidden('y0', null, ['id' => 'cropY0']) !!}
-			{!! Form::hidden('y1', null, ['id' => 'cropY1']) !!}
+            <img src="#" id="cropper" class="hide" />
+            {!! Form::hidden('x0', null, ['id' => 'cropX0']) !!}
+            {!! Form::hidden('x1', null, ['id' => 'cropX1']) !!}
+            {!! Form::hidden('y0', null, ['id' => 'cropY0']) !!}
+            {!! Form::hidden('y1', null, ['id' => 'cropY1']) !!}
         </div>
     </div>
 @endif

--- a/resources/views/admin/masterlist/create_character.blade.php
+++ b/resources/views/admin/masterlist/create_character.blade.php
@@ -131,6 +131,21 @@
         @endif
         <div>{!! Form::file('image', ['id' => 'mainImage']) !!}</div>
     </div>
+@if (Config::get('lorekeeper.settings.masterlist_image_automation') === 1)
+    <div class="form-group">
+        {!! Form::checkbox('use_cropper', 1, 1, ['class' => 'form-check-input', 'data-toggle' => 'toggle', 'id' => 'useCropper']) !!}
+        {!! Form::label('use_cropper', 'Use Thumbnail Automation', ['class' => 'form-check-label ml-3']) !!} {!! add_help('A thumbnail is required for the upload (used for the masterlist). You can use the Thumbnail Automation, or upload a custom thumbnail.') !!}
+    </div>
+    <div class="card mb-3" id="thumbnailCrop">
+        <div class="card-body">
+            <div id="cropSelect">By using this function, the thumbnail will be automatically generated from the full image.</div>
+            {!! Form::hidden('x0', 1) !!}
+            {!! Form::hidden('x1', 1) !!}
+            {!! Form::hidden('y0', 1) !!}
+            {!! Form::hidden('y1', 1) !!}
+        </div>
+    </div>
+@else
     <div class="form-group">
         {!! Form::checkbox('use_cropper', 1, 1, ['class' => 'form-check-input', 'data-toggle' => 'toggle', 'id' => 'useCropper']) !!}
         {!! Form::label('use_cropper', 'Use Image Cropper', ['class' => 'form-check-label ml-3']) !!} {!! add_help('A thumbnail is required for the upload (used for the masterlist). You can use the image cropper (crop dimensions can be adjusted in the site code), or upload a custom thumbnail.') !!}
@@ -138,13 +153,14 @@
     <div class="card mb-3" id="thumbnailCrop">
         <div class="card-body">
             <div id="cropSelect">Select an image to use the thumbnail cropper.</div>
-            <img src="#" id="cropper" class="hide" />
-            {!! Form::hidden('x0', null, ['id' => 'cropX0']) !!}
-            {!! Form::hidden('x1', null, ['id' => 'cropX1']) !!}
-            {!! Form::hidden('y0', null, ['id' => 'cropY0']) !!}
-            {!! Form::hidden('y1', null, ['id' => 'cropY1']) !!}
+			<img src="#" id="cropper" class="hide" />
+			{!! Form::hidden('x0', null, ['id' => 'cropX0']) !!}
+			{!! Form::hidden('x1', null, ['id' => 'cropX1']) !!}
+			{!! Form::hidden('y0', null, ['id' => 'cropY0']) !!}
+			{!! Form::hidden('y1', null, ['id' => 'cropY1']) !!}
         </div>
     </div>
+@endif
     <div class="card mb-3" id="thumbnailUpload">
         <div class="card-body">
             {!! Form::label('Thumbnail Image') !!} {!! add_help('This image is shown on the masterlist page.') !!}

--- a/resources/views/character/admin/_reupload_image_modal.blade.php
+++ b/resources/views/character/admin/_reupload_image_modal.blade.php
@@ -6,11 +6,11 @@
 @if (Config::get('lorekeeper.settings.masterlist_image_automation') === 1)
     <div class="form-group">
         {!! Form::checkbox('use_cropper', 1, 1, ['class' => 'form-check-input', 'data-toggle' => 'toggle', 'id' => 'useCropper']) !!}
-		{!! Form::label('use_cropper', 'Use Thumbnail Automation', ['class' => 'form-check-label ml-3']) !!} {!! add_help('A thumbnail is required for the upload (used for the masterlist). You can use the Thumbnail Automation, or upload a custom thumbnail.') !!}
+        {!! Form::label('use_cropper', 'Use Thumbnail Automation', ['class' => 'form-check-label ml-3']) !!} {!! add_help('A thumbnail is required for the upload (used for the masterlist). You can use the Thumbnail Automation, or upload a custom thumbnail.') !!}
     </div>
     <div class="card mb-3" id="thumbnailCrop">
         <div class="card-body">
-			<div id="cropSelect">By using this function, the thumbnail will be automatically generated from the full image.</div>
+            <div id="cropSelect">By using this function, the thumbnail will be automatically generated from the full image.</div>
             {!! Form::hidden('x0', 1) !!}
             {!! Form::hidden('x1', 1) !!}
             {!! Form::hidden('y0', 1) !!}
@@ -20,12 +20,12 @@
 @else
     <div class="form-group">
         {!! Form::checkbox('use_cropper', 1, 1, ['class' => 'form-check-input', 'data-toggle' => 'toggle', 'id' => 'useCropper']) !!}
-		{!! Form::label('use_cropper', 'Use Image Cropper', ['class' => 'form-check-label ml-3']) !!} {!! add_help('A thumbnail is required for the upload (used for the masterlist). You can use the image cropper (crop dimensions can be adjusted in the site code), or upload a custom thumbnail.') !!}
+        {!! Form::label('use_cropper', 'Use Image Cropper', ['class' => 'form-check-label ml-3']) !!} {!! add_help('A thumbnail is required for the upload (used for the masterlist). You can use the image cropper (crop dimensions can be adjusted in the site code), or upload a custom thumbnail.') !!}
     </div>
     <div class="card mb-3" id="thumbnailCrop">
         <div class="card-body">
-			<div id="cropSelect">Select an image to use the thumbnail cropper.</div>
-			<img src="#" id="cropper" class="hide" />
+            <div id="cropSelect">Select an image to use the thumbnail cropper.</div>
+            <img src="#" id="cropper" class="hide" />
             {!! Form::hidden('x0', null, ['id' => 'cropX0']) !!}
             {!! Form::hidden('x1', null, ['id' => 'cropX1']) !!}
             {!! Form::hidden('y0', null, ['id' => 'cropY0']) !!}

--- a/resources/views/character/admin/_reupload_image_modal.blade.php
+++ b/resources/views/character/admin/_reupload_image_modal.blade.php
@@ -3,20 +3,36 @@
         {!! Form::label('Character Image') !!} {!! add_help('This is the full masterlist image. Note that the image is not protected in any way, so take precautions to avoid art/design theft.') !!}
         <div>{!! Form::file('image', ['id' => 'mainImage']) !!}</div>
     </div>
+@if (Config::get('lorekeeper.settings.masterlist_image_automation') === 1)
     <div class="form-group">
         {!! Form::checkbox('use_cropper', 1, 1, ['class' => 'form-check-input', 'data-toggle' => 'toggle', 'id' => 'useCropper']) !!}
-        {!! Form::label('use_cropper', 'Use Image Cropper', ['class' => 'form-check-label ml-3']) !!} {!! add_help('A thumbnail is required for the upload (used for the masterlist). You can use the image cropper (crop dimensions can be adjusted in the site code), or upload a custom thumbnail.') !!}
+		{!! Form::label('use_cropper', 'Use Thumbnail Automation', ['class' => 'form-check-label ml-3']) !!} {!! add_help('A thumbnail is required for the upload (used for the masterlist). You can use the Thumbnail Automation, or upload a custom thumbnail.') !!}
     </div>
     <div class="card mb-3" id="thumbnailCrop">
         <div class="card-body">
-            <div id="cropSelect">Select an image to use the thumbnail cropper.</div>
-            <img src="#" id="cropper" class="hide" />
+			<div id="cropSelect">By using this function, the thumbnail will be automatically generated from the full image.</div>
+            {!! Form::hidden('x0', 1) !!}
+            {!! Form::hidden('x1', 1) !!}
+            {!! Form::hidden('y0', 1) !!}
+            {!! Form::hidden('y1', 1) !!}
+        </div>
+    </div>
+@else
+    <div class="form-group">
+        {!! Form::checkbox('use_cropper', 1, 1, ['class' => 'form-check-input', 'data-toggle' => 'toggle', 'id' => 'useCropper']) !!}
+		{!! Form::label('use_cropper', 'Use Image Cropper', ['class' => 'form-check-label ml-3']) !!} {!! add_help('A thumbnail is required for the upload (used for the masterlist). You can use the image cropper (crop dimensions can be adjusted in the site code), or upload a custom thumbnail.') !!}
+    </div>
+    <div class="card mb-3" id="thumbnailCrop">
+        <div class="card-body">
+			<div id="cropSelect">Select an image to use the thumbnail cropper.</div>
+			<img src="#" id="cropper" class="hide" />
             {!! Form::hidden('x0', null, ['id' => 'cropX0']) !!}
             {!! Form::hidden('x1', null, ['id' => 'cropX1']) !!}
             {!! Form::hidden('y0', null, ['id' => 'cropY0']) !!}
             {!! Form::hidden('y1', null, ['id' => 'cropY1']) !!}
         </div>
     </div>
+@endif
     <div class="card mb-3" id="thumbnailUpload">
         <div class="card-body">
             {!! Form::label('Thumbnail Image') !!} {!! add_help('This image is shown on the masterlist page.') !!}

--- a/resources/views/character/admin/upload_image.blade.php
+++ b/resources/views/character/admin/upload_image.blade.php
@@ -27,11 +27,11 @@
 @if (Config::get('lorekeeper.settings.masterlist_image_automation') === 1)
 <div class="form-group">
     {!! Form::checkbox('use_cropper', 1, 1, ['class' => 'form-check-input', 'data-toggle' => 'toggle', 'id' => 'useCropper']) !!}
-	{!! Form::label('use_cropper', 'Use Thumbnail Automation', ['class' => 'form-check-label ml-3']) !!} {!! add_help('A thumbnail is required for the upload (used for the masterlist). You can use the Thumbnail Automation, or upload a custom thumbnail.') !!}
+    {!! Form::label('use_cropper', 'Use Thumbnail Automation', ['class' => 'form-check-label ml-3']) !!} {!! add_help('A thumbnail is required for the upload (used for the masterlist). You can use the Thumbnail Automation, or upload a custom thumbnail.') !!}
 </div>
 <div class="card mb-3" id="thumbnailCrop">
     <div class="card-body">
-		<div id="cropSelect">By using this function, the thumbnail will be automatically generated from the full image.</div>
+        <div id="cropSelect">By using this function, the thumbnail will be automatically generated from the full image.</div>
         {!! Form::hidden('x0', 1) !!}
         {!! Form::hidden('x1', 1) !!}
         {!! Form::hidden('y0', 1) !!}
@@ -41,16 +41,16 @@
 @else
 <div class="form-group">
     {!! Form::checkbox('use_cropper', 1, 1, ['class' => 'form-check-input', 'data-toggle' => 'toggle', 'id' => 'useCropper']) !!}
-		{!! Form::label('use_cropper', 'Use Image Cropper', ['class' => 'form-check-label ml-3']) !!} {!! add_help('A thumbnail is required for the upload (used for the masterlist). You can use the image cropper (crop dimensions can be adjusted in the site code), or upload a custom thumbnail.') !!}
+        {!! Form::label('use_cropper', 'Use Image Cropper', ['class' => 'form-check-label ml-3']) !!} {!! add_help('A thumbnail is required for the upload (used for the masterlist). You can use the image cropper (crop dimensions can be adjusted in the site code), or upload a custom thumbnail.') !!}
 </div>
 <div class="card mb-3" id="thumbnailCrop">
-	<div class="card-body">
-		<div id="cropSelect">Select an image to use the thumbnail cropper.</div>
-		<img src="#" id="cropper" class="hide" />
-		{!! Form::hidden('x0', null, ['id' => 'cropX0']) !!}
-		{!! Form::hidden('x1', null, ['id' => 'cropX1']) !!}
-		{!! Form::hidden('y0', null, ['id' => 'cropY0']) !!}
-		{!! Form::hidden('y1', null, ['id' => 'cropY1']) !!}
+    <div class="card-body">
+        <div id="cropSelect">Select an image to use the thumbnail cropper.</div>
+        <img src="#" id="cropper" class="hide" />
+        {!! Form::hidden('x0', null, ['id' => 'cropX0']) !!}
+        {!! Form::hidden('x1', null, ['id' => 'cropX1']) !!}
+        {!! Form::hidden('y0', null, ['id' => 'cropY0']) !!}
+        {!! Form::hidden('y1', null, ['id' => 'cropY1']) !!}
     </div>
 </div>
 @endif

--- a/resources/views/character/admin/upload_image.blade.php
+++ b/resources/views/character/admin/upload_image.blade.php
@@ -24,20 +24,36 @@
     {!! Form::label('Character Image') !!} {!! add_help('This is the full masterlist image. Note that the image is not protected in any way, so take precautions to avoid art/design theft.') !!}
     <div>{!! Form::file('image', ['id' => 'mainImage']) !!}</div>
 </div>
+@if (Config::get('lorekeeper.settings.masterlist_image_automation') === 1)
 <div class="form-group">
     {!! Form::checkbox('use_cropper', 1, 1, ['class' => 'form-check-input', 'data-toggle' => 'toggle', 'id' => 'useCropper']) !!}
-    {!! Form::label('use_cropper', 'Use Image Cropper', ['class' => 'form-check-label ml-3']) !!} {!! add_help('A thumbnail is required for the upload (used for the masterlist). You can use the image cropper (crop dimensions can be adjusted in the site code), or upload a custom thumbnail.') !!}
+	{!! Form::label('use_cropper', 'Use Thumbnail Automation', ['class' => 'form-check-label ml-3']) !!} {!! add_help('A thumbnail is required for the upload (used for the masterlist). You can use the Thumbnail Automation, or upload a custom thumbnail.') !!}
 </div>
 <div class="card mb-3" id="thumbnailCrop">
     <div class="card-body">
-        <div id="cropSelect">Select an image to use the thumbnail cropper.</div>
-        <img src="#" id="cropper" class="hide" />
-        {!! Form::hidden('x0', null, ['id' => 'cropX0']) !!}
-        {!! Form::hidden('x1', null, ['id' => 'cropX1']) !!}
-        {!! Form::hidden('y0', null, ['id' => 'cropY0']) !!}
-        {!! Form::hidden('y1', null, ['id' => 'cropY1']) !!}
+		<div id="cropSelect">By using this function, the thumbnail will be automatically generated from the full image.</div>
+        {!! Form::hidden('x0', 1) !!}
+        {!! Form::hidden('x1', 1) !!}
+        {!! Form::hidden('y0', 1) !!}
+        {!! Form::hidden('y1', 1) !!}
     </div>
 </div>
+@else
+<div class="form-group">
+    {!! Form::checkbox('use_cropper', 1, 1, ['class' => 'form-check-input', 'data-toggle' => 'toggle', 'id' => 'useCropper']) !!}
+		{!! Form::label('use_cropper', 'Use Image Cropper', ['class' => 'form-check-label ml-3']) !!} {!! add_help('A thumbnail is required for the upload (used for the masterlist). You can use the image cropper (crop dimensions can be adjusted in the site code), or upload a custom thumbnail.') !!}
+</div>
+<div class="card mb-3" id="thumbnailCrop">
+	<div class="card-body">
+		<div id="cropSelect">Select an image to use the thumbnail cropper.</div>
+		<img src="#" id="cropper" class="hide" />
+		{!! Form::hidden('x0', null, ['id' => 'cropX0']) !!}
+		{!! Form::hidden('x1', null, ['id' => 'cropX1']) !!}
+		{!! Form::hidden('y0', null, ['id' => 'cropY0']) !!}
+		{!! Form::hidden('y1', null, ['id' => 'cropY1']) !!}
+    </div>
+</div>
+@endif
 <div class="card mb-3" id="thumbnailUpload">
     <div class="card-body">
         {!! Form::label('Thumbnail Image') !!} {!! add_help('This image is shown on the masterlist page.') !!}

--- a/resources/views/character/design/image.blade.php
+++ b/resources/views/character/design/image.blade.php
@@ -73,11 +73,11 @@
 @if (Config::get('lorekeeper.settings.masterlist_image_automation') === 1)
         <div class="form-group">
             {!! Form::checkbox('use_cropper', 1, 1, ['class' => 'form-check-input', 'data-toggle' => 'toggle', 'id' => 'useCropper']) !!}
-			{!! Form::label('use_cropper', 'Use Thumbnail Automation', ['class' => 'form-check-label ml-3']) !!} {!! add_help('A thumbnail is required for the upload (used for the masterlist). You can use the Thumbnail Automation, or upload a custom thumbnail.') !!}
+            {!! Form::label('use_cropper', 'Use Thumbnail Automation', ['class' => 'form-check-label ml-3']) !!} {!! add_help('A thumbnail is required for the upload (used for the masterlist). You can use the Thumbnail Automation, or upload a custom thumbnail.') !!}
         </div>
         <div class="card mb-3" id="thumbnailCrop">
             <div class="card-body">
-				<div id="cropSelect">By using this function, the thumbnail will be automatically generated from the full image.</div>
+                <div id="cropSelect">By using this function, the thumbnail will be automatically generated from the full image.</div>
                 {!! Form::hidden('x0', 1) !!}
                 {!! Form::hidden('x1', 1) !!}
                 {!! Form::hidden('y0', 1) !!}
@@ -87,11 +87,11 @@
 @else
         <div class="form-group">
             {!! Form::checkbox('use_cropper', 1, 1, ['class' => 'form-check-input', 'data-toggle' => 'toggle', 'id' => 'useCropper']) !!}
-			{!! Form::label('use_cropper', 'Use Image Cropper', ['class' => 'form-check-label ml-3']) !!} {!! add_help('A thumbnail is required for the upload (used for the masterlist). You can use the image cropper (crop dimensions can be adjusted in the site code), or upload a custom thumbnail.') !!}
+            {!! Form::label('use_cropper', 'Use Image Cropper', ['class' => 'form-check-label ml-3']) !!} {!! add_help('A thumbnail is required for the upload (used for the masterlist). You can use the image cropper (crop dimensions can be adjusted in the site code), or upload a custom thumbnail.') !!}
         </div>
         <div class="card mb-3" id="thumbnailCrop">
             <div class="card-body">
-				<div id="cropSelect">Select an image to use the thumbnail cropper.</div>
+                <div id="cropSelect">Select an image to use the thumbnail cropper.</div>
                 <img src="#" id="cropper" class="hide" />
                 {!! Form::hidden('x0', null, ['id' => 'cropX0']) !!}
                 {!! Form::hidden('x1', null, ['id' => 'cropX1']) !!}

--- a/resources/views/character/design/image.blade.php
+++ b/resources/views/character/design/image.blade.php
@@ -70,22 +70,36 @@
                 {!! Form::label('modify_thumbnail', 'Modify Thumbnail', ['class' => 'form-check-label ml-3']) !!} {!! add_help('Toggle this option to modify the thumbnail, otherwise only the credits will be saved.') !!}
             </div>
         @endif
+@if (Config::get('lorekeeper.settings.masterlist_image_automation') === 1)
         <div class="form-group">
             {!! Form::checkbox('use_cropper', 1, 1, ['class' => 'form-check-input', 'data-toggle' => 'toggle', 'id' => 'useCropper']) !!}
-            {!! Form::label('use_cropper', 'Use Image Cropper', ['class' => 'form-check-label ml-3']) !!} {!! add_help('A thumbnail is required for the upload (used for the masterlist). You can use the image cropper (crop dimensions can be adjusted in the site code), or upload a custom thumbnail.') !!}
+			{!! Form::label('use_cropper', 'Use Thumbnail Automation', ['class' => 'form-check-label ml-3']) !!} {!! add_help('A thumbnail is required for the upload (used for the masterlist). You can use the Thumbnail Automation, or upload a custom thumbnail.') !!}
         </div>
         <div class="card mb-3" id="thumbnailCrop">
             <div class="card-body">
-                @if($request->status == 'Draft' && $request->user_id == Auth::user()->id)
-                    <div id="cropSelect">Select an image to use the thumbnail cropper.</div>
-                @endif
-                <img src="#" id="cropper" class="hide" {{ ($request->status == 'Pending' && Auth::user()->hasPower('manage_characters')) ? 'data-url='.$request->imageUrl : '' }} />
-                {!! Form::hidden('x0', $request->x0, ['id' => 'cropX0']) !!}
-                {!! Form::hidden('x1', $request->x1, ['id' => 'cropX1']) !!}
-                {!! Form::hidden('y0', $request->y0, ['id' => 'cropY0']) !!}
-                {!! Form::hidden('y1', $request->y1, ['id' => 'cropY1']) !!}
+				<div id="cropSelect">By using this function, the thumbnail will be automatically generated from the full image.</div>
+                {!! Form::hidden('x0', 1) !!}
+                {!! Form::hidden('x1', 1) !!}
+                {!! Form::hidden('y0', 1) !!}
+                {!! Form::hidden('y1', 1) !!}
             </div>
         </div>
+@else
+        <div class="form-group">
+            {!! Form::checkbox('use_cropper', 1, 1, ['class' => 'form-check-input', 'data-toggle' => 'toggle', 'id' => 'useCropper']) !!}
+			{!! Form::label('use_cropper', 'Use Image Cropper', ['class' => 'form-check-label ml-3']) !!} {!! add_help('A thumbnail is required for the upload (used for the masterlist). You can use the image cropper (crop dimensions can be adjusted in the site code), or upload a custom thumbnail.') !!}
+        </div>
+        <div class="card mb-3" id="thumbnailCrop">
+            <div class="card-body">
+				<div id="cropSelect">Select an image to use the thumbnail cropper.</div>
+                <img src="#" id="cropper" class="hide" />
+                {!! Form::hidden('x0', null, ['id' => 'cropX0']) !!}
+                {!! Form::hidden('x1', null, ['id' => 'cropX1']) !!}
+                {!! Form::hidden('y0', null, ['id' => 'cropY0']) !!}
+                {!! Form::hidden('y1', null, ['id' => 'cropY1']) !!}
+            </div>
+        </div>
+@endif
         <div class="card mb-3" id="thumbnailUpload">
             <div class="card-body">
                 {!! Form::label('Thumbnail Image') !!} {!! add_help('This image is shown on the masterlist page.') !!}


### PR DESCRIPTION
Credit for original code to https://github.com/itinerare / @itinerare 

Adds option in settings to automate thumbnail process, making images square and resizing them to thumbnail size.
Replaces the image cropper, but allows user to still upload their own thumbnail.