### PR TITLE
Character Items Bugfix

### DIFF
--- a/app/Services/ItemService.php
+++ b/app/Services/ItemService.php
@@ -41,8 +41,6 @@ class ItemService extends Service
 
             $data = $this->populateCategoryData($data);
 
-            isset($data['character_limit']) && $data['character_limit'] ? $data['character_limit'] : $data['character_limit'] = 0;
-
             $image = null;
             if(isset($data['image']) && $data['image']) {
                 $data['has_image'] = 1;
@@ -80,8 +78,6 @@ class ItemService extends Service
 
             $data = $this->populateCategoryData($data, $category);
 
-            isset($data['character_limit']) && $data['character_limit'] ? $data['character_limit'] : $data['character_limit'] = 0;
-
             $image = null;
             if(isset($data['image']) && $data['image']) {
                 $data['has_image'] = 1;
@@ -110,6 +106,9 @@ class ItemService extends Service
     private function populateCategoryData($data, $category = null)
     {
         if(isset($data['description']) && $data['description']) $data['parsed_description'] = parse($data['description']);
+
+        isset($data['is_character_owned']) && $data['is_character_owned'] ? $data['is_character_owned'] : $data['is_character_owned'] = 0;
+        isset($data['character_limit']) && $data['character_limit'] ? $data['character_limit'] : $data['character_limit'] = 0;
 
         if(isset($data['remove_image']))
         {


### PR DESCRIPTION
- Consolidates  character limit into `populateCategoryData` as it was duplicated in two different functions that use `populateCategoryData`
- Fixes inability to disable category character ownership (use case: accidental enabling)
--- Thoughts: Should this handle currently character-owned items?

Tbh I am not sure on the usage of the tertiary and the standalone variable? But it was how it was before so I left it and used the same method for character ownership.