### PR TITLE
Hotfix to prevent 500 error when trying to view myo slots as non-admin

### DIFF
--- a/app/Http/Controllers/Users/UserController.php
+++ b/app/Http/Controllers/Users/UserController.php
@@ -147,12 +147,12 @@ class UserController extends Controller
      */
     public function getUserMyoSlots($name)
     {
-        $myo = $this->user->myoSlots()->get();
+        $myo = $this->user->myoSlots();
         if(!Auth::check() || !(Auth::check() && Auth::user()->hasPower('manage_characters'))) $myo->visible();
 
         return view('user.myo_slots', [
             'user' => $this->user,
-            'myos' => $myo,
+            'myos' => $myo->get(),
             'sublists' => Sublist::orderBy('sort', 'DESC')->get()
         ]);
     }


### PR DESCRIPTION
removed get() from first line, putting it into the variable area since otherwise laravel does not recognise it as a scope