### PR TITLE
Add an "is released" toggle to item editing (w/ extra fields enabled)

### DIFF
--- a/app/Http/Controllers/Users/SubmissionController.php
+++ b/app/Http/Controllers/Users/SubmissionController.php
@@ -34,7 +34,7 @@ class SubmissionController extends Controller
     */
 
     /**********************************************************************************************
-    
+
         PROMPT SUBMISSIONS
 
     **********************************************************************************************/
@@ -50,7 +50,7 @@ class SubmissionController extends Controller
         $submissions = Submission::with('prompt')->where('user_id', Auth::user()->id)->whereNotNull('prompt_id');
         $type = $request->get('type');
         if(!$type) $type = 'Pending';
-        
+
         $submissions = $submissions->where('status', ucfirst($type));
 
         return view('home.submissions', [
@@ -58,7 +58,7 @@ class SubmissionController extends Controller
             'isClaims' => false
         ]);
     }
-    
+
     /**
      * Shows the submission page.
      *
@@ -97,8 +97,8 @@ class SubmissionController extends Controller
             'prompts' => Prompt::active()->sortAlphabetical()->pluck('name', 'id')->toArray(),
             'characterCurrencies' => Currency::where('is_character_owned', 1)->orderBy('sort_character', 'DESC')->pluck('name', 'id'),
             'categories' => ItemCategory::orderBy('sort', 'DESC')->get(),
-            'item_filter' => Item::orderBy('name')->get()->keyBy('id'),
-            'items' => Item::orderBy('name')->pluck('name', 'id'),
+            'item_filter' => Item::orderBy('name')->released()->get()->keyBy('id'),
+            'items' => Item::orderBy('name')->released()->pluck('name', 'id'),
             'currencies' => Currency::where('is_user_owned', 1)->orderBy('name')->pluck('name', 'id'),
             'inventory' => $inventory,
             'page' => 'submission'
@@ -136,7 +136,7 @@ class SubmissionController extends Controller
             'count' => Submission::where('prompt_id', $id)->where('status', 'Approved')->where('user_id', Auth::user()->id)->count()
         ]);
     }
-    
+
     /**
      * Creates a new submission.
      *
@@ -157,7 +157,7 @@ class SubmissionController extends Controller
     }
 
     /**********************************************************************************************
-    
+
         CLAIMS
 
     **********************************************************************************************/
@@ -173,7 +173,7 @@ class SubmissionController extends Controller
         $submissions = Submission::where('user_id', Auth::user()->id)->whereNull('prompt_id');
         $type = $request->get('type');
         if(!$type) $type = 'Pending';
-        
+
         $submissions = $submissions->where('status', ucfirst($type));
 
         return view('home.submissions', [
@@ -181,7 +181,7 @@ class SubmissionController extends Controller
             'isClaims' => true
         ]);
     }
