### PR TITLE
Adding missing 404 to Permalinks

### DIFF
--- a/app/Http/Controllers/PermalinkController.php
+++ b/app/Http/Controllers/PermalinkController.php
@@ -54,13 +54,4 @@ class PermalinkController extends Controller
             'comment' => $comment,            
         ]);
     }
-
-     /**
-     * returns replies recursively
-     *
-     * @return \Illuminate\Contracts\Support\Renderable
-     */
-     public function replies() {
-        return ' what ';
-    }
 }

--- a/app/Http/Controllers/PermalinkController.php
+++ b/app/Http/Controllers/PermalinkController.php
@@ -25,6 +25,9 @@ class PermalinkController extends Controller
         $comments = Comment::all();
         //$comments = $comments->sortByDesc('created_at');
         $comment = $comments->find($id);
+         
+        if(!$comment) abort(404);
+        if(!$comment->commentable) abort(404);
 
         // Check if the comment can be viewed
         switch($comment->type) {


### PR DESCRIPTION
Permalinks used to throw 500 errors if either the comment didn't exist, or for instance the thing it was commented on was deleted.
Now it just will throw a 404!