### PR TITLE
Changed all name variables to have a maximum of 100 characters, as opposed to 25.

### DIFF
--- a/app/Models/Character/CharacterCategory.php
+++ b/app/Models/Character/CharacterCategory.php
@@ -29,7 +29,7 @@ class CharacterCategory extends Model
      * @var array
      */
     public static $createRules = [
-        'name' => 'required|unique:character_categories|between:3,25',
+        'name' => 'required|unique:character_categories|between:3,100',
         'code' => 'required|unique:character_categories|between:1,25',
         'description' => 'nullable',
         'image' => 'mimes:png',
@@ -41,7 +41,7 @@ class CharacterCategory extends Model
      * @var array
      */
     public static $updateRules = [
-        'name' => 'required|between:3,25',
+        'name' => 'required|between:3,100',
         'code' => 'required|between:1,25',
         'description' => 'nullable',
         'image' => 'mimes:png',

--- a/app/Models/Currency/Currency.php
+++ b/app/Models/Currency/Currency.php
@@ -32,7 +32,7 @@ class Currency extends Model
      * @var array
      */
     public static $createRules = [
-        'name' => 'required|unique:currencies|between:3,25',
+        'name' => 'required|unique:currencies|between:3,100',
         'abbreviation' => 'nullable|unique:currencies|between:1,25',
         'description' => 'nullable',
         'icon' => 'mimes:png',
@@ -45,7 +45,7 @@ class Currency extends Model
      * @var array
      */
     public static $updateRules = [
-        'name' => 'required|between:3,25',
+        'name' => 'required|between:3,100',
         'abbreviation' => 'nullable|between:1,25',
         'description' => 'nullable',
         'icon' => 'mimes:png',

--- a/app/Models/Feature/Feature.php
+++ b/app/Models/Feature/Feature.php
@@ -37,7 +37,7 @@ class Feature extends Model
         'species_id' => 'nullable',
         'subtype_id' => 'nullable',
         'rarity_id' => 'required|exists:rarities,id',
-        'name' => 'required|unique:features|between:3,25',
+        'name' => 'required|unique:features|between:3,100',
         'description' => 'nullable',
         'image' => 'mimes:png',
     ];
@@ -52,7 +52,7 @@ class Feature extends Model
         'species_id' => 'nullable',
         'subtype_id' => 'nullable',
         'rarity_id' => 'required|exists:rarities,id',
-        'name' => 'required|between:3,25',
+        'name' => 'required|between:3,100',
         'description' => 'nullable',
         'image' => 'mimes:png',
     ];

--- a/app/Models/Feature/FeatureCategory.php
+++ b/app/Models/Feature/FeatureCategory.php
@@ -29,7 +29,7 @@ class FeatureCategory extends Model
      * @var array
      */
     public static $createRules = [
-        'name' => 'required|unique:feature_categories|between:3,25',
+        'name' => 'required|unique:feature_categories|between:3,100',
         'description' => 'nullable',
         'image' => 'mimes:png',
     ];
@@ -40,7 +40,7 @@ class FeatureCategory extends Model
      * @var array
      */
     public static $updateRules = [
-        'name' => 'required|between:3,25',
+        'name' => 'required|between:3,100',
         'description' => 'nullable',
         'image' => 'mimes:png',
     ];

--- a/app/Models/Item/ItemCategory.php
+++ b/app/Models/Item/ItemCategory.php
@@ -29,7 +29,7 @@ class ItemCategory extends Model
      * @var array
      */
     public static $createRules = [
-        'name' => 'required|unique:item_categories|between:3,25',
+        'name' => 'required|unique:item_categories|between:3,100',
         'description' => 'nullable',
         'image' => 'mimes:png',
     ];
@@ -40,7 +40,7 @@ class ItemCategory extends Model
      * @var array
      */
     public static $updateRules = [
-        'name' => 'required|between:3,25',
+        'name' => 'required|between:3,100',
         'description' => 'nullable',
         'image' => 'mimes:png',
     ];

--- a/app/Models/News.php
+++ b/app/Models/News.php
@@ -48,7 +48,7 @@ class News extends Model
      * @var array
      */
     public static $createRules = [
-        'title' => 'required|between:3,25',
+        'title' => 'required|between:3,100',
         'text' => 'required',
     ];
     
@@ -58,7 +58,7 @@ class News extends Model
      * @var array
      */
     public static $updateRules = [
-        'title' => 'required|between:3,25',
+        'title' => 'required|between:3,100',
         'text' => 'required',
     ];
 

--- a/app/Models/Prompt/Prompt.php
+++ b/app/Models/Prompt/Prompt.php
@@ -42,7 +42,7 @@ class Prompt extends Model
      */
     public static $createRules = [
         'prompt_category_id' => 'nullable',
-        'name' => 'required|unique:prompts|between:3,25',
+        'name' => 'required|unique:prompts|between:3,100',
         'prefix' => 'nullable|unique:prompts|between:2,10',
         'summary' => 'nullable',
         'description' => 'nullable',
@@ -56,7 +56,7 @@ class Prompt extends Model
      */
     public static $updateRules = [
         'prompt_category_id' => 'nullable',
-        'name' => 'required|between:3,25',
+        'name' => 'required|between:3,100',
         'prefix' => 'nullable|between:2,10',
         'summary' => 'nullable',
         'description' => 'nullable',

--- a/app/Models/Prompt/PromptCategory.php
+++ b/app/Models/Prompt/PromptCategory.php
@@ -29,7 +29,7 @@ class PromptCategory extends Model
      * @var array
      */
     public static $createRules = [
-        'name' => 'required|unique:prompt_categories|between:3,25',
+        'name' => 'required|unique:prompt_categories|between:3,100',
         'description' => 'nullable',
         'image' => 'mimes:png',
     ];
@@ -40,7 +40,7 @@ class PromptCategory extends Model
      * @var array
      */
     public static $updateRules = [
-        'name' => 'required|between:3,25',
+        'name' => 'required|between:3,100',
         'description' => 'nullable',
         'image' => 'mimes:png',
     ];

--- a/app/Models/Rank/Rank.php
+++ b/app/Models/Rank/Rank.php
@@ -31,7 +31,7 @@ class Rank extends Model
      * @var array
      */
     public static $rules = [
-        'name' => 'required|between:3,25',
+        'name' => 'required|between:3,100',
         'description' => 'nullable',
         'color' => 'nullable|regex:/^#?[0-9a-fA-F]{6}$/i',
         'icon' => 'nullable'

--- a/app/Models/Rarity.php
+++ b/app/Models/Rarity.php
@@ -29,7 +29,7 @@ class Rarity extends Model
      * @var array
      */
     public static $createRules = [
-        'name' => 'required|unique:rarities|between:3,25',
+        'name' => 'required|unique:rarities|between:3,100',
         'color' => 'nullable|regex:/^#?[0-9a-fA-F]{6}$/i',
         'description' => 'nullable',
         'image' => 'mimes:png',
@@ -41,7 +41,7 @@ class Rarity extends Model
      * @var array
      */
     public static $updateRules = [
-        'name' => 'required|between:3,25',
+        'name' => 'required|between:3,100',
         'color' => 'nullable|regex:/^#?[0-9a-fA-F]{6}$/i',
         'description' => 'nullable',
         'image' => 'mimes:png',

--- a/app/Models/Sales.php
+++ b/app/Models/Sales.php
@@ -48,7 +48,7 @@ class Sales extends Model
      * @var array
      */
     public static $createRules = [
-        'title' => 'required|between:3,25',
+        'title' => 'required|between:3,100',
         'text' => 'required',
     ];
     
@@ -58,7 +58,7 @@ class Sales extends Model
      * @var array
      */
     public static $updateRules = [
-        'title' => 'required|between:3,25',
+        'title' => 'required|between:3,100',
         'text' => 'required',
     ];
 

--- a/app/Models/Shop/Shop.php
+++ b/app/Models/Shop/Shop.php
@@ -29,7 +29,7 @@ class Shop extends Model
      * @var array
      */
     public static $createRules = [
-        'name' => 'required|unique:item_categories|between:3,25',
+        'name' => 'required|unique:item_categories|between:3,100',
         'description' => 'nullable',
         'image' => 'mimes:png',
     ];
@@ -40,7 +40,7 @@ class Shop extends Model
      * @var array
      */
     public static $updateRules = [
-        'name' => 'required|between:3,25',
+        'name' => 'required|between:3,100',
         'description' => 'nullable',
         'image' => 'mimes:png',
     ];

--- a/app/Models/SitePage.php
+++ b/app/Models/SitePage.php
@@ -41,7 +41,7 @@ class SitePage extends Model
      */
     public static $createRules = [
         'key' => 'required|unique:site_pages|between:3,25|alpha_dash',
-        'title' => 'required|between:3,25',
+        'title' => 'required|between:3,100',
         'text' => 'nullable',
     ];
     
@@ -52,7 +52,7 @@ class SitePage extends Model
      */
     public static $updateRules = [
         'key' => 'required|between:3,25|alpha_dash',
-        'title' => 'required|between:3,25',
+        'title' => 'required|between:3,100',
         'text' => 'nullable',
     ];
 

--- a/app/Models/Species/Species.php
+++ b/app/Models/Species/Species.php
@@ -30,7 +30,7 @@ class Species extends Model
      * @var array
      */
     public static $createRules = [
-        'name' => 'required|unique:specieses|between:3,25',
+        'name' => 'required|unique:specieses|between:3,100',
         'description' => 'nullable',
         'image' => 'mimes:png',
     ];
@@ -42,7 +42,7 @@ class Species extends Model
      * @var array
      */
     public static $updateRules = [
-        'name' => 'required|between:3,25',
+        'name' => 'required|between:3,100',
         'description' => 'nullable',
         'image' => 'mimes:png',
     ];

--- a/app/Models/Species/Subtype.php
+++ b/app/Models/Species/Subtype.php
@@ -31,7 +31,7 @@ class Subtype extends Model
      */
     public static $createRules = [
         'species_id' => 'required',
-        'name' => 'required|between:3,25',
+        'name' => 'required|between:3,100',
         'description' => 'nullable',
         'image' => 'mimes:png',
     ];
@@ -44,7 +44,7 @@ class Subtype extends Model
      */
     public static $updateRules = [
         'species_id' => 'required',
-        'name' => 'required|between:3,25',
+        'name' => 'required|between:3,100',
         'description' => 'nullable',
         'image' => 'mimes:png',
     ];


### PR DESCRIPTION
A lot of names for pages, posts, prompts.. all of them had a character limit of 25. I have changed this to 100, where possible. Every single changed variable has been checked if the database supported it, and they have.

Altered are:
- News Post names
- Sales Post names
- Prompt names
- Prompt Category names
- Page names
- Rank names
- Species names
- Species Subtype names
- Shop names
- Rarity names
- Item Category names
- Features names (Note: These are traits)
- Feature Category names
- Currency names
- Character Category names

I have not altered the limits for abbreviations, keys, prefixes and the like, as 25 characters seems like a good maximum for short hand of the full name.
Item name limit has also not been changed as this was already at 100 characters.

The database for all of these allowed up to 191 characters, but I figured quadrupling the character amount should be more than plenty.