-    
+
     /**
      * Shows the claim page.
      *
@@ -201,7 +201,7 @@ class SubmissionController extends Controller
             'inventory' => $inventory
         ]);
     }
-    
+
     /**
      * Shows the submit claim page.
      *
@@ -220,14 +220,14 @@ class SubmissionController extends Controller
             'characterCurrencies' => Currency::where('is_character_owned', 1)->orderBy('sort_character', 'DESC')->pluck('name', 'id'),
             'categories' => ItemCategory::orderBy('sort', 'DESC')->get(),
             'inventory' => $inventory,
-            'item_filter' => Item::orderBy('name')->get()->keyBy('id'),
-            'items' => Item::orderBy('name')->pluck('name', 'id'),
+            'item_filter' => Item::orderBy('name')->released()->get()->keyBy('id'),
+            'items' => Item::orderBy('name')->released()->pluck('name', 'id'),
             'currencies' => Currency::where('is_user_owned', 1)->orderBy('name')->pluck('name', 'id'),
             'raffles' => Raffle::where('rolled_at', null)->where('is_active', 1)->orderBy('name')->pluck('name', 'id'),
             'page' => 'submission'
         ]));
     }
-    
+
     /**
      * Creates a new claim.
      *

--- a/app/Http/Controllers/WorldController.php
+++ b/app/Http/Controllers/WorldController.php
@@ -17,6 +17,7 @@ use App\Models\Character\CharacterCategory;
 use App\Models\Prompt\PromptCategory;
 use App\Models\Prompt\Prompt;
 use App\Models\Shop\Shop;
+use App\Models\Shop\ShopStock;
 use App\Models\User\User;
 
 class WorldController extends Controller
@@ -242,7 +243,7 @@ class WorldController extends Controller
      */
     public function getItems(Request $request)
     {
-        $query = Item::with('category');
+        $query = Item::with('category')->released();
         $data = $request->only(['item_category_id', 'name', 'sort']);
         if(isset($data['item_category_id']) && $data['item_category_id'] != 'none')
             $query->where('item_category_id', $data['item_category_id']);
@@ -290,7 +291,7 @@ class WorldController extends Controller
     public function getItem($id)
     {
         $categories = ItemCategory::orderBy('sort', 'DESC')->get();
-        $item = Item::where('id', $id)->first();
+        $item = Item::where('id', $id)->released()->first();
         if(!$item) abort(404);
 
         return view('world.item_page', [

--- a/app/Models/Item/Item.php
+++ b/app/Models/Item/Item.php
@@ -10,6 +10,7 @@ use App\Models\Item\ItemCategory;
 use App\Models\User\User;
 use App\Models\Shop\Shop;
 use App\Models\Prompt\Prompt;
+use App\Models\User\UserItem;
 
 class Item extends Model
 {
@@ -20,7 +21,7 @@ class Item extends Model
      */
     protected $fillable = [
         'item_category_id', 'name', 'has_image', 'description', 'parsed_description', 'allow_transfer',
-        'data', 'reference_url', 'artist_alias', 'artist_url', 'artist_id'
+        'data', 'reference_url', 'artist_alias', 'artist_url', 'artist_id', 'is_released'
     ];
 
     protected $appends = ['image_url'];
@@ -145,6 +146,17 @@ class Item extends Model
     public function scopeSortOldest($query)
     {
         return $query->orderBy('id');
+    }
+
+    /**
+     * Scope a query to show only released or "released" (at least one user-owned stack has ever existed) items.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeReleased($query)
+    {
+        return $query->whereIn('id', UserItem::pluck('item_id')->toArray())->orWhere('is_released', 1);
     }
 
     /**********************************************************************************************

--- a/app/Services/ItemService.php
+++ b/app/Services/ItemService.php
@@ -288,6 +288,8 @@ class ItemService extends Service
         else $data['parsed_description'] = null;
 
         if(!isset($data['allow_transfer'])) $data['allow_transfer'] = 0;
+        if(!isset($data['is_released']) && Config::get('lorekeeper.extensions.item_entry_expansion.extra_fields')) $data['is_released'] = 0;
+        else $data['is_released'] = 1;
 
         if(isset($data['remove_image']))
         {

--- a/database/migrations/2021_01_08_230640_add_released_to_items.php
+++ b/database/migrations/2021_01_08_230640_add_released_to_items.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddReleasedToItems extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('items', function (Blueprint $table) {
+            //
+            $table->boolean('is_released')->default(1);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('items', function (Blueprint $table) {
+            //
+            $table->dropColumn('is_released');
+        });
+    }
+}

--- a/resources/views/admin/items/create_edit_item.blade.php
+++ b/resources/views/admin/items/create_edit_item.blade.php
@@ -87,9 +87,17 @@
     </div>
 @endif
 
-<div class="form-group">
-    {!! Form::checkbox('allow_transfer', 1, $item->id ? $item->allow_transfer : 1, ['class' => 'form-check-input', 'data-toggle' => 'toggle']) !!}
-    {!! Form::label('allow_transfer', 'Allow User → User Transfer', ['class' => 'form-check-label ml-3']) !!} {!! add_help('If this is off, users will not be able to transfer this item to other users. Non-account-bound items can be account-bound when granted to users directly.') !!}
+<div class="row">
+    <div class="col-md form-group">
+        {!! Form::checkbox('allow_transfer', 1, $item->id ? $item->allow_transfer : 1, ['class' => 'form-check-input', 'data-toggle' => 'toggle']) !!}
+        {!! Form::label('allow_transfer', 'Allow User → User Transfer', ['class' => 'form-check-label ml-3']) !!} {!! add_help('If this is off, users will not be able to transfer this item to other users. Non-account-bound items can be account-bound when granted to users directly.') !!}
+    </div>
+    @if(Config::get('lorekeeper.extensions.item_entry_expansion.extra_fields'))
+        <div class="col-md form-group">
+            {!! Form::checkbox('is_released', 1, $item->id ? $item->is_released : 1, ['class' => 'form-check-input', 'data-toggle' => 'toggle']) !!}
+            {!! Form::label('is_released', 'Is Released', ['class' => 'form-check-label ml-3']) !!} {!! add_help('If this is off, users will not be able to view information for the item/it will be hidden from view. This is overridden by the item being owned at any point by anyone on the site.') !!}
+        </div>
+    @endif
 </div>
 
 @if(Config::get('lorekeeper.extensions.item_entry_expansion.extra_fields'))


### PR DESCRIPTION
- This toggle, when off, hides items from user view (in item index in world, item pages in world, and when making submissions/claims)
- It is overridden by a stack of the item existing
Tested locally/live - Requires migrate