### PR TITLE
Re-reduce dA request scope to only username

### DIFF
--- a/app/Services/LinkService.php
+++ b/app/Services/LinkService.php
@@ -19,11 +19,12 @@ class LinkService extends Service
     
     /**
      * Get the Auth URL for dA.
-     * 
+     *
      * @return string
      */
     public function getAuthRedirect($provider) {
-        return Socialite::driver($provider)->redirect();
+        if($provider == 'deviantart') return Socialite::driver($provider)->setScopes(['user'])->redirect();
+        else return Socialite::driver($provider)->redirect();
     }
 
     /**


### PR DESCRIPTION
As with #12, but updated to suit the new system. Other providers may need to be adjusted as appropriate in the future; however, I do not know their scopes offhand. The basic method should work for each, however-- setScopes() overwrites scopes specified within the individual provider packages and so is a ready way to curtail any unnecessary access without needing to modify things at/around the package level.

Tested live, no further actions necessary.