### PR TITLE
Fix for errored inventory addon forms not refilling the old data

### DIFF
--- a/app/Services/CharacterManager.php
+++ b/app/Services/CharacterManager.php
@@ -1961,13 +1961,13 @@ is_object($sender) ? $sender->id : null,
             // We're also not going to add logs as this might add unnecessary fluff to the logs and the items still belong to the user.
             // Perhaps later I'll add a way to locate items that are being held by updates/trades.
             if(isset($data['stack_id'])) {
-                foreach($data['stack_id'] as $key=>$stackId) {
+                foreach($data['stack_id'] as $stackId) {
                     $stack = UserItem::with('item')->find($stackId);
                     if(!$stack || $stack->user_id != $request->user_id) throw new \Exception("Invalid item selected.");
-                    $stack->update_count += $data['stack_quantity'][$key];
+                    $stack->update_count += $data['stack_quantity'][$stackId];
                     $stack->save();
 
-                    addAsset($userAssets, $stack, $data['stack_quantity'][$key]);
+                    addAsset($userAssets, $stack, $data['stack_quantity'][$stackId]);
                 }
             }
 

--- a/app/Services/CharacterManager.php
+++ b/app/Services/CharacterManager.php
@@ -1964,6 +1964,7 @@ is_object($sender) ? $sender->id : null,
                 foreach($data['stack_id'] as $stackId) {
                     $stack = UserItem::with('item')->find($stackId);
                     if(!$stack || $stack->user_id != $request->user_id) throw new \Exception("Invalid item selected.");
+                    if(!isset($data['stack_quantity'][$stackId])) throw new \Exception("Invalid quantity selected.");
                     $stack->update_count += $data['stack_quantity'][$stackId];
                     $stack->save();
 

--- a/app/Services/SubmissionManager.php
+++ b/app/Services/SubmissionManager.php
@@ -74,14 +74,14 @@ class SubmissionManager extends Service
             // Attach items. Technically, the user doesn't lose ownership of the item - we're just adding an additional holding field.
             // We're also not going to add logs as this might add unnecessary fluff to the logs and the items still belong to the user.
             if(isset($data['stack_id'])) {
-                foreach($data['stack_id'] as $key=>$stackId) {
+                foreach($data['stack_id'] as $stackId) {
                     $stack = UserItem::with('item')->find($stackId);
                     if(!$stack || $stack->user_id != $user->id) throw new \Exception("Invalid item selected.");
-                    if(!isset($data['stack_quantity'][$key])) $data['stack_quantity'][$key] = $stack->count;
-                    $stack->submission_count += $data['stack_quantity'][$key];
+                    if(!isset($data['stack_quantity'][$stackId])) throw new \Exception("Invalid quantity selected.");
+                    $stack->submission_count += $data['stack_quantity'][$stackId];
                     $stack->save();
 
-                    addAsset($userAssets, $stack, $data['stack_quantity'][$key]);
+                    addAsset($userAssets, $stack, $data['stack_quantity'][$stackId]);
                 }
             }
 

--- a/app/Services/TradeManager.php
+++ b/app/Services/TradeManager.php
@@ -166,14 +166,14 @@ class TradeManager extends Service
             // Attach items. Technically, the user doesn't lose ownership of the item - we're just adding an additional holding field.
             // Unlike for design updates, we're keeping track of attached items here.
             if(isset($data['stack_id'])) {
-                foreach($data['stack_id'] as $key=>$stackId) {
+                foreach($data['stack_id'] as $stackId) {
                     $stack = UserItem::with('item')->find($stackId);
                     if(!$stack || $stack->user_id != $user->id) throw new \Exception("Invalid item selected.");
                     if(!$stack->item->allow_transfer || isset($stack->data['disallow_transfer'])) throw new \Exception("One or more of the selected items cannot be transferred.");
-                    $stack->trade_count += $data['stack_quantity'][$key];
+                    $stack->trade_count += $data['stack_quantity'][$stackId];
                     $stack->save();
 
-                    addAsset($userAssets, $stack, $data['stack_quantity'][$key]);
+                    addAsset($userAssets, $stack, $data['stack_quantity'][$stackId]);
                     $assetCount++;
                 }
             }

--- a/app/Services/TradeManager.php
+++ b/app/Services/TradeManager.php
@@ -169,6 +169,7 @@ class TradeManager extends Service
                 foreach($data['stack_id'] as $stackId) {
                     $stack = UserItem::with('item')->find($stackId);
                     if(!$stack || $stack->user_id != $user->id) throw new \Exception("Invalid item selected.");
+                    if(!isset($data['stack_quantity'][$stackId])) throw new \Exception("Invalid quantity selected.");
                     if(!$stack->item->allow_transfer || isset($stack->data['disallow_transfer'])) throw new \Exception("One or more of the selected items cannot be transferred.");
                     $stack->trade_count += $data['stack_quantity'][$stackId];
                     $stack->save();

--- a/resources/views/widgets/_inventory_select.blade.php
+++ b/resources/views/widgets/_inventory_select.blade.php
@@ -45,7 +45,7 @@
                     </thead>
                     <tbody>
                         @foreach($inventory as $itemRow)
-                            <tr id ="itemRow{{ $itemRow->id }}" data-item-id="{{ $itemRow->id }}" class="d-flex {{ $itemRow->isTransferrable ? '' : 'accountbound' }} user-item select-item-row item-all category-all item-{{ $itemRow->item->id }} category-{{ $itemRow->item->item_category_id ? : 0 }} {{ (isset($selected) && in_array($itemRow->id, array_keys($selected))) || (isset($old_selection) && isset($old_selection[$itemRow->id])) ? 'category-selected' : '' }}">
+                            <tr id ="itemRow{{ $itemRow->id }}" class="d-flex {{ $itemRow->isTransferrable ? '' : 'accountbound' }} user-item select-item-row item-all category-all item-{{ $itemRow->item->id }} category-{{ $itemRow->item->item_category_id ? : 0 }} {{ (isset($selected) && in_array($itemRow->id, array_keys($selected))) || (isset($old_selection) && isset($old_selection[$itemRow->id])) ? 'category-selected' : '' }}">
                                 <td class="col-1">{!! Form::checkbox((isset($fieldName) && $fieldName ? $fieldName : 'stack_id[]'), $itemRow->id, isset($selected) && in_array($itemRow->id, array_keys($selected)) ? true : false, ['class' => 'inventory-checkbox']) !!}</td>
                                 <td class="col-2">@if(isset($itemRow->item->image_url)) <img class="small-icon" src="{{ $itemRow->item->image_url }}"> @endif {!! $itemRow->item->name !!}
                                 <td class="col-4">{!! array_key_exists('data', $itemRow->data) ? ($itemRow->data['data'] ? $itemRow->data['data'] : 'N/A') : 'N/A' !!}</td>

--- a/resources/views/widgets/_inventory_select.blade.php
+++ b/resources/views/widgets/_inventory_select.blade.php
@@ -1,3 +1,6 @@
+@php
+    if(old('stack_id')) $old_selection = array_combine(old('stack_id'), old('stack_quantity'));
+@endphp
 <h3>Your Inventory <a class="small inventory-collapse-toggle collapse-toggle collapsed" href="#userInventory" data-toggle="collapse">Show</a></h3>
 <hr>
 <div class="collapse" id="userInventory">
@@ -48,7 +51,9 @@
                                 <td class="col-4">{!! array_key_exists('data', $itemRow->data) ? ($itemRow->data['data'] ? $itemRow->data['data'] : 'N/A') : 'N/A' !!}</td>
                                 <td class="col-3">{!! array_key_exists('notes', $itemRow->data) ? ($itemRow->data['notes'] ? $itemRow->data['notes'] : 'N/A') : 'N/A' !!}</td>
                                 @if($itemRow->availableQuantity || in_array($itemRow->id, array_keys($selected)))
-                                    @if(in_array($itemRow->id, array_keys($selected)))
+                                    @if(isset($old_selection) && isset($old_selection[$itemRow->id]))
+                                        <td class="col-2">{!! Form::selectRange('stack_quantity[]', 1, $itemRow->getAvailableContextQuantity($selected[$itemRow->id] ?? 0), $old_selection[$itemRow->id], ['class' => 'quantity-select', 'type' => 'number', 'style' => 'min-width:40px;']) !!} /{{ $itemRow->getAvailableContextQuantity($selected[$itemRow->id] ?? 0) }} @if($page == 'trade') @if($itemRow->getOthers($selected[$itemRow->id], 0)) {{ $itemRow->getOthers($selected[$itemRow->id], 0) }} @endif @elseif($page == 'update') @if($itemRow->getOthers(0, $selected[$itemRow->id])) {{ $itemRow->getOthers(0, $selected[$itemRow->id]) }} @endif @endif</td>
+                                    @elseif(in_array($itemRow->id, array_keys($selected)))
                                         <td class="col-2">{!! Form::selectRange('stack_quantity[]', 1, $itemRow->getAvailableContextQuantity($selected[$itemRow->id]), $selected[$itemRow->id], ['class' => 'quantity-select', 'type' => 'number', 'style' => 'min-width:40px;']) !!} /{{ $itemRow->getAvailableContextQuantity($selected[$itemRow->id]) }} @if($page == 'trade') @if($itemRow->getOthers($selected[$itemRow->id], 0)) {{ $itemRow->getOthers($selected[$itemRow->id], 0) }} @endif @elseif($page == 'update') @if($itemRow->getOthers(0, $selected[$itemRow->id])) {{ $itemRow->getOthers(0, $selected[$itemRow->id]) }} @endif @endif</td>
                                     @else
                                         <td class="col-2">{!! Form::selectRange('', 1, $itemRow->availableQuantity, 1, ['class' => 'quantity-select', 'type' => 'number', 'style' => 'min-width:40px;']) !!} /{{ $itemRow->availableQuantity }} @if($itemRow->getOthers()) {{ $itemRow->getOthers() }} @endif</td>

--- a/resources/views/widgets/_inventory_select.blade.php
+++ b/resources/views/widgets/_inventory_select.blade.php
@@ -45,16 +45,46 @@
                     </thead>
                     <tbody>
                         @foreach($inventory as $itemRow)
-                            <tr id ="itemRow{{ $itemRow->id }}" class="d-flex {{ $itemRow->isTransferrable ? '' : 'accountbound' }} user-item select-item-row item-all category-all item-{{ $itemRow->item->id }} category-{{ $itemRow->item->item_category_id ? : 0 }} {{ isset($selected) && in_array($itemRow->id, array_keys($selected)) ? 'category-selected' : '' }}">
+                            <tr id ="itemRow{{ $itemRow->id }}" data-item-id="{{ $itemRow->id }}" class="d-flex {{ $itemRow->isTransferrable ? '' : 'accountbound' }} user-item select-item-row item-all category-all item-{{ $itemRow->item->id }} category-{{ $itemRow->item->item_category_id ? : 0 }} {{ (isset($selected) && in_array($itemRow->id, array_keys($selected))) || (isset($old_selection) && isset($old_selection[$itemRow->id])) ? 'category-selected' : '' }}">
                                 <td class="col-1">{!! Form::checkbox((isset($fieldName) && $fieldName ? $fieldName : 'stack_id[]'), $itemRow->id, isset($selected) && in_array($itemRow->id, array_keys($selected)) ? true : false, ['class' => 'inventory-checkbox']) !!}</td>
                                 <td class="col-2">@if(isset($itemRow->item->image_url)) <img class="small-icon" src="{{ $itemRow->item->image_url }}"> @endif {!! $itemRow->item->name !!}
                                 <td class="col-4">{!! array_key_exists('data', $itemRow->data) ? ($itemRow->data['data'] ? $itemRow->data['data'] : 'N/A') : 'N/A' !!}</td>
                                 <td class="col-3">{!! array_key_exists('notes', $itemRow->data) ? ($itemRow->data['notes'] ? $itemRow->data['notes'] : 'N/A') : 'N/A' !!}</td>
                                 @if($itemRow->availableQuantity || in_array($itemRow->id, array_keys($selected)))
                                     @if(isset($old_selection) && isset($old_selection[$itemRow->id]))
-                                        <td class="col-2">{!! Form::selectRange('stack_quantity[]', 1, $itemRow->getAvailableContextQuantity($selected[$itemRow->id] ?? 0), $old_selection[$itemRow->id], ['class' => 'quantity-select', 'type' => 'number', 'style' => 'min-width:40px;']) !!} /{{ $itemRow->getAvailableContextQuantity($selected[$itemRow->id] ?? 0) }} @if($page == 'trade') @if($itemRow->getOthers($selected[$itemRow->id], 0)) {{ $itemRow->getOthers($selected[$itemRow->id], 0) }} @endif @elseif($page == 'update') @if($itemRow->getOthers(0, $selected[$itemRow->id])) {{ $itemRow->getOthers(0, $selected[$itemRow->id]) }} @endif @endif</td>
+                                        <td class="col-2">{!! Form::selectRange(
+                                            'stack_quantity['.$itemRow->id.']',
+                                            1,
+                                            $itemRow->getAvailableContextQuantity($selected[$itemRow->id] ?? 0),
+                                            $old_selection[$itemRow->id],
+                                            ['class' => 'quantity-select', 'type' => 'number', 'style' => 'min-width:40px;']) !!}
+                                            /
+                                            {{ $itemRow->getAvailableContextQuantity($selected[$itemRow->id] ?? 0) }}
+                                            @if($page == 'trade')
+                                                @if($itemRow->getOthers($selected[$itemRow->id], 0)) {{ $itemRow->getOthers($selected[$itemRow->id], 0) }} @endif
+                                            @elseif($page == 'update')
+                                                @if($itemRow->getOthers(0, $selected[$itemRow->id])) {{ $itemRow->getOthers(0, $selected[$itemRow->id]) }} @endif
+                                            @elseif($itemRow->getOthers())
+                                                {{ $itemRow->getOthers() }}
+                                            @endif
+                                        </td>
                                     @elseif(in_array($itemRow->id, array_keys($selected)))
-                                        <td class="col-2">{!! Form::selectRange('stack_quantity[]', 1, $itemRow->getAvailableContextQuantity($selected[$itemRow->id]), $selected[$itemRow->id], ['class' => 'quantity-select', 'type' => 'number', 'style' => 'min-width:40px;']) !!} /{{ $itemRow->getAvailableContextQuantity($selected[$itemRow->id]) }} @if($page == 'trade') @if($itemRow->getOthers($selected[$itemRow->id], 0)) {{ $itemRow->getOthers($selected[$itemRow->id], 0) }} @endif @elseif($page == 'update') @if($itemRow->getOthers(0, $selected[$itemRow->id])) {{ $itemRow->getOthers(0, $selected[$itemRow->id]) }} @endif @endif</td>
+                                        <td class="col-2">{!! Form::selectRange(
+                                            'stack_quantity['.$itemRow->id.']',
+                                            1,
+                                            $itemRow->getAvailableContextQuantity($selected[$itemRow->id]),
+                                            $selected[$itemRow->id],
+                                            ['class' => 'quantity-select', 'type' => 'number', 'style' => 'min-width:40px;']) !!}
+                                            /
+                                            {{ $itemRow->getAvailableContextQuantity($selected[$itemRow->id]) }}
+                                            @if($page == 'trade')
+                                                @if($itemRow->getOthers($selected[$itemRow->id], 0)) {{ $itemRow->getOthers($selected[$itemRow->id], 0) }} @endif
+                                            @elseif($page == 'update')
+                                                @if($itemRow->getOthers(0, $selected[$itemRow->id])) {{ $itemRow->getOthers(0, $selected[$itemRow->id]) }} @endif
+                                            @elseif($itemRow->getOthers())
+                                                {{ $itemRow->getOthers() }}
+                                            @endif
+                                        </td>
                                     @else
                                         <td class="col-2">{!! Form::selectRange('', 1, $itemRow->availableQuantity, 1, ['class' => 'quantity-select', 'type' => 'number', 'style' => 'min-width:40px;']) !!} /{{ $itemRow->availableQuantity }} @if($itemRow->getOthers()) {{ $itemRow->getOthers() }} @endif</td>
                                     @endif

--- a/resources/views/widgets/_inventory_select_js.blade.php
+++ b/resources/views/widgets/_inventory_select_js.blade.php
@@ -33,7 +33,7 @@
             var rowId = "#itemRow" + $checkbox.val()
             if($checkbox.is(":checked")) {
                 $(rowId).addClass('category-selected');
-                $(rowId).find('.quantity-select').prop('name', 'stack_quantity[]')
+                $(rowId).find('.quantity-select').prop('name', 'stack_quantity['+$checkbox.val()+']')
             }
             else {
                 $(rowId).removeClass('category-selected');


### PR DESCRIPTION
When submitting Prompts, if an incorrect URL (or other form validation error) is used on the first attempt to submit, users will be returned to the form, with the fields seemingly repopulated with their previous input. However, if they then try to submit again without manually reselecting the inventory addons, the entire stack of the selected item will be used in the submission.

Other changes as a result of this fix:
- stack_quantity is now keyed by the stack_id, which helps in properly refilling the form on failed submit
- If stack_quantity is not set, an error is thrown instead of defaulting to the use of the whole stack; this error check has also been added to the CharacterManager (for design updates) and TradeManager

Tested locally.