### PR TITLE
Character Reward Expansion

### DIFF
--- a/app/Helpers/AssetHelpers.php
+++ b/app/Helpers/AssetHelpers.php
@@ -293,6 +293,7 @@ function fillCharacterAssets($assets, $sender, $recipient, $logType, $data, $sub
     if(!Config::get('lorekeeper.extensions.character_reward_expansion.default_recipient') && $recipient->user) $item_recipient = $recipient->user;
     else $item_recipient = $submitter;
 
+
     // Roll on any loot tables
     if(isset($assets['loot_tables']))
     {
@@ -309,13 +310,14 @@ function fillCharacterAssets($assets, $sender, $recipient, $logType, $data, $sub
         {
             $service = new \App\Services\CurrencyManager;
             foreach($contents as $asset)
-                if(!$service->creditCurrency($sender, $recipient, $logType, $data['data'], $asset['asset'], $asset['quantity'])) return false;
+                if(!$service->creditCurrency($sender, ( $asset['asset']->is_character_owned ? $recipient : $item_recipient), $logType, $data['data'], $asset['asset'], $asset['quantity'])) return false;
         }
         elseif($key == 'items' && count($contents))
         {
             $service = new \App\Services\InventoryManager;
-            if(!$service->creditItem($sender, ( ($asset['asset']->category && $asset['asset']->category->is_character_owned) ? $recipient : $item_recipient), $logType, $data, $asset['asset'], $asset['quantity'])) return false;
+            foreach($contents as $asset)
+                if(!$service->creditItem($sender, ( ($asset['asset']->category && $asset['asset']->category->is_character_owned) ? $recipient : $item_recipient), $logType, $data, $asset['asset'], $asset['quantity'])) return false;
         }
     }
-    return true;
+    return $assets;
 }

--- a/app/Helpers/AssetHelpers.php
+++ b/app/Helpers/AssetHelpers.php
@@ -26,10 +26,10 @@ function calculateGroupCurrency($data)
 
     // You'll need the names of the form fields you specified both in the form config and above.
     // You can get a particular field's value with $data['form_name'], for instance, $data['art_finish']
-    
+
     // This differentiates how values are calculated depending on the type of content being submitted.
     $pieceType = collect($data['piece_type'])->flip();
-    
+
     // For instance, if the user selected that the submission has a visual art component,
     // these actions will be performed:
     if($pieceType->has('art')) {
@@ -37,7 +37,7 @@ function calculateGroupCurrency($data)
         $total += ($data['art_finish'] + $data['art_type']);
         // This multiplies each option selected in the "bonus" form field by
         // the result from the "art type" field, and adds it to the total.
-        if(isset($data['art_bonus'])) foreach($data['art_bonus'] as $bonus) $total += (round($bonus) * $data['art_type']);        
+        if(isset($data['art_bonus'])) foreach($data['art_bonus'] as $bonus) $total += (round($bonus) * $data['art_type']);
     }
 
     // Likewise for if the user selected that the submission has a written component:
@@ -60,7 +60,7 @@ function calculateGroupCurrency($data)
 
 /**
  * Gets the asset keys for an array depending on whether the
- * assets being managed are owned by a user or character. 
+ * assets being managed are owned by a user or character.
  *
  * @param  bool  $isCharacter
  * @return array
@@ -68,12 +68,12 @@ function calculateGroupCurrency($data)
 function getAssetKeys($isCharacter = false)
 {
     if(!$isCharacter) return ['items', 'currencies', 'raffle_tickets', 'loot_tables', 'user_items', 'characters'];
-    else return ['currencies'];
+    else return ['currencies', 'items', 'character_items', 'loot_tables'];
 }
 
 /**
  * Gets the model name for an asset type.
- * The asset type has to correspond to one of the asset keys above. 
+ * The asset type has to correspond to one of the asset keys above.
  *
  * @param  string  $type
  * @param  bool    $namespaced
@@ -87,12 +87,12 @@ function getAssetModelString($type, $namespaced = true)
             if($namespaced) return '\App\Models\Item\Item';
             else return 'Item';
             break;
-        
+
         case 'currencies':
             if($namespaced) return '\App\Models\Currency\Currency';
             else return 'Currency';
             break;
-            
+
         case 'raffle_tickets':
             if($namespaced) return '\App\Models\Raffle\Raffle';
             else return 'Raffle';
@@ -102,15 +102,20 @@ function getAssetModelString($type, $namespaced = true)
             if($namespaced) return '\App\Models\Loot\LootTable';
             else return 'LootTable';
             break;
-            
+
         case 'user_items':
             if($namespaced) return '\App\Models\User\UserItem';
             else return 'UserItem';
             break;
-            
+
         case 'characters':
             if($namespaced) return '\App\Models\Character\Character';
             else return 'Character';
+            break;
+
+        case 'character_items':
+            if($namespaced) return '\App\Models\Character\CharacterItem';
+            else return 'CharacterItem';
             break;
     }
     return null;
@@ -283,8 +288,21 @@ function fillUserAssets($assets, $sender, $recipient, $logType, $data)
  * @param  string                           $data
  * @return array
  */
-function fillCharacterAssets($assets, $sender, $recipient, $logType, $data)
+function fillCharacterAssets($assets, $sender, $recipient, $logType, $data, $submitter = null)
 {
+    if(!Config::get('lorekeeper.extensions.character_reward_expansion.default_recipient') && $recipient->user) $item_recipient = $recipient->user;
+    else $item_recipient = $submitter;
+
+    // Roll on any loot tables
+    if(isset($assets['loot_tables']))
+    {
+        foreach($assets['loot_tables'] as $table)
+        {
+            $assets = mergeAssetsArrays($assets, $table['asset']->roll($table['quantity']));
+        }
+        unset($assets['loot_tables']);
+    }
+
     foreach($assets as $key => $contents)
     {
         if($key == 'currencies' && count($contents))
@@ -292,6 +310,11 @@ function fillCharacterAssets($assets, $sender, $recipient, $logType, $data)
             $service = new \App\Services\CurrencyManager;
             foreach($contents as $asset)
                 if(!$service->creditCurrency($sender, $recipient, $logType, $data['data'], $asset['asset'], $asset['quantity'])) return false;
+        }
+        elseif($key == 'items' && count($contents))
+        {
+            $service = new \App\Services\InventoryManager;
+            if(!$service->creditItem($sender, ( ($asset['asset']->category && $asset['asset']->category->is_character_owned) ? $recipient : $item_recipient), $logType, $data, $asset['asset'], $asset['quantity'])) return false;
         }
     }
     return true;

--- a/app/Http/Controllers/Admin/SubmissionController.php
+++ b/app/Http/Controllers/Admin/SubmissionController.php
@@ -30,11 +30,11 @@ class SubmissionController extends Controller
     {
         $submissions = Submission::with('prompt')->where('status', $status ? ucfirst($status) : 'Pending')->whereNotNull('prompt_id');
         $data = $request->only(['prompt_category_id', 'sort']);
-        if(isset($data['prompt_category_id']) && $data['prompt_category_id'] != 'none') 
+        if(isset($data['prompt_category_id']) && $data['prompt_category_id'] != 'none')
             $submissions->whereHas('prompt', function($query) use ($data) {
                 $query->where('prompt_category_id', $data['prompt_category_id']);
             });
-        if(isset($data['sort'])) 
+        if(isset($data['sort']))
         {
             switch($data['sort']) {
                 case 'newest':
@@ -44,7 +44,7 @@ class SubmissionController extends Controller
                     $submissions->sortOldest();
                     break;
             }
-        } 
+        }
         else $submissions->sortOldest();
         return view('admin.submissions.index', [
             'submissions' => $submissions->paginate(30)->appends($request->query()),
@@ -52,7 +52,7 @@ class SubmissionController extends Controller
             'isClaims' => false
         ]);
     }
