### PR TITLE
Fix redirection to 'home' when visiting '/register' while logged in

### DIFF
--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -18,7 +18,7 @@ class RedirectIfAuthenticated
     public function handle($request, Closure $next, $guard = null)
     {
         if (Auth::guard($guard)->check()) {
-            return redirect('/home');
+            return redirect('/');
         }
 
         return $next($request);


### PR DESCRIPTION
Now it redirects to the actual home page instead of the 404 page 'home' when attempting to go to the registration url when logged in.

#56 