### PR TITLE
Fix character inventory edits leading to a 404

### DIFF
--- a/routes/lorekeeper/members.php
+++ b/routes/lorekeeper/members.php
@@ -81,6 +81,8 @@ Route::group(['prefix' => 'character', 'namespace' => 'Characters'], function() 
     Route::get('{slug}/profile/edit', 'CharacterController@getEditCharacterProfile');
     Route::post('{slug}/profile/edit', 'CharacterController@postEditCharacterProfile');
 
+    Route::post('{slug}/inventory/edit', 'CharacterController@postInventoryEdit');
+
     Route::post('{slug}/bank/transfer', 'CharacterController@postCurrencyTransfer');
     Route::get('{slug}/transfer', 'CharacterController@getTransfer');
     Route::post('{slug}/transfer', 'CharacterController@postTransfer');


### PR DESCRIPTION
added a missing route preventing items from being removed or deleted from character inventories