-    
+
     /**
      * Shows the submission detail page.
      *
@@ -70,6 +70,7 @@ class SubmissionController extends Controller
             'rewardsData' => isset($submission->data['rewards']) ? parseAssetData($submission->data['rewards']) : null,
             'itemsrow' => Item::all()->keyBy('id'),
             'page' => 'submission',
+            'expanded_rewards' => Config::get('lorekeeper.extensions.character_reward_expansion.expanded'),
         ] + ($submission->status == 'Pending' ? [
             'characterCurrencies' => Currency::where('is_character_owned', 1)->orderBy('sort_character', 'DESC')->pluck('name', 'id'),
             'items' => Item::orderBy('name')->pluck('name', 'id'),
@@ -78,8 +79,8 @@ class SubmissionController extends Controller
             'raffles' => Raffle::where('rolled_at', null)->where('is_active', 1)->orderBy('name')->pluck('name', 'id'),
             'count' => Submission::where('prompt_id', $submission->prompt_id)->where('status', 'Approved')->where('user_id', $submission->user_id)->count()
         ] : []));
-    }    
-    
+    }
+
     /**
      * Shows the claim index page.
      *
@@ -90,7 +91,7 @@ class SubmissionController extends Controller
     {
         $submissions = Submission::where('status', $status ? ucfirst($status) : 'Pending')->whereNull('prompt_id');
         $data = $request->only(['sort']);
-        if(isset($data['sort'])) 
+        if(isset($data['sort']))
         {
             switch($data['sort']) {
                 case 'newest':
@@ -100,14 +101,14 @@ class SubmissionController extends Controller
                     $submissions->sortOldest();
                     break;
             }
-        } 
+        }
         else $submissions->sortOldest();
         return view('admin.submissions.index', [
             'submissions' => $submissions->paginate(30),
             'isClaims' => true
         ]);
     }
-    
+
     /**
      * Shows the claim detail page.
      *
@@ -123,6 +124,7 @@ class SubmissionController extends Controller
             'submission' => $submission,
             'inventory' => $inventory,
             'itemsrow' => Item::all()->keyBy('id'),
+            'expanded_rewards' => Config::get('lorekeeper.extensions.character_reward_expansion.expanded'),
         ] + ($submission->status == 'Pending' ? [
             'characterCurrencies' => Currency::where('is_character_owned', 1)->orderBy('sort_character', 'DESC')->pluck('name', 'id'),
             'items' => Item::orderBy('name')->pluck('name', 'id'),
@@ -145,7 +147,7 @@ class SubmissionController extends Controller
      */
     public function postSubmission(Request $request, SubmissionManager $service, $id, $action)
     {
-        $data = $request->only(['slug',  'character_quantity', 'character_currency_id', 'rewardable_type', 'rewardable_id', 'quantity', 'staff_comments' ]);
+        $data = $request->only(['slug',  'character_rewardable_quantity', 'character_rewardable_id',  'character_rewardable_type', 'character_currency_id', 'rewardable_type', 'rewardable_id', 'quantity', 'staff_comments' ]);
         if($action == 'reject' && $service->rejectSubmission($request->only(['staff_comments']) + ['id' => $id], Auth::user())) {
             flash('Submission rejected successfully.')->success();
         }

--- a/app/Http/Controllers/Users/SubmissionController.php
+++ b/app/Http/Controllers/Users/SubmissionController.php
@@ -92,7 +92,7 @@ class SubmissionController extends Controller
         $inventory = UserItem::with('item')->whereNull('deleted_at')->where('count', '>', '0')->where('user_id', Auth::user()->id)->get();
         return view('home.create_submission', [
             'closed' => $closed,
-            'isClaim' => false
+            'isClaim' => false,
         ] + ($closed ? [] : [
             'submission' => new Submission,
             'prompts' => Prompt::active()->sortAlphabetical()->pluck('name', 'id')->toArray(),
@@ -103,7 +103,8 @@ class SubmissionController extends Controller
             'character_items' => Item::whereIn('item_category_id', ItemCategory::where('is_character_owned',1)->pluck('id')->toArray() )->orderBy('name')->released()->pluck('name', 'id'),
             'currencies' => Currency::where('is_user_owned', 1)->orderBy('name')->pluck('name', 'id'),
             'inventory' => $inventory,
-            'page' => 'submission'
+            'page' => 'submission',
+            'expanded_rewards' => Config::get('lorekeeper.extensions.character_reward_expansion.expanded')
         ]));
     }
 
