### PR TITLE
Toggleable - Group Traits by Category on Character Profiles

### DIFF
--- a/config/lorekeeper/extensions.php
+++ b/config/lorekeeper/extensions.php
@@ -8,10 +8,10 @@ return [
     |--------------------------------------------------------------------------
     |
     | This enables/disables a selection of extensions which provide QoL and are
-    | broadly applicable, but perhaps not universally, and which are contained 
+    | broadly applicable, but perhaps not universally, and which are contained
     | in scope enough to be readily opt-in.
     |
-    | Extensions with a single value for their setting are enabled/disabled via it 
+    | Extensions with a single value for their setting are enabled/disabled via it
     | and have no additional configuration necessary here. 0 = disabled, 1 = enabled.
     | All of the extensions here are disabled by default.
     |
@@ -27,7 +27,7 @@ return [
 
     // Character Status Badges - Juni
     'character_status_badges' => 0,
-    
+
     // Character TH Profile Link - Juni
     'character_TH_profile_link' => 0,
 
@@ -38,6 +38,9 @@ return [
     'item_entry_expansion' => [
         'extra_fields' => 0,
         'resale_function' => 0,
-    ]
+    ],
+
+    // Group Traits By Category - Uri
+    'traits_by_category' => 0,
 
 ];

--- a/resources/views/character/_image_info.blade.php
+++ b/resources/views/character/_image_info.blade.php
@@ -48,16 +48,38 @@
 
                 <div class="mb-3">
                     <div><h5>Traits</h5></div>
-                    <div>
-                        <?php $features = $image->features()->with('feature.category')->get(); ?>
-                        @if($features->count())
-                            @foreach($features as $feature)
-                                <div>@if($feature->feature->feature_category_id) <strong>{!! $feature->feature->category->displayName !!}:</strong> @endif {!! $feature->feature->displayName !!} @if($feature->data) ({{ $feature->data }}) @endif</div>
-                            @endforeach
-                        @else
-                            <div>No traits listed.</div>
-                        @endif
-                    </div>
+                    @if(Config::get('lorekeeper.extensions.traits_by_category'))
+                        <div>
+                            @php $traitgroup = $image->features()->get()->groupBy('feature_category_id') @endphp
+                            @if($image->features()->count())
+                                @foreach($traitgroup as $key => $group)
+                                <div class="mb-2">
+                                    @if($key)
+                                        <strong>{!! $group->first()->feature->category->displayName !!}:</strong>
+                                    @else
+                                        <strong>Miscellaneous:</strong>
+                                    @endif
+                                    @foreach($group as $feature)
+                                        <div class="ml-md-2">{!! $feature->feature->displayName !!} @if($feature->data) ({{ $feature->data }}) @endif</div>
+                                    @endforeach
+                                </div>
+                                @endforeach
+                            @else
+                                <div>No traits listed.</div>
+                            @endif
+                        </div>
+                    @else
+                        <div>
+                            <?php $features = $image->features()->with('feature.category')->get(); ?>
+                            @if($features->count())
+                                @foreach($features as $feature)
+                                    <div>@if($feature->feature->feature_category_id) <strong>{!! $feature->feature->category->displayName !!}:</strong> @endif {!! $feature->feature->displayName !!} @if($feature->data) ({{ $feature->data }}) @endif</div>
+                                @endforeach
+                            @else
+                                <div>No traits listed.</div>
+                            @endif
+                        </div>
+                    @endif
                 </div>
                 <div>
                     <strong>Uploaded:</strong> {!! pretty_date($image->created_at) !!}

--- a/resources/views/pages/credits.blade.php
+++ b/resources/views/pages/credits.blade.php
@@ -12,75 +12,79 @@
 
 <hr>
 
-<h4 class="mb-0">Extensions</h4>
+<h4 class="mb-0">Core Extensions</h4>
 <p class="mb-2">These extensions were coded by the Lorekeeper community, and are now a part of core Lorekeeper.</p>
-<div class="extensions">
-    <p class="mb-0">
+<div class="extensions row no-gutters">
+    <p class="mb-0 col-md-4">
         <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:Stacked_Inventories"><strong>Stacked Inventories</strong></a> by <a href="https://github.com/Draginraptor">Draginraptor</a>
     </p>
-    <p class="mb-0">
+    <p class="mb-0 col-md-4">
         <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:Submission_Addons"><strong>Submission Addons</strong></a> by <a href="https://github.com/itinerare">itinerare</a>
     </p>
-    <p class="mb-0">
+    <p class="mb-0 col-md-4">
         <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:Character_Items"><strong>Character Items</strong></a> by <a href="https://github.com/itinerare">itinerare</a>
     </p>
-    <p class="mb-0">
+    <p class="mb-0 col-md-4">
         <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:Bootstrap_Tables"><strong>Bootstrap Tables</strong></a> by <a href="https://github.com/preimpression">Preimpression</a>
     </p>
-    <p class="mb-0">
+    <p class="mb-0 col-md-4">
         <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:Watermarking"><strong>Watermarking</strong></a> by <a href="https://github.com/itinerare">itinerare</a>
     </p>
-    <p class="mb-0">
+    <p class="mb-0 col-md-4">
         <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:Separate_Prompts"><strong>Separate Prompts</strong></a> by <a href="https://github.com/itinerare">itinerare</a>
     </p>
-    <p class="mb-0">
+    <p class="mb-0 col-md-4">
         <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:Comments"><strong>Comments</strong></a> by <a href="https://github.com/preimpression">Preimpression</a> & <a href="https://github.com/Ne-wt">Ne-wt</a>
     </p>
-    <p class="mb-0">
+    <p class="mb-0 col-md-4">
         <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:Reports"><strong>Reports</strong></a> by <a href="https://github.com/Ne-wt">Ne-wt</a>
     </p>
-    <p class="mb-0">
+    <p class="mb-0 col-md-4">
         <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:Masterlist_Sublists"><strong>Masterlist Sublists</strong></a> by <a href="https://github.com/junijwi">Junijwi</a>
     </p>
-    <p class="mb-0">
+    <p class="mb-0 col-md-4">
         <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:MYO_Item_Tag"><strong>MYO Item Tag</strong></a> by <a href="https://github.com/junijwi">Junijwi</a>
     </p>
-    <p class="mb-0">
+    <p class="mb-0 col-md-4">
         <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:User_Transfer_Reasons"><strong>User Transfer Reasons</strong></a> by <a href="https://github.com/snupsplus">Snupsplus</a>
     </p>
-    <p class="mb-0">
+    <p class="mb-0 col-md-4">
         <strong>Extension Tracker</strong> by <a href="https://github.com/preimpression">Preimpression</a> (This page/the section below!)
     </p>
-    <p class="mb-0">
+    <p class="mb-0 col-md-4">
         <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:Galleries"><strong>Galleries</strong></a> by <a href="https://github.com/itinerare">itinerare</a>
     </p>
-    <p class="mb-0">
+    <p class="mb-0 col-md-4">
         <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:Navbar_News_Notif"><strong>Navbar News Notif</strong></a> by <a href="https://github.com/junijwi">Junijwi</a> ({{ Config::get('lorekeeper.extensions.navbar_news_notif') ? 'Enabled' : 'Disabled' }})
     </p>
-    <p class="mb-0">
+    <p class="mb-0 col-md-4">
         <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:Species_Trait_Index"><strong>Species Trait Index</strong></a> by <a href="https://github.com/itinerare">itinerare</a> ({{ Config::get('lorekeeper.extensions.species_trait_index') ? 'Enabled' : 'Disabled' }})
     </p>
-    <p class="mb-0">
+    <p class="mb-0 col-md-4">
         <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:Character_Status_Badges"><strong>Character Status Badges</strong></a> by <a href="https://github.com/junijwi">Junijwi</a> ({{ Config::get('lorekeeper.extensions.character_status_badges') ? 'Enabled' : 'Disabled' }})
     </p>
-    <p class="mb-0">
+    <p class="mb-0 col-md-4">
         <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:Character_TH_Profile_Link"><strong>Character TH Profile Link</strong></a> by <a href="https://github.com/junijwi">Junijwi</a> ({{ Config::get('lorekeeper.extensions.character_TH_profile_link') ? 'Enabled' : 'Disabled' }})
     </p>
-    <p class="mb-0">
+    <p class="mb-0 col-md-4">
         <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:Design_Update_Voting"><strong>Design Update Voting</strong></a> by <a href="https://github.com/itinerare">itinerare</a> ({{ Config::get('lorekeeper.extensions.design_update_voting') ? 'Enabled' : 'Disabled' }})
     </p>
-    <p class="mb-0">
+    <p class="mb-0 col-md-4">
         <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:Item_Entry_Expansion"><strong>Item Entry Expansion</strong></a> by <a href="https://github.com/itinerare">itinerare</a> ({{ Config::get('lorekeeper.extensions.item_entry_expansion.extra_fields') ? 'Enabled' : 'Disabled' }}/{{ Config::get('lorekeeper.extensions.item_entry_expansion.resale_function') ? 'Enabled' : 'Disabled' }})
+    </p>
+    <p class="mb-0 col-md-4">
+        <strong>Group Traits by Category</strong> by <a href="https://github.com/preimpression">Preimpression</a> ({{ Config::get('lorekeeper.extensions.traits_by_category') ? 'Enabled' : 'Disabled' }})
     </p>
 </div>
 
 <hr/>
+<h4 class="mb-0">Installed Extensions</h4>
 <p class="mb-2">These extensions have been added to this site.</p>
 
 @if($extensions->count())
-    <div class="extensions">
+    <div class="extensions row no-gutters">
         @foreach($extensions as $extension)
-            <p class="mb-0">
+            <p class="mb-0 col-md-4">
                 <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:{{ $extension->wiki_key }}">
                     <strong>{{ str_replace('_',' ',$extension->wiki_key) }}</strong>
                     <small>v. {{ $extension->version }}</small>


### PR DESCRIPTION
- A config toggle to group traits by category on the Character Profile page (image info.)
- Adjusting Credits page into bootstrap columns
- Also changed "Extensions" and [Nothing] to "Core Extensions" and "Installed Extensions" to help with potential confusion.