### PR TITLE
Fix to gallery submissions + "View Page" button addition

### DIFF
--- a/resources/views/admin/pages/create_edit_page.blade.php
+++ b/resources/views/admin/pages/create_edit_page.blade.php
@@ -9,6 +9,9 @@
     @if($page->id && !Config::get('lorekeeper.text_pages.'.$page->key))
         <a href="#" class="btn btn-danger float-right delete-page-button">Delete Page</a>
     @endif
+    @if($page->id)
+        <a href="{{ $page->url }}" class="btn btn-info float-right mr-md-2">View Page</a>
+    @endif
 </h1>
 
 {!! Form::open(['url' => $page->id ? 'admin/pages/edit/'.$page->id : 'admin/pages/create', 'files' => true]) !!}

--- a/resources/views/galleries/create_edit_submission.blade.php
+++ b/resources/views/galleries/create_edit_submission.blade.php
@@ -74,7 +74,7 @@
                 @if($gallery->prompt_selection == 1 && (!$submission->id || Auth::user()->hasPower('manage_submissions')))
                     <div class="form-group">
                         {!! Form::label('prompt_id', ($submission->id && Auth::user()->hasPower('manage_submissions') ? '[Admin] ' : '').'Prompt (Optional)') !!} {!! add_help('This <strong>does not</strong> automatically submit to the selected prompt, and you will need to submit to it separately. The prompt selected here will be displayed on the submission page for future reference. You will not be able to edit this after creating the submission.') !!}
-                        {!! Form::select('prompt_id', $prompts, null, ['class' => 'form-control selectize', 'id' => 'prompt', 'placeholder' => 'Select a Prompt']) !!}
+                        {!! Form::select('prompt_id', $prompts, $submission->prompt_id, ['class' => 'form-control selectize', 'id' => 'prompt', 'placeholder' => 'Select a Prompt']) !!}
                     </div>
                 @else
                     {!! $submission->prompt_id ? '<p><strong>Prompt:</strong> '.$submission->prompt->displayName.'</p>' : '' !!}


### PR DESCRIPTION
- I've been wanting a "view page" button for site pages for eons and decided to add it. Most other things have previews while pages do not, so a link is necessary imo and not just for develop

- Adds `$submission->prompt_id` to the create_edit_submission file so that when an admin edits a file, they don't accidentally strip it of its prompt.