@@ -135,8 +136,7 @@ class SubmissionController extends Controller
 
         return view('home._prompt', [
             'prompt' => $prompt,
-            'count' => Submission::where('prompt_id', $id)->where('status', 'Approved')->where('user_id', Auth::user()->id)->count(),
-            'expanded_rewards' => Config::get('lorekeeper.extensions.character_reward_expansion.expanded')
+            'count' => Submission::where('prompt_id', $id)->where('status', 'Approved')->where('user_id', Auth::user()->id)->count()
         ]);
     }
 

--- a/app/Http/Controllers/Users/SubmissionController.php
+++ b/app/Http/Controllers/Users/SubmissionController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 
 use DB;
 use Auth;
+use Config;
 use Settings;
 use App\Models\User\User;
 use App\Models\User\UserItem;
@@ -99,6 +100,7 @@ class SubmissionController extends Controller
             'categories' => ItemCategory::orderBy('sort', 'DESC')->get(),
             'item_filter' => Item::orderBy('name')->released()->get()->keyBy('id'),
             'items' => Item::orderBy('name')->released()->pluck('name', 'id'),
+            'character_items' => Item::whereIn('item_category_id', ItemCategory::where('is_character_owned',1)->pluck('id')->toArray() )->orderBy('name')->released()->pluck('name', 'id'),
             'currencies' => Currency::where('is_user_owned', 1)->orderBy('name')->pluck('name', 'id'),
             'inventory' => $inventory,
             'page' => 'submission'
@@ -133,7 +135,8 @@ class SubmissionController extends Controller
 
         return view('home._prompt', [
             'prompt' => $prompt,
-            'count' => Submission::where('prompt_id', $id)->where('status', 'Approved')->where('user_id', Auth::user()->id)->count()
+            'count' => Submission::where('prompt_id', $id)->where('status', 'Approved')->where('user_id', Auth::user()->id)->count(),
+            'expanded_rewards' => Config::get('lorekeeper.extensions.character_reward_expansion.expanded')
         ]);
     }
 
