### PR TITLE
Add item categories, rarity conditions to loot table options

### DIFF
--- a/app/Http/Controllers/Admin/Data/LootTableController.php
+++ b/app/Http/Controllers/Admin/Data/LootTableController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Auth;
 
 use App\Models\Item\Item;
+use App\Models\Item\ItemCategory;
 use App\Models\Currency\Currency;
 use App\Models\Loot\LootTable;
 
@@ -36,7 +37,7 @@ class LootTableController extends Controller
             'tables' => LootTable::paginate(20)
         ]);
     }
-    
+
     /**
      * Shows the create loot table page.
      *
@@ -44,14 +45,19 @@ class LootTableController extends Controller
      */
     public function getCreateLootTable()
     {
+        $rarities = Item::whereNotNull('data')->get()->pluck('rarity')->unique()->toArray();
+        sort($rarities);
+
         return view('admin.loot_tables.create_edit_loot_table', [
             'table' => new LootTable,
             'items' => Item::orderBy('name')->pluck('name', 'id'),
+            'categories' => ItemCategory::orderBy('sort', 'DESC')->pluck('name', 'id'),
             'currencies' => Currency::orderBy('name')->pluck('name', 'id'),
             'tables' => LootTable::orderBy('name')->pluck('name', 'id'),
+            'rarities' => array_filter($rarities),
         ]);
     }
-    
+
     /**
      * Shows the edit loot table page.
      *
@@ -62,11 +68,17 @@ class LootTableController extends Controller
     {
         $table = LootTable::find($id);
         if(!$table) abort(404);
+
+        $rarities = Item::whereNotNull('data')->get()->pluck('rarity')->unique()->toArray();
+        sort($rarities);
+
         return view('admin.loot_tables.create_edit_loot_table', [
             'table' => $table,
             'items' => Item::orderBy('name')->pluck('name', 'id'),
+            'categories' => ItemCategory::orderBy('sort', 'DESC')->pluck('name', 'id'),
             'currencies' => Currency::orderBy('name')->pluck('name', 'id'),
             'tables' => LootTable::orderBy('name')->pluck('name', 'id'),
+            'rarities' => array_filter($rarities),
         ]);
     }
 
@@ -82,7 +94,8 @@ class LootTableController extends Controller
     {
         $id ? $request->validate(LootTable::$updateRules) : $request->validate(LootTable::$createRules);
         $data = $request->only([
-            'name', 'display_name', 'rewardable_type', 'rewardable_id', 'quantity', 'weight'
+            'name', 'display_name', 'rewardable_type', 'rewardable_id', 'quantity', 'weight',
+            'criteria', 'rarity'
         ]);
         if($id && $service->updateLootTable(LootTable::find($id), $data)) {
             flash('Loot table updated successfully.')->success();
@@ -96,7 +109,7 @@ class LootTableController extends Controller
         }
         return redirect()->back();
     }
-    
+
     /**
      * Gets the loot table deletion modal.
      *
@@ -129,7 +142,7 @@ class LootTableController extends Controller
         }
         return redirect()->to('admin/data/loot-tables');
     }
-    
+
     /**
      * Gets the loot table test roll modal.
      *

--- a/app/Models/Loot/Loot.php
+++ b/app/Models/Loot/Loot.php
@@ -13,7 +13,8 @@ class Loot extends Model
      * @var array
      */
     protected $fillable = [
-        'loot_table_id', 'rewardable_type', 'rewardable_id', 'quantity', 'weight'
+        'loot_table_id', 'rewardable_type', 'rewardable_id',
+        'quantity', 'weight', 'data'
     ];
 
     /**
@@ -22,7 +23,7 @@ class Loot extends Model
      * @var string
      */
     protected $table = 'loots';
-    
+
     /**
      * Validation rules for creation.
      *
@@ -34,7 +35,7 @@ class Loot extends Model
         'quantity' => 'required|integer|min:1',
         'weight' => 'required|integer|min:1',
     ];
-    
+
     /**
      * Validation rules for updating.
      *
@@ -48,15 +49,15 @@ class Loot extends Model
     ];
 
     /**********************************************************************************************
-    
+
         RELATIONS
 
     **********************************************************************************************/
-    
+
     /**
      * Get the reward attached to the loot entry.
      */
-    public function reward() 
+    public function reward()
     {
         switch ($this->rewardable_type)
         {
@@ -66,10 +67,31 @@ class Loot extends Model
                 return $this->belongsTo('App\Models\Currency\Currency', 'rewardable_id');
             case 'LootTable':
                 return $this->belongsTo('App\Models\Loot\LootTable', 'rewardable_id');
+            case 'ItemCategory':
+                return $this->belongsTo('App\Models\Item\ItemCategory', 'rewardable_id');
+            case 'ItemCategoryRarity':
+                return $this->belongsTo('App\Models\Item\ItemCategory', 'rewardable_id');
             case 'None':
                 // Laravel requires a relationship instance to be returned (cannot return null), so returning one that doesn't exist here.
                 return $this->belongsTo('App\Models\Loot\Loot', 'rewardable_id', 'loot_table_id')->whereNull('loot_table_id');
         }
         return null;
+    }
+
+    /**********************************************************************************************
+
+        ACCESSORS
+
+    **********************************************************************************************/
+
+    /**
+     * Get the data attribute as an associative array.
+     *
+     * @return array
+     */
+    public function getDataAttribute()
+    {
+        if (!$this->attributes['data']) return null;
+        return json_decode($this->attributes['data'], true);
     }
 }

