### PR TITLE
Fix bug with galleries being (incorrectly) visible

### DIFF
--- a/app/Http/Controllers/GalleryController.php
+++ b/app/Http/Controllers/GalleryController.php
@@ -35,7 +35,7 @@ class GalleryController extends Controller
     public function __construct()
     {
         parent::__construct();
-        View::share('sidebarGalleries', Gallery::whereNull('parent_id')->active()->sort()->get());
+        View::share('sidebarGalleries', Gallery::whereNull('parent_id')->visible()->sort()->get());
     }
 
     /**
@@ -61,7 +61,7 @@ class GalleryController extends Controller
      */
     public function getGallery($id, Request $request)
     {
-        $gallery = Gallery::find($id);
+        $gallery = Gallery::visible()->where('id', $id)->first();
         if(!$gallery) abort(404);
 
         $query = GallerySubmission::where('gallery_id', $gallery->id)->visible(Auth::check() ? Auth::user() : null)->accepted();

--- a/app/Models/Gallery/Gallery.php
+++ b/app/Models/Gallery/Gallery.php
@@ -123,6 +123,23 @@ class Gallery extends Model
 
     }
 
+    /**
+     * Scope a query to only include visible galleries.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeVisible($query)
+    {
+        return $query
+            ->where(function($query) {
+                $query->whereNull('start_at')->orWhere('start_at', '<', Carbon::now())->orWhere(function($query) {
+                    $query->where('start_at', '>=', Carbon::now())->where('hide_before_start', 0);
+                });
+        });
+
+    }
+
     /**********************************************************************************************
 
         ACCESSORS

--- a/resources/views/galleries/_sidebar.blade.php
+++ b/resources/views/galleries/_sidebar.blade.php
@@ -13,7 +13,7 @@
     @if($galleryPage && $sideGallery->children->count())
         <li class="sidebar-section">
             <div class="sidebar-section-header">{{ $sideGallery->name }}: Sub-Galleries</div>
-            @foreach($sideGallery->children as $child)
+            @foreach($sideGallery->children()->visible()->get() as $child)
                 <div class="sidebar-item"><a href="{{ url('gallery/'.$child->id) }}" class="{{ set_active('gallery/'.$child->id) }}">{{ $child->name }}</a></div>
             @endforeach
         </li>

--- a/resources/views/galleries/index.blade.php
+++ b/resources/views/galleries/index.blade.php
@@ -30,8 +30,8 @@
                         {{ $gallery->children->count() && (isset($gallery->start_at) || isset($gallery->end_at)) ? ' ・ ' : '' }}
                         @if($gallery->children->count())
                             Sub-galleries:
-                            @foreach($gallery->children as $count=>$child)
-                                {!! $child->displayName !!}{{ $count < $gallery->children->count() - 1 ? ', ' : '' }}
+                            @foreach($gallery->children()->visible()->get() as $count=>$child)
+                                {!! $child->displayName !!}{{ !$loop->final ? ', ' : '' }}
                             @endforeach
                         @endif
                     </p>


### PR DESCRIPTION
Adds a visible() scope to galleries and correctly checks against it.
Tested live, no further actions required