@@ -147,7 +150,7 @@ class SubmissionController extends Controller
     public function postNewSubmission(Request $request, SubmissionManager $service)
     {
         $request->validate(Submission::$createRules);
-        if($service->createSubmission($request->only(['url', 'prompt_id', 'comments', 'slug', 'character_quantity', 'character_currency_id', 'rewardable_type', 'rewardable_id', 'quantity', 'stack_id', 'stack_quantity', 'currency_id', 'currency_quantity']), Auth::user())) {
+        if($service->createSubmission($request->only(['url', 'prompt_id', 'comments', 'slug', 'character_rewardable_type', 'character_rewardable_id', 'character_rewardable_quantity', 'rewardable_type', 'rewardable_id', 'quantity', 'stack_id', 'stack_quantity', 'currency_id', 'currency_quantity']), Auth::user())) {
             flash('Prompt submitted successfully.')->success();
         }
         else {
@@ -214,7 +217,7 @@ class SubmissionController extends Controller
         $inventory = UserItem::with('item')->whereNull('deleted_at')->where('count', '>', '0')->where('user_id', Auth::user()->id)->get();
         return view('home.create_submission', [
             'closed' => $closed,
-            'isClaim' => true
+            'isClaim' => true,
         ] + ($closed ? [] : [
             'submission' => new Submission,
             'characterCurrencies' => Currency::where('is_character_owned', 1)->orderBy('sort_character', 'DESC')->pluck('name', 'id'),
@@ -224,7 +227,8 @@ class SubmissionController extends Controller
             'items' => Item::orderBy('name')->released()->pluck('name', 'id'),
             'currencies' => Currency::where('is_user_owned', 1)->orderBy('name')->pluck('name', 'id'),
             'raffles' => Raffle::where('rolled_at', null)->where('is_active', 1)->orderBy('name')->pluck('name', 'id'),
-            'page' => 'submission'
+            'page' => 'submission',
+            'expanded_rewards' => Config::get('lorekeeper.extensions.character_reward_expansion.expanded')
         ]));
     }
 
@@ -238,7 +242,7 @@ class SubmissionController extends Controller
     public function postNewClaim(Request $request, SubmissionManager $service)
     {
         $request->validate(Submission::$createRules);
-        if($service->createSubmission($request->only(['url', 'comments', 'stack_id', 'stack_quantity', 'slug', 'character_quantity', 'character_currency_id', 'rewardable_type', 'rewardable_id', 'quantity', 'currency_id', 'currency_quantity']), Auth::user(), true)) {
+        if($service->createSubmission($request->only(['url', 'comments', 'stack_id', 'stack_quantity', 'slug', 'character_rewardable_type', 'character_rewardable_id', 'character_rewardable_quantity', 'rewardable_type','rewardable_id', 'quantity', 'currency_id', 'currency_quantity']), Auth::user(), true)) {
             flash('Claim submitted successfully.')->success();
         }
         else {

--- a/app/Models/Submission/SubmissionCharacter.php
+++ b/app/Models/Submission/SubmissionCharacter.php
@@ -26,33 +26,33 @@ class SubmissionCharacter extends Model
     protected $table = 'submission_characters';
 
     /**********************************************************************************************
-    
+
         RELATIONS
 
     **********************************************************************************************/
-    
+
     /**
      * Get the submission this is attached to.
      */
-    public function submission() 
+    public function submission()
     {
         return $this->belongsTo('App\Models\Submission\Submission', 'submission_id');
     }
-    
+
     /**
      * Get the character being attached to the submission.
      */
-    public function character() 
+    public function character()
     {
         return $this->belongsTo('App\Models\Character\Character', 'character_id');
     }
 
     /**********************************************************************************************
-    
+
         ACCESSORS
 
     **********************************************************************************************/
-    
+
     /**
      * Get the data attribute as an associative array.
      *

--- a/app/Services/SubmissionManager.php
+++ b/app/Services/SubmissionManager.php
@@ -380,7 +380,7 @@ class SubmissionManager extends Service
                 // Users might not pass in clean arrays (may contain redundant data) so we need to clean that up
                 $assets = $this->processRewards($data + ['character_id' => $c->id, 'currencies' => $currencies], true);
 
-                if(!fillCharacterAssets($assets, $user, $c, $promptLogType, $promptData)) throw new \Exception("Failed to distribute rewards to character.");
+                if(!fillCharacterAssets($assets, $user, $c, $promptLogType, $promptData, $submission->user)) throw new \Exception("Failed to distribute rewards to character.");
 
                 SubmissionCharacter::create([
                     'character_id' => $c->id,

--- a/app/Services/SubmissionManager.php
+++ b/app/Services/SubmissionManager.php
@@ -46,6 +46,7 @@ class SubmissionManager extends Service
         DB::beginTransaction();
 
         try {
+
             // 1. check that the prompt can be submitted at this time
             // 2. check that the characters selected exist (are visible too)
             // 3. check that the currencies selected can be attached to characters
@@ -126,6 +127,10 @@ class SubmissionManager extends Service
                     ]) // list of rewards and addons
             ] + ($isClaim ? [] : ['prompt_id' => $prompt->id,]));
 
+            // $clearNull = function($value, $key){
+            //     return array_filter
+            // };
+
             // Retrieve all currency IDs for characters
             $currencyIds = [];
             if(isset($data['character_currency_id'])) {
@@ -133,6 +138,14 @@ class SubmissionManager extends Service
                 {
                     foreach($c as $currencyId) $currencyIds[] = $currencyId;
                 }
+            }
+            elseif(isset($data['character_rewardable_type']))
+            {
+                dd('line 144 of SubmissionManager');
+                // foreach($data['character_rewardable_type'] as $key => $type)
+                // {
+                //     if()
+                // }
             }
             array_unique($currencyIds);
             $currencies = Currency::whereIn('id', $currencyIds)->where('is_character_owned', 1)->get()->keyBy('id');
@@ -172,11 +185,14 @@ class SubmissionManager extends Service
         if($isCharacter)
         {
             $assets = createAssetsArray(true);
-            if(isset($data['character_currency_id'][$data['character_id']]) && isset($data['character_quantity'][$data['character_id']]))
+
+            if(isset($data['character_rewardable_type'][$data['character_id']]) && isset($data['character_rewardable_id'][$data['character_id']]) && isset($data['character_rewardable_quantity'][$data['character_id']]))
             {
-                foreach($data['character_currency_id'][$data['character_id']] as $key => $currency)
+                $ids = array_values(array_filter($data['character_rewardable_id'][$data['character_id']]));
+                dd($assets, $data, $ids);
+                foreach($data['character_rewardable_type'][$data['character_id']] as $key => $type)
                 {
-                    if($data['character_quantity'][$data['character_id']][$key]) addAsset($assets, $data['currencies'][$currency], $data['character_quantity'][$data['character_id']][$key]);
+                    if($data['character_rewardable_quantity'][$data['character_id']][$key]) addAsset($assets, $data['currencies'][$currency], $data['character_quantity'][$data['character_id']][$key]);
                 }
             }
             return $assets;

--- a/config/lorekeeper/extensions.php
+++ b/config/lorekeeper/extensions.php
@@ -43,4 +43,10 @@ return [
     // Group Traits By Category - Uri
     'traits_by_category' => 0,
 
+    // Character Reward Expansion - Uri
+    'character_reward_expansion' => [
+        'expanded' => 1,
+        'default_recipient' => 0, // 0 to default to the character's owner (if a user), 1 to default to the submission user.
+    ],
+
 ];

--- a/resources/views/admin/submissions/submission.blade.php
+++ b/resources/views/admin/submissions/submission.blade.php
@@ -5,7 +5,7 @@
 @section('home-content')
 @if($submission->prompt_id)
     {!! breadcrumbs(['Admin Panel' => 'admin', 'Prompt Queue' => 'admin/submissions/pending', 'Submission (#' . $submission->id . ')' => $submission->viewUrl]) !!}
-@else 
+@else
     {!! breadcrumbs(['Admin Panel' => 'admin', 'Claim Queue' => 'admin/claims/pending', 'Claim (#' . $submission->id . ')' => $submission->viewUrl]) !!}
 @endif
 
@@ -66,7 +66,7 @@
         <h2>Characters</h2>
         <div id="characters" class="mb-3">
             @foreach($submission->characters as $character)
-                @include('widgets._character_select_entry', ['characterCurrencies' => $characterCurrencies, 'character' => $character])
+                @include('widgets._character_select_entry', ['characterCurrencies' => $characterCurrencies, 'items' => $items, 'tables' => $tables, 'character' => $character, 'expanded_rewards' => $expanded_rewards])
             @endforeach
         </div>
         <div class="text-right mb-3">
@@ -152,7 +152,12 @@
                             <table class="table table-sm">
                                 <thead>
                                     <tr>
+                                        @if($expanded_rewards)
+                                        <th width="35%">Reward Type</th>
+                                        <th width="35%">Reward</th>
+                                        @else
                                         <th width="70%">Reward</th>
+                                        @endif
                                         <th width="30%">Amount</th>
                                     </tr>
                                 </thead>
@@ -169,11 +174,25 @@
         </div>
         <table>
             <tr class="character-reward-row">
-                <td>
-                    {!! Form::select('character_currency_id[]', $characterCurrencies, 0, ['class' => 'form-control currency-id']) !!}
-                </td>
+
+                    @if($expanded_rewards)
+                    <td>
+                        {!! Form::select('character_rewardable_type[]', ['Item' => 'Item', 'Currency' => 'Currency', 'LootTable' => 'Loot Table'], null, ['class' => 'form-control character-rewardable-type', 'placeholder' => 'Select Reward Type']) !!}
+                    </td>
+                    <td class="lootDivs">
+                        <div class="character-currencies hide">{!! Form::select('character_rewardable_id[]', $characterCurrencies, 0, ['class' => 'form-control character-currency-id', 'placeholder' => 'Select Currency']) !!}</div>
+                        <div class="character-items hide">{!! Form::select('character_rewardable_id[]', $items, 0, ['class' => 'form-control character-item-id', 'placeholder' => 'Select Item']) !!}</div>
+                        <div class="character-tables hide">{!! Form::select('character_rewardable_id[]', $tables, 0, ['class' => 'form-control character-table-id', 'placeholder' => 'Select Loot Table']) !!}</div>
+                    </td>
+                    @else
+                        <td class="lootDivs">
+                            {!! Form::hidden('character_rewardable_type[]', 'Currency', ['class' => 'character-rewardable-type']) !!}
+                            {!! Form::select('character_rewardable_id[]', $characterCurrencies, 0, ['class' => 'form-control character-currency-id', 'placeholder' => 'Select Currency']) !!}
+                        </td>
+                    @endif
+
                 <td class="d-flex align-items-center">
-                    {!! Form::text('character_quantity[]', 0, ['class' => 'form-control mr-2 quantity']) !!}
+                    {!! Form::text('character_quantity[]', 0, ['class' => 'form-control mr-2  character-rewardable-quantity']) !!}
                     <a href="#" class="remove-reward d-block"><i class="fas fa-times text-muted"></i></a>
                 </td>
             </tr>
@@ -217,13 +236,13 @@
 @endsection
 
 @section('scripts')
-@parent 
+@parent
 @if($submission->status == 'Pending')
     @include('js._loot_js', ['showLootTables' => true, 'showRaffles' => true])
     @include('js._character_select_js')
 
     <script>
-        
+
         $(document).ready(function() {
             var $confirmationModal = $('#confirmationModal');
             var $submissionForm = $('#submissionForm');
@@ -235,14 +254,14 @@
             var $rejectionButton = $('#rejectionButton');
             var $rejectionContent = $('#rejectionContent');
             var $rejectionSubmit = $('#rejectionSubmit');
-            
+
             $approvalButton.on('click', function(e) {
                 e.preventDefault();
                 $approvalContent.removeClass('hide');
                 $rejectionContent.addClass('hide');
                 $confirmationModal.modal('show');
             });
-            
+
             $rejectionButton.on('click', function(e) {
                 e.preventDefault();
                 $rejectionContent.removeClass('hide');

--- a/resources/views/home/_submission_content.blade.php
+++ b/resources/views/home/_submission_content.blade.php
@@ -79,14 +79,33 @@
                             </tr>
                         </thead>
                         <tbody>
-                            @foreach(parseAssetData($character->data) as $type)
+                            @foreach(parseAssetData($character->data) as $key => $type)
+
                                 @foreach($type as $asset)
                                     <tr>
-                                        <td>{!! $asset['asset']->displayName !!}</td>
+                                        <td>{!! $asset['asset']->displayName !!} ({!! ucfirst($key) !!})</td>
                                         <td>{{ $asset['quantity'] }}</td>
                                     </tr>
                                 @endforeach
                             @endforeach
+
+                            {{--
+
+                            If you want to "Categorize" the rewards by type, uncomment this and comment or remove the above @foreach.
+
+                            @foreach(parseAssetData($character->data) as $key => $type)
+                                @if(count($type))
+                                <tr><td colspan="2"><strong>{!! strtoupper($key) !!}</strong></td></tr>
+                                    @foreach($type as $asset)
+                                        <tr>
+                                            <td>{!! $asset['asset']->displayName !!}</td>
+                                            <td>{{ $asset['quantity'] }}</td>
+                                        </tr>
+                                    @endforeach
+                                @endif
+                            @endforeach
+
+                            --}}
                         </tbody>
                     </table>
                     </div>

--- a/resources/views/home/create_submission.blade.php
+++ b/resources/views/home/create_submission.blade.php
@@ -80,7 +80,7 @@
         </div>
     {!! Form::close() !!}
 
-    @include('widgets._character_select', ['characterCurrencies' => $characterCurrencies])
+    @include('widgets._character_select', ['characterCurrencies' => $characterCurrencies, 'showLootTables' => false])
     @if($isClaim)
         @include('widgets._loot_select_row', ['items' => $items, 'currencies' => $currencies, 'showLootTables' => false, 'showRaffles' => true])
     @else

--- a/resources/views/js/_character_select_js.blade copy.php
+++ b/resources/views/js/_character_select_js.blade copy.php
@@ -42,43 +42,67 @@
                 });
                 updateRewardNames($clone, node.find('.character-info').data('id'));
                 $(this).parent().parent().find('.character-rewards').append($clone);
-                attachRewardTypeListener(node.find('.character-rewardable-type'));
             });
         }
 
+
+        $('.character-rewardable-type').on('change', function(e) {
+                console.log('hello');
+            var val = $(this).val();
+            var $cell = $(this).parent().find('.character-loot-row-select');
+                console.log($cell);
+
+            var $clone = null;
+            if(val == 'Item') $clone = $itemSelect.clone();
+            else if (val == 'Currency') $clone = $currencySelect.clone();
+            @if(isset($showLootTables) && $showLootTables)
+                else if (val == 'LootTable') $clone = $tableSelect.clone();
+            @endif
+
+            $cell.html('');
+            $cell.append($clone);
+        });
+
         function attachRewardTypeListener(node) {
             node.on('change', function(e) {
+                console.log($(this));
+                console.log('hello');
                 var val = $(this).val();
-                var $cell = $(this).parent().parent().find('.lootDivs');
+                var $cell = $(this).parent().parent().find('.character-loot-row-select');
 
-                $cell.children().addClass('hide');
-                $cell.children().children().val(null);
-
-                if(val == 'Item') {
-                    $cell.children('.character-items').addClass('show');
-                    $cell.children('.character-items').removeClass('hide');
-                    $cell.children('.character-items');
-                }
-                else if (val == 'Currency'){
-                    $cell.children('.character-currencies').addClass('show');
-                    $cell.children('.character-currencies').removeClass('hide');
-                }
+                var $clone = null;
+                if(val == 'Item') $clone = $itemSelect.clone();
+                else if (val == 'Currency') $clone = $currencySelect.clone();
                 @if(isset($showLootTables) && $showLootTables)
-                    else if (val == 'LootTable'){
-                        $cell.children('.character-tables').addClass('show');
-                        $cell.children('.character-tables').addClass('show');
-                        $cell.children('.character-tables').removeClass('hide');
-                    }
+                    else if (val == 'LootTable') $clone = $tableSelect.clone();
                 @endif
+
+                $cell.html('');
+                $cell.append($clone);
+                $clone.selectize();
             });
+        }
+
+        function updateOptions() {
+            if(flat) $('#flatOptions').removeClass('hide');
+            else $('#flatOptions').addClass('hide');
+
+            if(range) $('#rangeOptions').removeClass('hide');
+            else $('#rangeOptions').addClass('hide');
+
+            if(min) $('#minOptions').removeClass('hide');
+            else $('#minOptions').addClass('hide');
+
+            if(rate) $('#rateOptions').removeClass('hide');
+            else $('#rateOptions').addClass('hide');
         }
 
         function updateRewardNames(node, id) {
             node.find('.character-rewardable-type').attr('name', 'character_rewardable_type[' + id + '][]');
             node.find('.character-rewardable-quantity').attr('name', 'character_rewardable_quantity[' + id + '][]');
-            node.find('.character-currency-id').attr('name', 'character_rewardable_id[' + id + '][]');
-            node.find('.character-item-id').attr('name', 'character_rewardable_id[' + id + '][]');
-            node.find('.character-table-id').attr('name', 'character_rewardable_id[' + id + '][]');
+            node.find('.character-currency-id').attr('name', 'character_currency_id[' + id + '][]');
+            node.find('.character-item-id').attr('name', 'character_item_id[' + id + '][]');
+            node.find('.character-table-id').attr('name', 'character_table_id[' + id + '][]');
         }
 
     });

--- a/resources/views/js/_character_select_js.blade.php
+++ b/resources/views/js/_character_select_js.blade.php
@@ -44,6 +44,7 @@
                 $(this).parent().parent().find('.character-rewards').append($clone);
                 attachRewardTypeListener(node.find('.character-rewardable-type'));
             });
+            attachRewardTypeListener(node.find('.character-rewardable-type'));
         }
 
         function attachRewardTypeListener(node) {
@@ -63,13 +64,11 @@
                     $cell.children('.character-currencies').addClass('show');
                     $cell.children('.character-currencies').removeClass('hide');
                 }
-                @if(isset($showLootTables) && $showLootTables)
-                    else if (val == 'LootTable'){
-                        $cell.children('.character-tables').addClass('show');
-                        $cell.children('.character-tables').addClass('show');
-                        $cell.children('.character-tables').removeClass('hide');
-                    }
-                @endif
+                else if (val == 'LootTable'){
+                    $cell.children('.character-tables').addClass('show');
+                    $cell.children('.character-tables').addClass('show');
+                    $cell.children('.character-tables').removeClass('hide');
+                }
             });
         }
 

--- a/resources/views/pages/credits.blade.php
+++ b/resources/views/pages/credits.blade.php
@@ -75,6 +75,9 @@
     <p class="mb-0 col-md-4">
         <strong>Group Traits by Category</strong> by <a href="https://github.com/preimpression">Preimpression</a> ({{ Config::get('lorekeeper.extensions.traits_by_category') ? 'Enabled' : 'Disabled' }})
     </p>
+    <p class="mb-0 col-md-4">
+        <strong>Character Rewards</strong> by <a href="https://github.com/preimpression">Preimpression</a> ({{ Config::get('lorekeeper.extensions.character_reward_expansion.expanded') ? 'Enabled' : 'Disabled' }}/{{ Config::get('lorekeeper.extensions.character_reward_expansion.default_recipient') ? 'Submitter' : 'Character Owner' }})
+    </p>
 </div>
 
 <hr/>

--- a/resources/views/widgets/_character_select.blade.php
+++ b/resources/views/widgets/_character_select.blade.php
@@ -21,10 +21,10 @@
                             <thead>
                                 <tr>
                                     @if($expanded_rewards)
-                                    <th width="35%">Reward Type</th>
-                                    <th width="35%">Reward</th>
+                                        <th width="35%">Reward Type</th>
+                                        <th width="35%">Reward</th>
                                     @else
-                                    <th width="70%">Reward</th>
+                                        <th width="70%">Reward</th>
                                     @endif
                                     <th width="30%">Amount</th>
                                 </tr>
@@ -42,18 +42,22 @@
     </div>
     <table>
         <tr class="character-reward-row">
-            <td>
-                @if($expanded_rewards)
+
+            @if($expanded_rewards)
+                <td>
                     {!! Form::select('character_rewardable_type[]', ['Item' => 'Item', 'Currency' => 'Currency'] + (isset($showLootTables) && $showLootTables ? ['LootTable' => 'Loot Table'] : []), null, ['class' => 'form-control character-rewardable-type', 'placeholder' => 'Select Reward Type']) !!}
-                @else
+                </td>
+                <td class="lootDivs">
+                    <div class="character-currencies hide">{!! Form::select('character_currency_id[]', $characterCurrencies, 0, ['class' => 'form-control character-currency-id', 'placeholder' => 'Select Currency']) !!}</div>
+                    <div class="character-items hide">{!! Form::select('character_item_id[]', $items, 0, ['class' => 'form-control character-item-id', 'placeholder' => 'Select Item']) !!}</div>
+                    @if(isset($showLootTables) && $showLootTables) <div class="character-loots hide">{!! Form::select('character_rewardable_id[]', $tables, 0, ['class' => 'form-control character-rtable-id', 'placeholder' => 'Select Loot Table']) !!}</div> @endif
+                </td>
+            @else
+                <td class="lootDivs">
                     {!! Form::hidden('character_rewardable_type[]', 'Currency', ['class' => 'character-rewardable-type']) !!}
-                @endif
-            </td>
-            <td class="lootDivs">
-                <div class="character-currencies hide">{!! Form::select('character_currency_id[]', $characterCurrencies, 0, ['class' => 'form-control character-currency-id', 'placeholder' => 'Select Currency']) !!}</div>
-                <div class="character-items hide">{!! Form::select('character_item_id[]', $items, 0, ['class' => 'form-control character-item-id', 'placeholder' => 'Select Item']) !!}</div>
-                @if(isset($showLootTables) && $showLootTables) <div class="character-loots hide">{!! Form::select('character_rewardable_id[]', $tables, 0, ['class' => 'form-control character-rtable-id', 'placeholder' => 'Select Loot Table']) !!}</div> @endif
-            </td>
+                    <div class="character-currencies">{!! Form::select('character_currency_id[]', $characterCurrencies, 0, ['class' => 'form-control character-currency-id', 'placeholder' => 'Select Currency']) !!}</div>
+                </td>
+            @endif
 
             <td class="d-flex align-items-center">
                 {!! Form::text('character_quantity[]', 0, ['class' => 'form-control mr-2  character-rewardable-quantity']) !!}

--- a/resources/views/widgets/_character_select.blade.php
+++ b/resources/views/widgets/_character_select.blade.php
@@ -20,7 +20,12 @@
                         <table class="table table-sm">
                             <thead>
                                 <tr>
+                                    @if($expanded_rewards)
+                                    <th width="35%">Reward Type</th>
+                                    <th width="35%">Reward</th>
+                                    @else
                                     <th width="70%">Reward</th>
+                                    @endif
                                     <th width="30%">Amount</th>
                                 </tr>
                             </thead>
@@ -38,10 +43,20 @@
     <table>
         <tr class="character-reward-row">
             <td>
-                {!! Form::select('character_currency_id[]', $characterCurrencies, 0, ['class' => 'form-control currency-id']) !!}
+                @if($expanded_rewards)
+                    {!! Form::select('character_rewardable_type[]', ['Item' => 'Item', 'Currency' => 'Currency'] + (isset($showLootTables) && $showLootTables ? ['LootTable' => 'Loot Table'] : []), null, ['class' => 'form-control character-rewardable-type', 'placeholder' => 'Select Reward Type']) !!}
+                @else
+                    {!! Form::hidden('character_rewardable_type[]', 'Currency', ['class' => 'character-rewardable-type']) !!}
+                @endif
             </td>
+            <td class="lootDivs">
+                <div class="character-currencies hide">{!! Form::select('character_currency_id[]', $characterCurrencies, 0, ['class' => 'form-control character-currency-id', 'placeholder' => 'Select Currency']) !!}</div>
+                <div class="character-items hide">{!! Form::select('character_item_id[]', $items, 0, ['class' => 'form-control character-item-id', 'placeholder' => 'Select Item']) !!}</div>
+                @if(isset($showLootTables) && $showLootTables) <div class="character-loots hide">{!! Form::select('character_rewardable_id[]', $tables, 0, ['class' => 'form-control character-rtable-id', 'placeholder' => 'Select Loot Table']) !!}</div> @endif
+            </td>
+
             <td class="d-flex align-items-center">
-                {!! Form::text('character_quantity[]', 0, ['class' => 'form-control mr-2 quantity']) !!}
+                {!! Form::text('character_quantity[]', 0, ['class' => 'form-control mr-2  character-rewardable-quantity']) !!}
                 <a href="#" class="remove-reward d-block"><i class="fas fa-times text-muted"></i></a>
             </td>
         </tr>

--- a/resources/views/widgets/_character_select_entry.blade.php
+++ b/resources/views/widgets/_character_select_entry.blade.php
@@ -21,23 +21,33 @@
                     <table class="table table-sm">
                         <thead>
                             <tr>
+                                @if($expanded_rewards)
+                                <th width="35%">Reward Type</th>
+                                <th width="35%">Reward</th>
+                                @else
                                 <th width="70%">Reward</th>
+                                @endif
                                 <th width="30%">Amount</th>
                             </tr>
                         </thead>
                         <tbody class="character-rewards">
                             @foreach($character->rewards as $reward)
                                 <tr class="character-reward-row">
-                                    <td>
-                                        @if($expanded_rewards)
-                                            {!! Form::select('character_rewardable_type['.$character->character_id.'][]', ['Item' => 'Item', 'Currency' => 'Currency'] + (isset($showLootTables) && $showLootTables ? ['LootTable' => 'Loot Table'] : []), null, ['class' => 'form-control character-rewardable-type', 'placeholder' => 'Select Reward Type']) !!}
+                                    @if($expanded_rewards)
+                                        <td>
+                                            {!! Form::select('character_rewardable_type['.$character->character_id.'][]', ['Item' => 'Item', 'Currency' => 'Currency', 'LootTable' => 'Loot Table'], $reward->rewardable_type, ['class' => 'form-control character-rewardable-type', 'placeholder' => 'Select Reward Type']) !!}
+                                        </td>
+                                        <td class="lootDivs">
+                                            <div class="character-currencies  {{ $reward->rewardable_type == 'Currency' ? 'show' : 'hide'}}">{!! Form::select('character_rewardable_id['.$character->character_id.'][]', $characterCurrencies, ($reward->rewardable_type == 'Currency' ? $reward->rewardable_id : null) , ['class' => 'form-control character-currency-id', 'placeholder' => 'Select Currency']) !!}</div>
+                                            <div class="character-items  {{ $reward->rewardable_type == 'Item' ? 'show' : 'hide'}}">{!! Form::select('character_rewardable_id['.$character->character_id.'][]', $items, ($reward->rewardable_type == 'Item' ? $reward->rewardable_id : null) , ['class' => 'form-control character-item-id', 'placeholder' => 'Select Item']) !!}</div>
+                                            <div class="character-tables {{ $reward->rewardable_type == 'Loot Table' ? 'show' : 'hide'}}">{!! Form::select('character_rewardable_id['.$character->character_id.'][]', $tables, ($reward->rewardable_type == 'Loot Table' ? $reward->rewardable_id : null) , ['class' => 'form-control character-table-id', 'placeholder' => 'Select Loot Table']) !!}</div>
+                                        </td>
                                         @else
+                                        <td class="lootDivs">
                                             {!! Form::hidden('character_rewardable_type['.$character->character_id.'][]', 'Currency', ['class' => 'character-rewardable-type']) !!}
-                                        @endif
-                                    </td>
-                                    <td class="character-loot-row">
-                                        {!! Form::select('character_rewardable_id['.$character->character_id.'][]', $characterCurrencies, $reward->rewardable_id, ['class' => 'form-control character-rewardable-id', 'placeholder' => 'Select Reward']) !!}
-                                    </td>
+                                            {!! Form::select('character_rewardable_id['.$character->character_id.'][]', $characterCurrencies, ($reward->rewardable_type == 'Currency' ? $reward->rewardable_id : null) , ['class' => 'form-control character-currency-id', 'placeholder' => 'Select Currency']) !!}
+                                        </td>
+                                    @endif
                                     <td class="d-flex align-items-center">
                                         {!! Form::text('character_rewardable_quantity['.$character->character_id.'][]', $reward->quantity, ['class' => 'form-control mr-2 character-rewardable-quantity']) !!}
                                         <a href="#" class="remove-reward d-block"><i class="fas fa-times text-muted"></i></a>

--- a/resources/views/widgets/_character_select_entry.blade.php
+++ b/resources/views/widgets/_character_select_entry.blade.php
@@ -29,10 +29,17 @@
                             @foreach($character->rewards as $reward)
                                 <tr class="character-reward-row">
                                     <td>
-                                        {!! Form::select('character_currency_id['.$character->character_id.'][]', $characterCurrencies, $reward->rewardable_id, ['class' => 'form-control currency-id']) !!}
+                                        @if($expanded_rewards)
+                                            {!! Form::select('character_rewardable_type['.$character->character_id.'][]', ['Item' => 'Item', 'Currency' => 'Currency'] + (isset($showLootTables) && $showLootTables ? ['LootTable' => 'Loot Table'] : []), null, ['class' => 'form-control character-rewardable-type', 'placeholder' => 'Select Reward Type']) !!}
+                                        @else
+                                            {!! Form::hidden('character_rewardable_type['.$character->character_id.'][]', 'Currency', ['class' => 'character-rewardable-type']) !!}
+                                        @endif
+                                    </td>
+                                    <td class="character-loot-row">
+                                        {!! Form::select('character_rewardable_id['.$character->character_id.'][]', $characterCurrencies, $reward->rewardable_id, ['class' => 'form-control character-rewardable-id', 'placeholder' => 'Select Reward']) !!}
                                     </td>
                                     <td class="d-flex align-items-center">
-                                        {!! Form::text('character_quantity['.$character->character_id.'][]', $reward->quantity, ['class' => 'form-control mr-2 quantity']) !!}
+                                        {!! Form::text('character_rewardable_quantity['.$character->character_id.'][]', $reward->quantity, ['class' => 'form-control mr-2 character-rewardable-quantity']) !!}
                                         <a href="#" class="remove-reward d-block"><i class="fas fa-times text-muted"></i></a>
                                     </td>
                                 </tr>
@@ -47,3 +54,4 @@
         </div>
     </div>
 </div>
+


### PR DESCRIPTION
Expands character rewards for submissions and claims.
Left in code for `currency_id` etc in case it is used in extensions etc.

Two config flips: 
- Enable/Disable
- Default non-character-held rewards to owner character/submitter