--- a/app/Models/Loot/Loot.php
+++ b/app/Models/Loot/Loot.php
@@ -63,6 +63,8 @@ class Loot extends Model
         {
             case 'Item':
                 return $this->belongsTo('App\Models\Item\Item', 'rewardable_id');
+            case 'ItemRarity':
+                return $this->belongsTo('App\Models\Item\Item', 'rewardable_id');
             case 'Currency':
                 return $this->belongsTo('App\Models\Currency\Currency', 'rewardable_id');
             case 'LootTable':

--- a/app/Models/Loot/LootTable.php
+++ b/app/Models/Loot/LootTable.php
@@ -3,6 +3,8 @@
 namespace App\Models\Loot;
 
 use Config;
+use App\Models\Item\Item;
+
 use App\Models\Model;
 
 class LootTable extends Model
@@ -22,7 +24,7 @@ class LootTable extends Model
      * @var string
      */
     protected $table = 'loot_tables';
-    
+
     /**
      * Validation rules for creation.
      *
@@ -32,7 +34,7 @@ class LootTable extends Model
         'name' => 'required',
         'display_name' => 'required',
     ];
-    
+
     /**
      * Validation rules for updating.
      *
@@ -44,7 +46,7 @@ class LootTable extends Model
     ];
 
     /**********************************************************************************************
-    
+
         RELATIONS
 
     **********************************************************************************************/
@@ -52,17 +54,17 @@ class LootTable extends Model
     /**
      * Get the loot data for this loot table.
      */
-    public function loot() 
+    public function loot()
     {
         return $this->hasMany('App\Models\Loot\Loot', 'loot_table_id');
     }
 
     /**********************************************************************************************
-    
+
         ACCESSORS
 
     **********************************************************************************************/
-    
+
     /**
      * Displays the model's name, linked to its encyclopedia page.
      *
@@ -84,18 +86,18 @@ class LootTable extends Model
     }
 
     /**********************************************************************************************
-    
+
         OTHER FUNCTIONS
 
     **********************************************************************************************/
-    
+
     /**
      * Rolls on the loot table and consolidates the rewards.
      *
      * @param  int  $quantity
      * @return \Illuminate\Support\Collection
      */
-    public function roll($quantity = 1) 
+    public function roll($quantity = 1)
     {
         $rewards = createAssetsArray();
 
@@ -105,12 +107,12 @@ class LootTable extends Model
 
         for($i = 0; $i < $quantity; $i++)
         {
-            $roll = mt_rand(0, $totalWeight - 1); 
+            $roll = mt_rand(0, $totalWeight - 1);
             $result = null;
             $prev = null;
             $count = 0;
             foreach($loot as $l)
-            { 
+            {
                 $count += $l->weight;
 
                 if($roll < $count)
@@ -125,7 +127,42 @@ class LootTable extends Model
             if($result) {
                 // If this is chained to another loot table, roll on that table
                 if($result->rewardable_type == 'LootTable') $rewards = mergeAssetsArrays($rewards, $result->reward->roll($result->quantity));
+                elseif($result->rewardable_type == 'ItemCategory' || $result->rewardable_type == 'ItemCategoryRarity') $rewards = mergeAssetsArrays($rewards, $this->rollCategory($result->rewardable_id, $result->quantity, (isset($result->data['criteria']) ? $result->data['criteria'] : null), (isset($result->data['rarity']) ? $result->data['rarity'] : null)));
                 else addAsset($rewards, $result->reward, $result->quantity);
+            }
+        }
+        return $rewards;
+    }
+
+    /**
+     * Rolls on an item category.
+     *
+     * @param  int    $id
+     * @param  int    $quantity
+     * @param  string $condition
+     * @param  string $rarity
+     * @return \Illuminate\Support\Collection
+     */
+    public function rollCategory($id, $quantity = 1, $criteria = null, $rarity = null)
+    {
+        $rewards = createAssetsArray();
+
+        if(isset($criteria) && $criteria && isset($rarity) && $rarity) $loot = Item::where('item_category_id', $id)->released()->whereNotNull('data')->whereRaw('JSON_EXTRACT(`data`, \'$.rarity\')'. $criteria . $rarity)->get();
+        else $loot = Item::where('item_category_id', $id)->released()->get();
+        if(!$loot->count()) throw new \Exception('There are no items to select from!');
+
+        $totalWeight = $loot->count();
+
+        for($i = 0; $i < $quantity; $i++)
+        {
+            $roll = mt_rand(0, $totalWeight - 1);
+            $result = null;
+
+            $result = $loot[$roll];
+
+            if($result) {
+                // If this is chained to another loot table, roll on that table
+                addAsset($rewards, $result, 1);
             }
         }
         return $rewards;

--- a/app/Models/Loot/LootTable.php
+++ b/app/Models/Loot/LootTable.php
@@ -148,7 +148,10 @@ class LootTable extends Model
     {
         $rewards = createAssetsArray();
 
-        if(isset($criteria) && $criteria && isset($rarity) && $rarity) $loot = Item::where('item_category_id', $id)->released()->whereNotNull('data')->whereRaw('JSON_EXTRACT(`data`, \'$.rarity\')'. $criteria . $rarity)->get();
+        if(isset($criteria) && $criteria && isset($rarity) && $rarity) {
+            if(Config::get('lorekeeper.extensions.item_entry_expansion.loot_tables.alternate_filtering')) $loot = Item::where('item_category_id', $id)->released()->whereNotNull('data')->where('data->rarity', $criteria, $rarity)->get();
+            else $loot = Item::where('item_category_id', $id)->released()->whereNotNull('data')->whereRaw('JSON_EXTRACT(`data`, \'$.rarity\')'. $criteria . $rarity)->get();
+        }
         else $loot = Item::where('item_category_id', $id)->released()->get();
         if(!$loot->count()) throw new \Exception('There are no items to select from!');
 
@@ -181,7 +184,8 @@ class LootTable extends Model
     {
         $rewards = createAssetsArray();
 
-        $loot = Item::released()->whereNotNull('data')->whereRaw('JSON_EXTRACT(`data`, \'$.rarity\')'. $criteria . $rarity)->get();
+        if(Config::get('lorekeeper.extensions.item_entry_expansion.loot_tables.alternate_filtering')) $loot = Item::released()->whereNotNull('data')->where('data->rarity', $criteria, $rarity)->get();
+        else $loot = Item::released()->whereNotNull('data')->whereRaw('JSON_EXTRACT(`data`, \'$.rarity\')'. $criteria . $rarity)->get();
         if(!$loot->count()) throw new \Exception('There are no items to select from!');
 
         $totalWeight = $loot->count();

--- a/app/Models/Loot/LootTable.php
+++ b/app/Models/Loot/LootTable.php
@@ -160,8 +160,6 @@ class LootTable extends Model
         for($i = 0; $i < $quantity; $i++)
         {
             $roll = mt_rand(0, $totalWeight - 1);
-            $result = null;
-
             $result = $loot[$roll];
 
             if($result) {
@@ -193,8 +191,6 @@ class LootTable extends Model
         for($i = 0; $i < $quantity; $i++)
         {
             $roll = mt_rand(0, $totalWeight - 1);
-            $result = null;
-
             $result = $loot[$roll];
 
             if($result) {

--- a/app/Services/LootService.php
+++ b/app/Services/LootService.php
@@ -37,7 +37,7 @@ class LootService extends Service
             foreach($data['rewardable_type'] as $key => $type)
             {
                 if(!$type) throw new \Exception("Loot type is required.");
-                if(!$data['rewardable_id'][$key]) throw new \Exception("Reward is required.");
+                if($type != 'ItemRarity' && !$data['rewardable_id'][$key]) throw new \Exception("Reward is required.");
                 if(!$data['quantity'][$key] || $data['quantity'][$key] < 1) throw new \Exception("Quantity is required and must be an integer greater than 0.");
                 if(!$data['weight'][$key] || $data['weight'][$key] < 1) throw new \Exception("Weight is required and must be an integer greater than 0.");
                 if($type == 'ItemCategoryRarity') {
@@ -74,7 +74,7 @@ class LootService extends Service
             foreach($data['rewardable_type'] as $key => $type)
             {
                 if(!$type) throw new \Exception("Loot type is required.");
-                if(!$data['rewardable_id'][$key]) throw new \Exception("Reward is required.");
+                if($type != 'ItemRarity' && !$data['rewardable_id'][$key]) throw new \Exception("Reward is required.");
                 if(!$data['quantity'][$key] || $data['quantity'][$key] < 1) throw new \Exception("Quantity is required and must be an integer greater than 0.");
                 if(!$data['weight'][$key] || $data['weight'][$key] < 1) throw new \Exception("Weight is required and must be an integer greater than 0.");
                 if($type == 'ItemCategoryRarity') {
@@ -107,7 +107,7 @@ class LootService extends Service
 
         foreach($data['rewardable_type'] as $key => $type)
         {
-            if($type == 'ItemCategoryRarity')
+            if($type == 'ItemCategoryRarity' || $type == 'ItemRarity')
                 $lootData = [
                     'criteria' => $data['criteria'][$key],
                     'rarity' => $data['rarity'][$key]
@@ -116,7 +116,7 @@ class LootService extends Service
             Loot::create([
                 'loot_table_id'   => $table->id,
                 'rewardable_type' => $type,
-                'rewardable_id'   => $data['rewardable_id'][$key],
+                'rewardable_id'   => isset($data['rewardable_id'][$key]) ? $data['rewardable_id'][$key] : 1,
                 'quantity'        => $data['quantity'][$key],
                 'weight'          => $data['weight'][$key],
                 'data'            => isset($lootData) ? json_encode($lootData) : null

--- a/app/Services/LootService.php
+++ b/app/Services/LootService.php
@@ -32,7 +32,7 @@ class LootService extends Service
         DB::beginTransaction();
 
         try {
-            
+
             // More specific validation
             foreach($data['rewardable_type'] as $key => $type)
             {
@@ -40,14 +40,18 @@ class LootService extends Service
                 if(!$data['rewardable_id'][$key]) throw new \Exception("Reward is required.");
                 if(!$data['quantity'][$key] || $data['quantity'][$key] < 1) throw new \Exception("Quantity is required and must be an integer greater than 0.");
                 if(!$data['weight'][$key] || $data['weight'][$key] < 1) throw new \Exception("Weight is required and must be an integer greater than 0.");
+                if($type == 'ItemCategoryRarity') {
+                    if(!isset($data['criteria'][$key]) || !$data['criteria'][$key]) throw new \Exception("Criteria is required for conditional item categories.");
+                    if(!isset($data['rarity'][$key]) || !$data['rarity'][$key]) throw new \Exception("A rarity is required for conditional item categories.");
+                }
             }
 
             $table = LootTable::create(Arr::only($data, ['name', 'display_name']));
 
-            $this->populateLootTable($table, Arr::only($data, ['rewardable_type', 'rewardable_id', 'quantity', 'weight']));
+            $this->populateLootTable($table, Arr::only($data, ['rewardable_type', 'rewardable_id', 'quantity', 'weight', 'criteria', 'rarity']));
 
             return $this->commitReturn($table);
-        } catch(\Exception $e) { 
+        } catch(\Exception $e) {
             $this->setError('error', $e->getMessage());
         }
         return $this->rollbackReturn(false);
@@ -57,7 +61,7 @@ class LootService extends Service
      * Updates a loot table.
      *
      * @param  \App\Models\Loot\LootTable  $table
-     * @param  array                       $data 
+     * @param  array                       $data
      * @return bool|\App\Models\Loot\LootTable
      */
     public function updateLootTable($table, $data)
@@ -65,7 +69,7 @@ class LootService extends Service
         DB::beginTransaction();
 
         try {
-            
+
             // More specific validation
             foreach($data['rewardable_type'] as $key => $type)
             {
@@ -73,14 +77,18 @@ class LootService extends Service
                 if(!$data['rewardable_id'][$key]) throw new \Exception("Reward is required.");
                 if(!$data['quantity'][$key] || $data['quantity'][$key] < 1) throw new \Exception("Quantity is required and must be an integer greater than 0.");
                 if(!$data['weight'][$key] || $data['weight'][$key] < 1) throw new \Exception("Weight is required and must be an integer greater than 0.");
+                if($type == 'ItemCategoryRarity') {
+                    if(!isset($data['criteria'][$key]) || !$data['criteria'][$key]) throw new \Exception("Criteria is required for conditional item categories.");
+                    if(!isset($data['rarity'][$key]) || !$data['rarity'][$key]) throw new \Exception("A rarity is required for conditional item categories.");
+                }
             }
 
             $table->update(Arr::only($data, ['name', 'display_name']));
 
-            $this->populateLootTable($table, Arr::only($data, ['rewardable_type', 'rewardable_id', 'quantity', 'weight']));
+            $this->populateLootTable($table, Arr::only($data, ['rewardable_type', 'rewardable_id', 'quantity', 'weight', 'criteria', 'rarity']));
 
             return $this->commitReturn($table);
-        } catch(\Exception $e) { 
+        } catch(\Exception $e) {
             $this->setError('error', $e->getMessage());
         }
         return $this->rollbackReturn(false);
@@ -90,7 +98,7 @@ class LootService extends Service
      * Handles the creation of loot for a loot table.
      *
      * @param  \App\Models\Loot\LootTable  $table
-     * @param  array                       $data 
+     * @param  array                       $data
      */
     private function populateLootTable($table, $data)
     {
@@ -99,12 +107,19 @@ class LootService extends Service
 
         foreach($data['rewardable_type'] as $key => $type)
         {
+            if($type == 'ItemCategoryRarity')
+                $lootData = [
+                    'criteria' => $data['criteria'][$key],
+                    'rarity' => $data['rarity'][$key]
+                ];
+
             Loot::create([
                 'loot_table_id'   => $table->id,
                 'rewardable_type' => $type,
                 'rewardable_id'   => $data['rewardable_id'][$key],
                 'quantity'        => $data['quantity'][$key],
-                'weight'          => $data['weight'][$key]
+                'weight'          => $data['weight'][$key],
+                'data'            => isset($lootData) ? json_encode($lootData) : null
             ]);
         }
     }
@@ -124,12 +139,12 @@ class LootService extends Service
             // - Prompts
             // - Box rewards (unfortunately this can't be checked easily)
             if(PromptReward::where('rewardable_type', 'LootTable')->where('rewardable_id', $table->id)->exists()) throw new \Exception("A prompt uses this table to distribute rewards. Please remove it from the rewards list first.");
-            
+
             $table->loot()->delete();
             $table->delete();
 
             return $this->commitReturn(true);
-        } catch(\Exception $e) { 
+        } catch(\Exception $e) {
             $this->setError('error', $e->getMessage());
         }
         return $this->rollbackReturn(false);

--- a/config/lorekeeper/extensions.php
+++ b/config/lorekeeper/extensions.php
@@ -36,7 +36,7 @@ return [
 
     // Item Entry Expansion - Mercury
     'item_entry_expansion' => [
-        'extra_fields' => 0,
+        'extra_fields' => 1,
         'resale_function' => 0,
     ],
 

--- a/config/lorekeeper/extensions.php
+++ b/config/lorekeeper/extensions.php
@@ -38,6 +38,7 @@ return [
     'item_entry_expansion' => [
         'extra_fields' => 1,
         'resale_function' => 0,
+        'loot_tables' => 0, // Adds the ability to use either rarity criteria for items or item categories with rarity criteria in loot tables. Note that disabling this does not apply retroactively.
     ],
 
     // Group Traits By Category - Uri

--- a/config/lorekeeper/extensions.php
+++ b/config/lorekeeper/extensions.php
@@ -38,7 +38,11 @@ return [
     'item_entry_expansion' => [
         'extra_fields' => 1,
         'resale_function' => 0,
-        'loot_tables' => 0, // Adds the ability to use either rarity criteria for items or item categories with rarity criteria in loot tables. Note that disabling this does not apply retroactively.
+        'loot_tables' => [
+            // Adds the ability to use either rarity criteria for items or item categories with rarity criteria in loot tables. Note that disabling this does not apply retroactively.
+            'enable' => 0,
+            'alternate_filtering' => 0 // By default this uses more broadly compatible methods to filter by rarity. If you are on Dreamhost/know your DB software can handle searching in JSON, it's recommended to set this to 1 instead.
+        ],
     ],
 
     // Group Traits By Category - Uri

--- a/database/migrations/2021_03_28_172111_add_item_category_info_to_loots.php
+++ b/database/migrations/2021_03_28_172111_add_item_category_info_to_loots.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddItemCategoryInfoToLoots extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('loots', function (Blueprint $table) {
+            //
+            $table->string('data')->nullable()->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('loots', function (Blueprint $table) {
+            //
+            $table->dropColumn('data');
+        });
+    }
+}

--- a/resources/views/admin/items/create_edit_item.blade.php
+++ b/resources/views/admin/items/create_edit_item.blade.php
@@ -43,7 +43,7 @@
         <div class="col-md">
             <div class="form-group">
                 {!! Form::label('Item Rarity (Optional)') !!} {!! add_help('This should be a number.') !!}
-                {!! Form::text('rarity', $item && $item->rarity ? $item->rarity : '', ['class' => 'form-control']) !!}
+                {!! Form::number('rarity', $item && $item->rarity ? $item->rarity : '', ['class' => 'form-control']) !!}
             </div>
         </div>
     @endif

--- a/resources/views/admin/loot_tables/create_edit_loot_table.blade.php
+++ b/resources/views/admin/loot_tables/create_edit_loot_table.blade.php
@@ -48,19 +48,24 @@
         @if($table->id)
             @foreach($table->loot as $loot)
                 <tr class="loot-row">
-                    <td>{!! Form::select('rewardable_type[]', ['Item' => 'Item', 'Currency' => 'Currency', 'LootTable' => 'Loot Table', 'ItemCategory' => 'Item Category', 'ItemCategoryRarity' => 'Item Category (Conditional)', 'None' => 'None'], $loot->rewardable_type, ['class' => 'form-control reward-type', 'placeholder' => 'Select Reward Type']) !!}</td>
+                    <td>{!! Form::select('rewardable_type[]', ['Item' => 'Item', 'ItemRarity' => 'Item Rarity', 'Currency' => 'Currency', 'LootTable' => 'Loot Table', 'ItemCategory' => 'Item Category', 'ItemCategoryRarity' => 'Item Category (Conditional)', 'None' => 'None'], $loot->rewardable_type, ['class' => 'form-control reward-type', 'placeholder' => 'Select Reward Type']) !!}</td>
                     <td class="loot-row-select">
                         @if($loot->rewardable_type == 'Item')
                             {!! Form::select('rewardable_id[]', $items, $loot->rewardable_id, ['class' => 'form-control item-select selectize', 'placeholder' => 'Select Item']) !!}
+                        @elseif($loot->rewardable_type == 'ItemRarity')
+                            <div class="item-rarity-select d-flex">
+                                {!! Form::select('criteria[]', ['=' => '=', '<' => '<', '>' => '>', '<=' => '<=', '>=' => '>='], isset($loot->data['criteria']) ? $loot->data['criteria'] : null, ['class' => 'form-control', 'placeholder' => 'Criteria']) !!}
+                                {!! Form::select('rarity[]', $rarities, isset($loot->data['rarity']) ? $loot->data['rarity'] : null, ['class' => 'form-control', 'placeholder' => 'Rarity']) !!}
+                            </div>
                         @elseif($loot->rewardable_type == 'Currency')
                             {!! Form::select('rewardable_id[]', $currencies, $loot->rewardable_id, ['class' => 'form-control currency-select selectize', 'placeholder' => 'Select Currency']) !!}
                         @elseif($loot->rewardable_type == 'LootTable')
                             {!! Form::select('rewardable_id[]', $tables, $loot->rewardable_id, ['class' => 'form-control table-select selectize', 'placeholder' => 'Select Loot Table']) !!}
                         @elseif($loot->rewardable_type == 'ItemCategoryRarity')
                             <div class="category-rarity-select d-flex">
-                                {!! Form::select('rewardable_id[]', $categories, $loot->rewardable_id, ['class' => 'form-control selectize', 'placeholder' => 'Select Item Category']) !!}
-                                {!! Form::select('criteria[]', ['=' => '=', '<' => '<', '>' => '>', '<=' => '<=', '>=' => '>='], isset($loot->data['criteria']) ? $loot->data['criteria'] : null, ['class' => 'form-control', 'placeholder' => 'Select Criteria']) !!}
-                                {!! Form::select('rarity[]', $rarities, isset($loot->data['rarity']) ? $loot->data['rarity'] : null, ['class' => 'form-control', 'placeholder' => 'Select Rarity']) !!}
+                                {!! Form::select('rewardable_id[]', $categories, $loot->rewardable_id, ['class' => 'form-control selectize', 'placeholder' => 'Category']) !!}
+                                {!! Form::select('criteria[]', ['=' => '=', '<' => '<', '>' => '>', '<=' => '<=', '>=' => '>='], isset($loot->data['criteria']) ? $loot->data['criteria'] : null, ['class' => 'form-control', 'placeholder' => 'Criteria']) !!}
+                                {!! Form::select('rarity[]', $rarities, isset($loot->data['rarity']) ? $loot->data['rarity'] : null, ['class' => 'form-control', 'placeholder' => 'Rarity']) !!}
                             </div>
                         @elseif($loot->rewardable_type == 'ItemCategory')
                             {!! Form::select('rewardable_id[]', $categories, $loot->rewardable_id, ['class' => 'form-control item-select selectize', 'placeholder' => 'Select Item']) !!}
@@ -88,7 +93,7 @@
     <table class="table table-sm">
         <tbody id="lootRow">
             <tr class="loot-row">
-                <td>{!! Form::select('rewardable_type[]', ['Item' => 'Item', 'Currency' => 'Currency', 'LootTable' => 'Loot Table', 'ItemCategory' => 'Item Category', 'ItemCategoryRarity' => 'Item Category (Conditional)', 'None' => 'None'], null, ['class' => 'form-control reward-type', 'placeholder' => 'Select Reward Type']) !!}</td>
+                <td>{!! Form::select('rewardable_type[]', ['Item' => 'Item', 'ItemRarity' => 'Item Rarity', 'Currency' => 'Currency', 'LootTable' => 'Loot Table', 'ItemCategory' => 'Item Category', 'ItemCategoryRarity' => 'Item Category (Conditional)', 'None' => 'None'], null, ['class' => 'form-control reward-type', 'placeholder' => 'Select Reward Type']) !!}</td>
                 <td class="loot-row-select"></td>
                 <td>{!! Form::text('quantity[]', 1, ['class' => 'form-control']) !!}</td>
                 <td class="loot-row-weight">{!! Form::text('weight[]', 1, ['class' => 'form-control loot-weight']) !!}</td>
@@ -98,6 +103,10 @@
         </tbody>
     </table>
     {!! Form::select('rewardable_id[]', $items, null, ['class' => 'form-control item-select', 'placeholder' => 'Select Item']) !!}
+    <div class="item-rarity-select d-flex">
+        {!! Form::select('criteria[]', ['=' => '=', '<' => '<', '>' => '>', '<=' => '<=', '>=' => '>='], null, ['class' => 'form-control criteria-select', 'placeholder' => 'Criteria']) !!}
+        {!! Form::select('rarity[]', $rarities, null, ['class' => 'form-control criteria-select', 'placeholder' => 'Rarity']) !!}
+    </div>
     {!! Form::select('rewardable_id[]', $currencies, null, ['class' => 'form-control currency-select', 'placeholder' => 'Select Currency']) !!}
     {!! Form::select('rewardable_id[]', $tables, null, ['class' => 'form-control table-select', 'placeholder' => 'Select Loot Table']) !!}
     {!! Form::select('rewardable_id[]', $categories, null, ['class' => 'form-control category-select', 'placeholder' => 'Select Item Category']) !!}
@@ -131,6 +140,7 @@ $( document ).ready(function() {
     var $lootTable  = $('#lootTableBody');
     var $lootRow = $('#lootRow').find('.loot-row');
     var $itemSelect = $('#lootRowData').find('.item-select');
+    var $itemRaritySelect = $('#lootRowData').find('.item-rarity-select');
     var $currencySelect = $('#lootRowData').find('.currency-select');
     var $tableSelect = $('#lootRowData').find('.table-select');
     var $categorySelect = $('#lootRowData').find('.category-select');
@@ -167,6 +177,7 @@ $( document ).ready(function() {
 
         var $clone = null;
         if(val == 'Item') $clone = $itemSelect.clone();
+        else if (val == 'ItemRarity') $clone = $itemRaritySelect.clone();
         else if (val == 'Currency') $clone = $currencySelect.clone();
         else if (val == 'ItemCategory') $clone = $categorySelect.clone();
         else if (val == 'ItemCategoryRarity') $clone = $categoryRaritySelect.clone();
@@ -184,6 +195,7 @@ $( document ).ready(function() {
 
             var $clone = null;
             if(val == 'Item') $clone = $itemSelect.clone();
+            else if (val == 'ItemRarity') $clone = $itemRaritySelect.clone();
             else if (val == 'ItemCategory') $clone = $categorySelect.clone();
             else if (val == 'ItemCategoryRarity') $clone = $categoryRaritySelect.clone();
             else if (val == 'Currency') $clone = $currencySelect.clone();
@@ -192,7 +204,7 @@ $( document ).ready(function() {
 
             $cell.html('');
             $cell.append($clone);
-            if (val != 'ItemCategoryRarity') $clone.selectize();
+            if (val != 'ItemCategoryRarity' && val != 'ItemRarity') $clone.selectize();
         });
     }
 

--- a/resources/views/admin/loot_tables/create_edit_loot_table.blade.php
+++ b/resources/views/admin/loot_tables/create_edit_loot_table.blade.php
@@ -48,7 +48,7 @@
         @if($table->id)
             @foreach($table->loot as $loot)
                 <tr class="loot-row">
-                    <td>{!! Form::select('rewardable_type[]', ['Item' => 'Item', 'ItemRarity' => 'Item Rarity', 'Currency' => 'Currency', 'LootTable' => 'Loot Table', 'ItemCategory' => 'Item Category', 'ItemCategoryRarity' => 'Item Category (Conditional)', 'None' => 'None'], $loot->rewardable_type, ['class' => 'form-control reward-type', 'placeholder' => 'Select Reward Type']) !!}</td>
+                    <td>{!! Form::select('rewardable_type[]', Config::get('lorekeeper.extensions.item_entry_expansion.loot_tables') ? ['Item' => 'Item', 'ItemRarity' => 'Item Rarity', 'Currency' => 'Currency', 'LootTable' => 'Loot Table', 'ItemCategory' => 'Item Category', 'ItemCategoryRarity' => 'Item Category (Conditional)', 'None' => 'None'] : ['Item' => 'Item', 'Currency' => 'Currency', 'LootTable' => 'Loot Table', 'ItemCategory' => 'Item Category', 'None' => 'None'], $loot->rewardable_type, ['class' => 'form-control reward-type', 'placeholder' => 'Select Reward Type']) !!}</td>
                     <td class="loot-row-select">
                         @if($loot->rewardable_type == 'Item')
                             {!! Form::select('rewardable_id[]', $items, $loot->rewardable_id, ['class' => 'form-control item-select selectize', 'placeholder' => 'Select Item']) !!}
@@ -93,7 +93,7 @@
     <table class="table table-sm">
         <tbody id="lootRow">
             <tr class="loot-row">
-                <td>{!! Form::select('rewardable_type[]', ['Item' => 'Item', 'ItemRarity' => 'Item Rarity', 'Currency' => 'Currency', 'LootTable' => 'Loot Table', 'ItemCategory' => 'Item Category', 'ItemCategoryRarity' => 'Item Category (Conditional)', 'None' => 'None'], null, ['class' => 'form-control reward-type', 'placeholder' => 'Select Reward Type']) !!}</td>
+                <td>{!! Form::select('rewardable_type[]', Config::get('lorekeeper.extensions.item_entry_expansion.loot_tables') ? ['Item' => 'Item', 'ItemRarity' => 'Item Rarity', 'Currency' => 'Currency', 'LootTable' => 'Loot Table', 'ItemCategory' => 'Item Category', 'ItemCategoryRarity' => 'Item Category (Conditional)', 'None' => 'None'] : ['Item' => 'Item', 'Currency' => 'Currency', 'LootTable' => 'Loot Table', 'ItemCategory' => 'Item Category', 'None' => 'None'], null, ['class' => 'form-control reward-type', 'placeholder' => 'Select Reward Type']) !!}</td>
                 <td class="loot-row-select"></td>
                 <td>{!! Form::text('quantity[]', 1, ['class' => 'form-control']) !!}</td>
                 <td class="loot-row-weight">{!! Form::text('weight[]', 1, ['class' => 'form-control loot-weight']) !!}</td>

--- a/resources/views/admin/loot_tables/create_edit_loot_table.blade.php
+++ b/resources/views/admin/loot_tables/create_edit_loot_table.blade.php
@@ -48,7 +48,7 @@
         @if($table->id)
             @foreach($table->loot as $loot)
                 <tr class="loot-row">
-                    <td>{!! Form::select('rewardable_type[]', Config::get('lorekeeper.extensions.item_entry_expansion.loot_tables') ? ['Item' => 'Item', 'ItemRarity' => 'Item Rarity', 'Currency' => 'Currency', 'LootTable' => 'Loot Table', 'ItemCategory' => 'Item Category', 'ItemCategoryRarity' => 'Item Category (Conditional)', 'None' => 'None'] : ['Item' => 'Item', 'Currency' => 'Currency', 'LootTable' => 'Loot Table', 'ItemCategory' => 'Item Category', 'None' => 'None'], $loot->rewardable_type, ['class' => 'form-control reward-type', 'placeholder' => 'Select Reward Type']) !!}</td>
+                    <td>{!! Form::select('rewardable_type[]', Config::get('lorekeeper.extensions.item_entry_expansion.loot_tables.enable') ? ['Item' => 'Item', 'ItemRarity' => 'Item Rarity', 'Currency' => 'Currency', 'LootTable' => 'Loot Table', 'ItemCategory' => 'Item Category', 'ItemCategoryRarity' => 'Item Category (Conditional)', 'None' => 'None'] : ['Item' => 'Item', 'Currency' => 'Currency', 'LootTable' => 'Loot Table', 'ItemCategory' => 'Item Category', 'None' => 'None'], $loot->rewardable_type, ['class' => 'form-control reward-type', 'placeholder' => 'Select Reward Type']) !!}</td>
                     <td class="loot-row-select">
                         @if($loot->rewardable_type == 'Item')
                             {!! Form::select('rewardable_id[]', $items, $loot->rewardable_id, ['class' => 'form-control item-select selectize', 'placeholder' => 'Select Item']) !!}
@@ -93,7 +93,7 @@
     <table class="table table-sm">
         <tbody id="lootRow">
             <tr class="loot-row">
-                <td>{!! Form::select('rewardable_type[]', Config::get('lorekeeper.extensions.item_entry_expansion.loot_tables') ? ['Item' => 'Item', 'ItemRarity' => 'Item Rarity', 'Currency' => 'Currency', 'LootTable' => 'Loot Table', 'ItemCategory' => 'Item Category', 'ItemCategoryRarity' => 'Item Category (Conditional)', 'None' => 'None'] : ['Item' => 'Item', 'Currency' => 'Currency', 'LootTable' => 'Loot Table', 'ItemCategory' => 'Item Category', 'None' => 'None'], null, ['class' => 'form-control reward-type', 'placeholder' => 'Select Reward Type']) !!}</td>
+                <td>{!! Form::select('rewardable_type[]', Config::get('lorekeeper.extensions.item_entry_expansion.loot_tables.enable') ? ['Item' => 'Item', 'ItemRarity' => 'Item Rarity', 'Currency' => 'Currency', 'LootTable' => 'Loot Table', 'ItemCategory' => 'Item Category', 'ItemCategoryRarity' => 'Item Category (Conditional)', 'None' => 'None'] : ['Item' => 'Item', 'Currency' => 'Currency', 'LootTable' => 'Loot Table', 'ItemCategory' => 'Item Category', 'None' => 'None'], null, ['class' => 'form-control reward-type', 'placeholder' => 'Select Reward Type']) !!}</td>
                 <td class="loot-row-select"></td>
                 <td>{!! Form::text('quantity[]', 1, ['class' => 'form-control']) !!}</td>
                 <td class="loot-row-weight">{!! Form::text('weight[]', 1, ['class' => 'form-control loot-weight']) !!}</td>


### PR DESCRIPTION
Following my asking after the notion almost a year ago now, haha, I did it.

New:
- Adds item category as an option for loot tables; an item is selected at random from those in the category.
- Optional/toggleable: Adds rarity criteria for both items and item categories as options for loot tables; these allow rolling from all items/all items in a category that are (=/</>/<=/>=) any given rarity that exists on the site. Note that this expects rarities to be numeric, though strings should still work with `=`.
- Optional/toggleable: By default this uses whereRaw() for filtering which works consistently on local, but on DH (and presumably with software that supports JSON natively) a cleaner where() searching within the JSON that way was more consistent; thus, I included an option to switch to the former.

Misc:
- Change item rarity field to be a number field instead of a text field.

Tested locally, live - Requires migrate, configuring in lorekeeper/extensions as desired