### PR TITLE
Feature/item search

### DIFF
--- a/app/Http/Controllers/Users/InventoryController.php
+++ b/app/Http/Controllers/Users/InventoryController.php
@@ -15,6 +15,10 @@ use App\Models\Character\Character;
 use App\Models\Character\CharacterItem;
 use App\Services\InventoryManager;
 
+use App\Models\Trade;
+use App\Models\Character\CharacterDesignUpdate;
+use App\Models\Submission\Submission;
+
 use App\Http\Controllers\Controller;
 
 class InventoryController extends Controller
@@ -36,7 +40,7 @@ class InventoryController extends Controller
     public function getIndex()
     {
         $categories = ItemCategory::orderBy('sort', 'DESC')->get();
-        $items = count($categories) ? 
+        $items = count($categories) ?
             Auth::user()->items()
                 ->where('count', '>', 0)
                 ->orderByRaw('FIELD(item_category_id,'.implode(',', $categories->pluck('id')->toArray()).')')
@@ -44,7 +48,7 @@ class InventoryController extends Controller
                 ->orderBy('updated_at')
                 ->get()
                 ->groupBy(['item_category_id', 'id']) :
-            Auth::user()->items() 
+            Auth::user()->items()
                 ->where('count', '>', 0)
                 ->orderBy('name')
                 ->orderBy('updated_at')
@@ -124,7 +128,7 @@ class InventoryController extends Controller
     {
         if(!$request->ids) { flash('No items selected.')->error(); }
         if(!$request->quantities) { flash('Quantities not set.')->error(); }
-        
+
         if($request->ids && $request->quantities) {
             switch($request->action) {
                 default:
@@ -148,7 +152,7 @@ class InventoryController extends Controller
         }
         return redirect()->back();
     }
-    
+
     /**
      * Transfers inventory items to another user.
      *
@@ -184,7 +188,7 @@ class InventoryController extends Controller
         }
         return redirect()->back();
     }
-    
+
     /**
      * Deletes an inventory stack.
      *
@@ -233,7 +237,7 @@ class InventoryController extends Controller
             'user' => Auth::user(),
         ]);
     }
-    
+
     /**
      * Acts on an item based on the item's tag.
      *
@@ -253,5 +257,41 @@ class InventoryController extends Controller
             foreach($service->errors()->getMessages()['error'] as $error) flash($error)->error();
         }
         return redirect()->back();
+    }
+
+    /**
+     * Show the account search page.
+     *
+     * @return \Illuminate\Contracts\Support\Renderable
+     */
+    public function getAccountSearch(Request $request)
+    {
+        $item = Item::find($request->only(['item_id']))->first();
+        $user = Auth::user();
+
+        if($item) {
+            // Gather all instances of this item in the user's inventory
+            $userItems = UserItem::where('user_id', $user->id)->where('item_id', $item->id)->where('count', '>', 0)->get();
+
+            // Gather the user's characters and the items they own
+            $characters = Character::where('user_id', $user->id)->orderBy('slug', 'ASC')->get();
+            $characterItems = CharacterItem::whereIn('character_id', $characters->pluck('id')->toArray())->where('item_id', $item->id)->where('count', '>', 0)->get();
+
+            // Gather hold locations
+            $designUpdates = CharacterDesignUpdate::where('user_id', $user->id)->whereNotNull('data')->get();
+            $trades = Trade::where('sender_id', $user->id)->orWhere('recipient_id', $user->id)->get();
+            $submissions = Submission::where('user_id', $user->id)->whereNotNull('data')->get();
+        }
+
+        return view('home.account_search', [
+            'item' => $item ? $item : null,
+            'items' => Item::orderBy('name')->pluck('name', 'id'),
+            'userItems' => $item ? $userItems : null,
+            'characterItems' => $item ? $characterItems : null,
+            'characters' => $item ? $characters : null,
+            'designUpdates' => $item ? $designUpdates :null,
+            'trades' => $item ? $trades : null,
+            'submissions' => $item ? $submissions : null,
+        ]);
     }
 }

--- a/app/Http/Controllers/Users/InventoryController.php
+++ b/app/Http/Controllers/Users/InventoryController.php
@@ -266,7 +266,7 @@ class InventoryController extends Controller
      */
     public function getAccountSearch(Request $request)
     {
-        $item = Item::find($request->only(['item_id']))->first();
+        $item = Item::released()->find($request->only(['item_id']))->first();
         $user = Auth::user();
 
         if($item) {
@@ -285,7 +285,7 @@ class InventoryController extends Controller
 
         return view('home.account_search', [
             'item' => $item ? $item : null,
-            'items' => Item::orderBy('name')->pluck('name', 'id'),
+            'items' => Item::orderBy('name')->released()->pluck('name', 'id'),
             'userItems' => $item ? $userItems : null,
             'characterItems' => $item ? $characterItems : null,
             'characters' => $item ? $characters : null,

--- a/resources/views/admin/grants/item_search.blade.php
+++ b/resources/views/admin/grants/item_search.blade.php
@@ -1,0 +1,91 @@
+@extends('admin.layout')
+
+@section('admin-title') Item Search @endsection
+
+@section('admin-content')
+{!! breadcrumbs(['Admin Panel' => 'admin', 'Item Search' => 'admin']) !!}
+
+<h1>Item Search</h1>
+
+{!! Form::open(['method' => 'GET', 'class' => '']) !!}
+<div class="form-inline justify-content-end">
+    <div class="form-group ml-3 mb-3">
+        {!! Form::select('item_id', $items, Request::get('item_id'), ['class' => 'form-control selectize', 'placeholder' => 'Select an Item', 'style' => 'width: 25em; max-width: 100%;']) !!}
+    </div>
+    <div class="form-group ml-3 mb-3">
+        {!! Form::submit('Search', ['class' => 'btn btn-primary']) !!}
+    </div>
+</div>
+{!! Form::close() !!}
+</div>
+
+@if($item)
+    <h3>{{ $item->name }}</h3>
+
+    There are currently {{ $userItems->pluck('count')->sum()+$characterItems->pluck('count')->sum() }} of this item owned by users and characters.
+
+    <ul>
+        @foreach($users as $user)
+            <li>
+                {!! $user->displayName !!} has {{ $userItems->where('user_id', $user->id)->pluck('count')->sum() }}
+                @if($userItems->where('user_id', $user->id)->pluck('count')->sum() > $userItems->where('user_id', $user->id)->pluck('availableQuantity')->sum())
+                 ({{ $userItems->where('user_id', $user->id)->pluck('availableQuantity')->sum() }} Available)
+                    <ul>
+                        @foreach($userItems->where('user_id', $user->id) as $item)
+                            @if($item->count > $item->availableQuantity)
+                                <?php
+                                    $userTradesSent = $trades->where('sender_id', $user->id);
+                                    $userTradesReceived = $trades->where('recipient_id', $user->id);
+                                    $userUpdates = $designUpdates->where('user_id', $user->id);
+                                    $userSubmissions = $submissions->where('user_id', $user->id);
+
+                                    // Collect hold location IDs and quantities
+                                    $holdLocations = [];
+                                    if(isset($item->trade_count) && $item->trade_count > 0) {
+                                        foreach($userTradesSent as $trade)
+                                            if(isset($trade->data['sender']) && $trade->data['sender'] != [] && isset($trade->data['sender']['user_items']) && isset($trade->data['sender']['user_items'][$item->id])) $holdLocations['trade'][$trade->id] = $trade->data['sender']['user_items'][$item->id];
+                                        foreach($userTradesReceived as $trade)
+                                            if(isset($trade->data['recipient']) && $trade->data['recipient'] != [] && isset($trade->data['recipient']['user_items']) && isset($trade->data['recipient']['user_items'][$item->id])) $holdLocations['trade'][$trade->id] = $trade->data['recipient']['user_items'][$item->id];
+                                    }
+                                    if(isset($item->update_count) && $item->update_count > 0)
+                                        foreach($userUpdates as $update)
+                                            if($update->data['user'] != [] && isset($update->data['user']['user_items']) && isset($update->data['user']['user_items'][$item->id])) $holdLocations['update'][$update->id] = $update->data['user']['user_items'][$item->id];
+                                    if(isset($item->submission_count) && $item->submission_count > 0)
+                                        foreach($userSubmissions as $submission)
+                                            if($submission->data['user'] != [] && isset($submission->data['user']['user_items']) && isset($submission->data['user']['user_items'][$item->id])) $holdLocations['submission'][$submission->id] = $submission->data['user']['user_items'][$item->id];
+
+                                    // Format a string with all the places a stack is held
+                                    $held = [];
+                                    if(isset($holdLocations['trade']))
+                                        foreach($holdLocations['trade'] as $trade=>$quantity) array_push($held, '<a href="'.App\Models\Trade::find($trade)->url.'">Trade #'.App\Models\Trade::find($trade)->id.'</a>'.' ('.$quantity.')');
+                                    if(isset($holdLocations['update']))
+                                        foreach($holdLocations['update'] as $update=>$quantity) array_push($held, '<a href="'.App\Models\Character\CharacterDesignUpdate::find($update)->url.'">Design Update #'.App\Models\Character\CharacterDesignUpdate::find($update)->id.'</a>'.' ('.$quantity.')');
+                                    if(isset($holdLocations['submission']))
+                                        foreach($holdLocations['submission'] as $submission=>$quantity) array_push($held, '<a href="'.App\Models\Submission\Submission::find($submission)->viewUrl.'">Submission #'.App\Models\Submission\Submission::find($submission)->id.'</a>'.' ('.$quantity.')');
+                                    $heldString = implode(', ',$held);
+                                ?>
+                                <li>
+                                    {{ $item->getOthers() }} : {!! $heldString !!}
+                                </li>
+                            @endif
+                        @endforeach
+                    </ul>
+                @endif
+            </li>
+        @endforeach
+        @foreach($characters as $character)
+            <li>
+                <a href="{{ $character->url }}">{{ $character->fullName }}</a> has {{ $characterItems->where('character_id', $character->id)->pluck('count')->sum() }}
+            </li>
+        @endforeach
+    </ul>
+@endif
+
+<script>
+    $(document).ready(function() {
+        $('.selectize').selectize();
+    });
+
+</script>
+
+@endsection

--- a/resources/views/admin/grants/item_search.blade.php
+++ b/resources/views/admin/grants/item_search.blade.php
@@ -60,9 +60,9 @@
                                     if(isset($holdLocations['trade']))
                                         foreach($holdLocations['trade'] as $trade=>$quantity) array_push($held, '<a href="'.App\Models\Trade::find($trade)->url.'">Trade #'.App\Models\Trade::find($trade)->id.'</a>'.' ('.$quantity.')');
                                     if(isset($holdLocations['update']))
-                                        foreach($holdLocations['update'] as $update=>$quantity) array_push($held, '<a href="'.App\Models\Character\CharacterDesignUpdate::find($update)->url.'">Design Update #'.App\Models\Character\CharacterDesignUpdate::find($update)->id.'</a>'.' ('.$quantity.')');
+                                        foreach($holdLocations['update'] as $update=>$quantity) array_push($held, (Auth::user()->hasPower('manage_characters') ? '<a href="'.App\Models\Character\CharacterDesignUpdate::find($update)->url.'">Design Update #'.App\Models\Character\CharacterDesignUpdate::find($update)->id.'</a>' : 'Design Update #'.App\Models\Character\CharacterDesignUpdate::find($update)->id).' ('.$quantity.')');
                                     if(isset($holdLocations['submission']))
-                                        foreach($holdLocations['submission'] as $submission=>$quantity) array_push($held, '<a href="'.App\Models\Submission\Submission::find($submission)->viewUrl.'">Submission #'.App\Models\Submission\Submission::find($submission)->id.'</a>'.' ('.$quantity.')');
+                                        foreach($holdLocations['submission'] as $submission=>$quantity) array_push($held, (Auth::user()->hasPower('manage_submissions') ? '<a href="'.App\Models\Submission\Submission::find($submission)->viewUrl.'">Submission #'.App\Models\Submission\Submission::find($submission)->id.'</a>' : 'Submission #'.App\Models\Submission\Submission::find($submission)->id).' ('.$quantity.')');
                                     $heldString = implode(', ',$held);
                                 ?>
                                 <li>

--- a/resources/views/admin/grants/item_search.blade.php
+++ b/resources/views/admin/grants/item_search.blade.php
@@ -19,7 +19,6 @@
     </div>
 </div>
 {!! Form::close() !!}
-</div>
 
 @if($item)
     <h3>{{ $item->name }}</h3>

--- a/resources/views/admin/grants/item_search.blade.php
+++ b/resources/views/admin/grants/item_search.blade.php
@@ -7,6 +7,8 @@
 
 <h1>Item Search</h1>
 
+<p>Select an item to search for all occurrences of it in user and character inventories. It will only display currently extant stacks (where the count is more than zero). If a stack is currently "held" in a trade, design update, or submission, this will be stated and all held locations will be linked.</p>
+
 {!! Form::open(['method' => 'GET', 'class' => '']) !!}
 <div class="form-inline justify-content-end">
     <div class="form-group ml-3 mb-3">
@@ -22,7 +24,7 @@
 @if($item)
     <h3>{{ $item->name }}</h3>
 
-    There are currently {{ $userItems->pluck('count')->sum()+$characterItems->pluck('count')->sum() }} of this item owned by users and characters.
+    <p>There are currently {{ $userItems->pluck('count')->sum()+$characterItems->pluck('count')->sum() }} of this item owned by users and characters.</p>
 
     <ul>
         @foreach($users as $user)

--- a/resources/views/admin/items/items.blade.php
+++ b/resources/views/admin/items/items.blade.php
@@ -10,6 +10,9 @@
 <p>This is a list of items in the game. Specific details about items can be added when they are granted to users (e.g. reason for grant). By default, items are merely collectibles and any additional functionality must be manually processed, or custom coded in for the specific item.</p>
 
 <div class="text-right mb-3">
+    @if(Auth::user()->hasPower('edit_inventories'))
+        <a class="btn btn-primary" href="{{ url('admin/grants/item-search') }}"><i class="fas fa-search"></i> Item Search</a>
+    @endif
     <a class="btn btn-primary" href="{{ url('admin/data/item-categories') }}"><i class="fas fa-folder"></i> Item Categories</a>
     <a class="btn btn-primary" href="{{ url('admin/data/items/create') }}"><i class="fas fa-plus"></i> Create New Item</a>
 </div>

--- a/resources/views/home/account_search.blade.php
+++ b/resources/views/home/account_search.blade.php
@@ -19,7 +19,6 @@
     </div>
 </div>
 {!! Form::close() !!}
-</div>
 
 @if($item)
     <h3>{{ $item->name }}</h3>

--- a/resources/views/home/account_search.blade.php
+++ b/resources/views/home/account_search.blade.php
@@ -1,0 +1,96 @@
+@extends('home.layout')
+
+@section('home-title') Account Search @endsection
+
+@section('home-content')
+{!! breadcrumbs(['Inventory' => 'inventory', 'Account Search' => 'account-search']) !!}
+
+<h1>Account Search</h1>
+
+<p>Select an item to search for all occurrences of it in your and your characters' inventories. If a stack is currently "held" in a trade, design update, or submission, this will be stated and all held locations will be linked.</p>
+
+{!! Form::open(['method' => 'GET', 'class' => '']) !!}
+<div class="form-inline justify-content-end">
+    <div class="form-group ml-3 mb-3">
+        {!! Form::select('item_id', $items, Request::get('item_id'), ['class' => 'form-control selectize', 'placeholder' => 'Select an Item', 'style' => 'width: 25em; max-width: 100%;']) !!}
+    </div>
+    <div class="form-group ml-3 mb-3">
+        {!! Form::submit('Search', ['class' => 'btn btn-primary']) !!}
+    </div>
+</div>
+{!! Form::close() !!}
+</div>
+
+@if($item)
+    <h3>{{ $item->name }}</h3>
+
+    <p>You currently have {{ $userItems->pluck('count')->sum()+$characterItems->pluck('count')->sum() }} of this item between your and your characters' inventories.</p>
+
+    @if($userItems->count())
+        <h5>Your Inventory:</h5>
+        <ul>
+            @foreach($userItems as $item)
+                <li>
+                    A stack of {{ $item->count }}
+                    @if($item->count > $item->availableQuantity)
+                    ({{ $item->availableQuantity }} Available {{ $item->getOthers() }})
+                        <ul>
+                            <?php
+                                $tradesSent = $trades->where('sender_id', Auth::user()->id);
+                                $tradesReceived = $trades->where('recipient_id', Auth::user()->id);
+
+                                // Collect hold location IDs and quantities
+                                $holdLocations = [];
+                                if(isset($item->trade_count) && $item->trade_count > 0) {
+                                    foreach($tradesSent as $trade)
+                                        if(isset($trade->data['sender']) && $trade->data['sender'] != [] && isset($trade->data['sender']['user_items']) && isset($trade->data['sender']['user_items'][$item->id])) $holdLocations['trade'][$trade->id] = $trade->data['sender']['user_items'][$item->id];
+                                    foreach($tradesReceived as $trade)
+                                        if(isset($trade->data['recipient']) && $trade->data['recipient'] != [] && isset($trade->data['recipient']['user_items']) && isset($trade->data['recipient']['user_items'][$item->id])) $holdLocations['trade'][$trade->id] = $trade->data['recipient']['user_items'][$item->id];
+                                }
+                                if(isset($item->update_count) && $item->update_count > 0)
+                                    foreach($designUpdates as $update)
+                                        if($update->data['user'] != [] && isset($update->data['user']['user_items']) && isset($update->data['user']['user_items'][$item->id])) $holdLocations['update'][$update->id] = $update->data['user']['user_items'][$item->id];
+                                if(isset($item->submission_count) && $item->submission_count > 0)
+                                    foreach($submissions as $submission)
+                                        if($submission->data['user'] != [] && isset($submission->data['user']['user_items']) && isset($submission->data['user']['user_items'][$item->id])) $holdLocations['submission'][$submission->id] = $submission->data['user']['user_items'][$item->id];
+
+                                // Format a string with all the places a stack is held
+                                $held = [];
+                                if(isset($holdLocations['trade']))
+                                    foreach($holdLocations['trade'] as $trade=>$quantity) array_push($held, '<a href="'.App\Models\Trade::find($trade)->url.'">Trade #'.App\Models\Trade::find($trade)->id.'</a>'.' ('.$quantity.')');
+                                if(isset($holdLocations['update']))
+                                    foreach($holdLocations['update'] as $update=>$quantity) array_push($held, '<a href="'.App\Models\Character\CharacterDesignUpdate::find($update)->url.'">Design Update #'.App\Models\Character\CharacterDesignUpdate::find($update)->id.'</a>'.' ('.$quantity.')');
+                                if(isset($holdLocations['submission']))
+                                    foreach($holdLocations['submission'] as $submission=>$quantity) array_push($held, '<a href="'.App\Models\Submission\Submission::find($submission)->viewUrl.'">Submission #'.App\Models\Submission\Submission::find($submission)->id.'</a>'.' ('.$quantity.')');
+                            ?>
+                            @foreach($held as $location)
+                                <li>
+                                    {!! $location !!}
+                                </li>
+                            @endforeach
+                        </ul>
+                    @endif
+                </li>
+            @endforeach
+        </ul>
+    @endif
+    @if($characterItems->count())
+        <h5>Character Inventories:</h5>
+        <ul>
+            @foreach($characterItems as $item)
+                <li>
+                    <a href="{{ $item->character->url }}">{{ $item->character->fullName }}</a> has a stack of {{ $item->count }}
+                </li>
+            @endforeach
+        </ul>
+    @endif
+@endif
+
+<script>
+    $(document).ready(function() {
+        $('.selectize').selectize();
+    });
+
+</script>
+
+@endsection

--- a/resources/views/home/account_search.blade.php
+++ b/resources/views/home/account_search.blade.php
@@ -27,7 +27,7 @@
     <p>You currently have {{ $userItems->pluck('count')->sum()+$characterItems->pluck('count')->sum() }} of this item between your and your characters' inventories.</p>
 
     @if($userItems->count())
-        <h5>Your Inventory:</h5>
+        <h5>In Your Inventory:</h5>
         <ul>
             @foreach($userItems as $item)
                 <li>
@@ -75,7 +75,7 @@
         </ul>
     @endif
     @if($characterItems->count())
-        <h5>Character Inventories:</h5>
+        <h5>In Character Inventories:</h5>
         <ul>
             @foreach($characterItems as $item)
                 <li>

--- a/resources/views/home/inventory.blade.php
+++ b/resources/views/home/inventory.blade.php
@@ -7,9 +7,13 @@
 
 <h1>
     Inventory
+    <div class="float-right mb-3">
+        <a class="btn btn-primary" href="{{ url('inventory/account-search') }}"><i class="fas fa-search"></i> Account Search</a>
+    </div>
 </h1>
 
 <p>This is your inventory. Click on an item to view more details and actions you can perform on it.</p>
+
 @foreach($items as $categoryId=>$categoryItems)
     <div class="card mb-3 inventory-category">
         <h5 class="card-header inventory-header">

--- a/routes/lorekeeper/admin.php
+++ b/routes/lorekeeper/admin.php
@@ -84,7 +84,7 @@ Route::group(['prefix' => 'data', 'namespace' => 'Data', 'middleware' => 'power:
     Route::post('galleries/edit/{id?}', 'GalleryController@postCreateEditGallery');
     Route::post('galleries/delete/{id}', 'GalleryController@postDeleteGallery');
     Route::post('galleries/sort', 'GalleryController@postSortGallery');
-    
+
     # CURRENCIES
     Route::get('currencies', 'CurrencyController@getIndex');
     Route::get('currencies/sort', 'CurrencyController@getSort');
@@ -278,7 +278,10 @@ Route::group(['prefix' => 'grants', 'namespace' => 'Users', 'middleware' => 'pow
 
     Route::get('items', 'GrantController@getItems');
     Route::post('items', 'GrantController@postItems');
+
+    Route::get('item-search', 'GrantController@getItemSearch');
 });
+
 
 # MASTERLIST
 Route::group(['prefix' => 'masterlist', 'namespace' => 'Characters', 'middleware' => 'power:manage_characters'], function() {

--- a/routes/lorekeeper/members.php
+++ b/routes/lorekeeper/members.php
@@ -39,6 +39,7 @@ Route::group(['prefix' => 'account', 'namespace' => 'Users'], function() {
 Route::group(['prefix' => 'inventory', 'namespace' => 'Users'], function() {
     Route::get('/', 'InventoryController@getIndex');
     Route::post('edit', 'InventoryController@postEdit');
+    Route::get('account-search', 'InventoryController@getAccountSearch');
 
     Route::get('selector', 'InventoryController@getSelector');
 });
@@ -120,7 +121,7 @@ Route::group(['prefix' => 'gallery'], function() {
     Route::post('edit/{id}', 'GalleryController@postCreateEditGallerySubmission');
 
     Route::post('collaborator/{id}', 'GalleryController@postEditCollaborator');
-    
+
     Route::get('archive/{id}', 'GalleryController@getArchiveSubmission');
     Route::post('archive/{id}', 'GalleryController@postArchiveSubmission');
 });
@@ -179,9 +180,9 @@ Route::group(['prefix' => 'shops'], function() {
     Route::get('history', 'ShopController@getPurchaseHistory');
 });
 
-/**************************************************************************************************	
+/**************************************************************************************************
     Comments
-**************************************************************************************************/	
+**************************************************************************************************/
 Route::group(['prefix' => 'comments', 'namespace' => 'Comments'], function() {
     Route::post('/', 'CommentController@store')->name('comments.store');
     Route::delete('/{comment}', 'CommentController@destroy')->name('comments.destroy');


### PR DESCRIPTION
Add a feature to search for stacks of a given item within user and character inventories. This takes two forms:

- Admin-facing item search, accessible from admin/data/items
- User-facing account search, accessible from /inventory
- Both versions allow the viewer to select an item and search for all stacks of it. 
- The admin-facing version searches all on-site users and characters. 
- It then displays, for each user and character that have one or more of the item, the total number the user/character has. It also shows, for each stack where at least part of it is "held" somewhere (trade/design update/submission), information about where each item in the stack is held. 
- This includes linking to the individual trade, design update, or submission in which the item is currently held. 
- The user facing version does similarly, except it is restricted to the logged-in user's inventory and characters. Each individual stack is shown instead, as well as relevant information about hold counts and locations; in general, the user-facing account isn't quite as compacted as the admin-facing version is since there will generally be less information to display.

This one's a little on the experimental side despite being relatively small/constrained, haha.

Tested locally/live - No further actions required