### PR TITLE
fix: will now log to the correct user

### DIFF
--- a/app/Services/SubmissionManager.php
+++ b/app/Services/SubmissionManager.php
@@ -376,7 +376,7 @@ class SubmissionManager extends Service
             {
                 foreach($addonData['currencies'] as $currencyId=>$quantity) {
                     $currency = Currency::find($currencyId);
-                    if(!$currencyManager->createLog($submission->user->id, 'User', null, null,
+                    if(!$currencyManager->createLog($submission->user_id, 'User', null, null,
                     $submission->prompt_id ? 'Prompt Approved' : 'Claim Approved', 'Used in ' . ($submission->prompt_id ? 'prompt' : 'claim') . ' (<a href="'.$submission->viewUrl.'">#'.$submission->id.'</a>)', $currencyId, $quantity))
                         throw new \Exception("Failed to create currency log.");
                 }

--- a/app/Services/SubmissionManager.php
+++ b/app/Services/SubmissionManager.php
@@ -376,7 +376,7 @@ class SubmissionManager extends Service
             {
                 foreach($addonData['currencies'] as $currencyId=>$quantity) {
                     $currency = Currency::find($currencyId);
-                    if(!$currencyManager->createLog($user->id, 'User', null, null,
+                    if(!$currencyManager->createLog($submission->user->id, 'User', null, null,
                     $submission->prompt_id ? 'Prompt Approved' : 'Claim Approved', 'Used in ' . ($submission->prompt_id ? 'prompt' : 'claim') . ' (<a href="'.$submission->viewUrl.'">#'.$submission->id.'</a>)', $currencyId, $quantity))
                         throw new \Exception("Failed to create currency log.");
                 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,7 +31,7 @@ Route::group(['middleware' => ['auth', 'verified']], function() {
 
     # SET BIRTHDATE
     Route::get('/birthday', 'HomeController@getBirthday')->name('birthday');
-    Route::post('/birthday', 'HomeController@postBirthday')->name('birthday');
+    Route::post('/birthday', 'HomeController@postBirthday');
 
     Route::get('/blocked', 'HomeController@getBirthdayBlocked')->name('blocked');
 


### PR DESCRIPTION
fix: submission approval will now log to the correct user instead of the approving admin when including currency from user's bank

This issue likely arose because $user was only the submitter for a short while before it was switched back into $staff within the above block.

patch 2 includes removing the duplicate birthday name for the web route which was previously blocking `php artisan route:cache` from running.