### PR TITLE
Opt out of FLoC

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -4,6 +4,10 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
+    <?php
+        header("Permissions-Policy: interest-cohort=()");
+    ?>
+
     <!-- CSRF Token -->
     <meta name="csrf-token" content="{{ csrf_token() }}">
 


### PR DESCRIPTION
Adds a header opting a site out of Google's FLoC. While it's not a security issue, it _is_ a privacy issue; this is in the wake of github itself, for instance, adding this header to this site as well as to github pages.
As a prompt response to the matter seems prudent-- regardless of the ultimate fate of the technology-- I feel it practical to merge this into master in the vein of a hotfix, though it is not technically one since it's not fixing a bug per se.

Tested locally - Requires no further action