### PR TITLE
Add contribution info

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Lorekeeper Contribution Guide
+
+For support and general questions and discussions, please visit the [support Discord server](https://discord.gg/U4JZfsu)! Please do not use the issue tracker for general support questions. Please also remember that unless explicitly stated otherwise/you have hired services to that end, all support is free and offered on a volunteer basis, and there is no guarantee or obligation upon maintainers and/or community members to provide support.
+
+The following are accepted uses for the [issue tracker](https://github.com/corowne/Lorekeeper/issues):
+- Bug reports
+- Feature or enhancement requests (within reason)-- note that these may be denied if they are deemed out of scope of the project and/or are not feasible to implement for any reason.
+
+## Opening an Issue
+### Reporting a bug
+
+File bugs in the [issue tracker](https://github.com/corowne/Lorekeeper/issues). Please follow these guidelines:
+
+- Search existing issues first! Make sure your issue hasn't already been reported.
+- Stay on topic, but describe the issue in detail so that others can reproduce it.
+- Don't use one issue for multiple bugs! Keeping them 1:1 helps with tracking and fixing problems. Similarly, don't make multiple issues for one bug.
+- Provide screenshot(s) if possible.
+
+### Feature requests
+
+It's recommended to discuss potential new features in the [support Discord](https://discord.gg/U4JZfsu) before creating an issue, as this helps check that it is valid for a feature request and if it would be useful to others-- something which increases its likelihood of being implemented. Please also check that your request has not already been posted on the [issue tracker](https://github.com/corowne/Lorekeeper/issues).
+
+Avoid listing multiple requests in one issue. One issue per request makes it easier to track and discuss it. If need be, you may make multiple issues (within reason), but do not spam. Do not make multiple issues for the same request.
+
+## Contributing Code
+
+Please see the full [Contribution Guide](http://wiki.lorekeeper.me/index.php?title=Contributing_to_Lorekeeper) for more information!
+
+### About abandoned pull requests
+
+In the case where a pull request is started but not finished and the contributor is nonresponsive despite efforts to contact them, the pull request will be closed regardless of its status. It is up to contributors to finish work, make any requested changes, etc., not maintainers.
+
+However, knowledge from the issue and/or pull request may be used to create a new pull request, potentially based on the changes from the closed pull request.


### PR DESCRIPTION
Add contribution info within the repo with basic guidelines and a link to the relevant article on the wiki, as github displays a message to first-time contributors if the file is present.