### PR TITLE
Add 'user_reason' to MyoController for postTransfer.

### DIFF
--- a/app/Http/Controllers/Characters/MyoController.php
+++ b/app/Http/Controllers/Characters/MyoController.php
@@ -205,7 +205,7 @@ class MyoController extends Controller
     {
         if(!Auth::check()) abort(404);
 
-        if($service->createTransfer($request->only(['recipient_id','user_reason']), $this->character, Auth::user())) {
+        if($service->createTransfer($request->only(['recipient_id', 'user_reason']), $this->character, Auth::user())) {
             flash('Transfer created successfully.')->success();
         }
         else {

--- a/app/Http/Controllers/Characters/MyoController.php
+++ b/app/Http/Controllers/Characters/MyoController.php
@@ -205,7 +205,7 @@ class MyoController extends Controller
     {
         if(!Auth::check()) abort(404);
 
-        if($service->createTransfer($request->only(['recipient_id']), $this->character, Auth::user())) {
+        if($service->createTransfer($request->only(['recipient_id','user_reason']), $this->character, Auth::user())) {
             flash('Transfer created successfully.')->success();
         }
         else {


### PR DESCRIPTION
Add 'user_reason' to MyoController for postTransfer.

Previously, when attempting to user-transfer a MYO slot, it would give a "undefined index: user_reason" error.