### PR TITLE
feat: implement news/sales rss feeds

### DIFF
--- a/app/Models/News.php
+++ b/app/Models/News.php
@@ -6,10 +6,12 @@ use Carbon\Carbon;
 use Config;
 use App\Models\Model;
 use Illuminate\Support\Str;
+use Spatie\Feed\Feedable;
+use Spatie\Feed\FeedItem;
 
 use App\Traits\Commentable;
 
-class News extends Model
+class News extends Model implements Feedable
 {
     use Commentable;
     /**
@@ -51,7 +53,7 @@ class News extends Model
         'title' => 'required|between:3,100',
         'text' => 'required',
     ];
-    
+
     /**
      * Validation rules for updating.
      *
@@ -63,21 +65,21 @@ class News extends Model
     ];
 
     /**********************************************************************************************
-    
+
         RELATIONS
 
     **********************************************************************************************/
-    
+
     /**
      * Get the user who created the news post.
      */
-    public function user() 
+    public function user()
     {
         return $this->belongsTo('App\Models\User\User');
     }
 
     /**********************************************************************************************
-    
+
         SCOPES
 
     **********************************************************************************************/
@@ -105,7 +107,7 @@ class News extends Model
     }
 
     /**********************************************************************************************
-    
+
         ACCESSORS
 
     **********************************************************************************************/
@@ -138,5 +140,37 @@ class News extends Model
     public function getUrlAttribute()
     {
         return url('news/'.$this->slug);
+    }
+
+    /**********************************************************************************************
+
+        OTHER FUNCTIONS
+
+    **********************************************************************************************/
+
+    /**
+     * Returns all feed items.
+     *
+     */
+    public static function getFeedItems()
+    {
+        return News::visible()->get();
+    }
+
+    /**
+     * Generates feed item information.
+     *
+     * @return /Spatie/Feed/FeedItem;
+     */
+    public function toFeedItem(): FeedItem
+    {
+        return FeedItem::create([
+            'id' => '/news/'.$this->id,
+            'title' => $this->title,
+            'summary' => $this->parsed_text,
+            'updated' => $this->updated_at,
+            'link' => $this->url,
+            'author' => $this->user->name
+        ]);
     }
 }

--- a/app/Models/Sales/Sales.php
+++ b/app/Models/Sales/Sales.php
@@ -7,8 +7,10 @@ use Config;
 use App\Models\Model;
 use App\Traits\Commentable;
 use Illuminate\Support\Str;
+use Spatie\Feed\Feedable;
+use Spatie\Feed\FeedItem;
 
-class Sales extends Model
+class Sales extends Model implements Feedable
 {
     use Commentable;
     /**
@@ -146,5 +148,39 @@ class Sales extends Model
     public function getUrlAttribute()
     {
         return url('sales/'.$this->slug);
+    }
+
+    /**********************************************************************************************
+
+        OTHER FUNCTIONS
+
+    **********************************************************************************************/
+
+    /**
+     * Returns all feed items.
+     *
+     */
+    public static function getFeedItems()
+    {
+        return Sales::visible()->get();
+    }
+
+    /**
+     * Generates feed item information.
+     *
+     * @return /Spatie/Feed/FeedItem;
+     */
+    public function toFeedItem(): FeedItem
+    {
+        $summary = ($this->characters->count() ? $this->characters->count().' character'.($this->characters->count() > 1 ? 's are' : ' is').' associated with this sale. Click through to read more.<hr/>' : '').$this->parsed_text;
+
+        return FeedItem::create([
+            'id' => '/sales/'.$this->id,
+            'title' => $this->title,
+            'summary' => $summary,
+            'updated' => $this->updated_at,
+            'link' => $this->url,
+            'author' => $this->user->name
+        ]);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -29,13 +29,14 @@
         "laravel/ui": "^3.1.0",
         "laravelcollective/html": "^6.0",
         "socialiteproviders/deviantart": "^4.1",
+        "socialiteproviders/discord": "^4.1",
         "socialiteproviders/imgur": "^4.1",
         "socialiteproviders/instagram": "^4.1",
         "socialiteproviders/tumblr": "^4.1",
         "socialiteproviders/twitch": "^5.3",
         "socialiteproviders/twitter": "^4.1",
-        "spatie/laravel-honeypot": "^3.0.1",
-        "socialiteproviders/discord": "^4.1"
+        "spatie/laravel-feed": "^3.2",
+        "spatie/laravel-honeypot": "^3.0.1"
     },
     "require-dev": {
         "beyondcode/laravel-dump-server": "^1.0",

--- a/config/feed.php
+++ b/config/feed.php
@@ -1,0 +1,67 @@
+<?php
+
+return [
+    'feeds' => [
+        'news' => [
+            /*
+             * Here you can specify which class and method will return
+             * the items that should appear in the feed. For example:
+             * 'App\Model@getAllFeedItems'
+             *
+             * You can also pass an argument to that method:
+             * ['App\Model@getAllFeedItems', 'argument']
+             */
+            'items' => 'App\Models\News@getFeedItems',
+
+            /*
+             * The feed will be available on this url.
+             */
+            'url' => '/news',
+
+            'title' => env('APP_NAME', 'Laravel').' ・ News',
+            'description' => 'Site news.',
+            'language' => 'en-US',
+
+            /*
+             * The view that will render the feed.
+             */
+            'view' => 'feed::atom',
+
+            /*
+             * The type to be used in the <link> tag
+             */
+            'type' => 'application/atom+xml',
+        ],
+
+        'sales' => [
+            /*
+             * Here you can specify which class and method will return
+             * the items that should appear in the feed. For example:
+             * 'App\Model@getAllFeedItems'
+             *
+             * You can also pass an argument to that method:
+             * ['App\Model@getAllFeedItems', 'argument']
+             */
+            'items' => 'App\Models\Sales\Sales@getFeedItems',
+
+            /*
+             * The feed will be available on this url.
+             */
+            'url' => '/sales',
+
+            'title' => env('APP_NAME', 'Laravel').' ・ Sales',
+            'description' => 'Site news.',
+            'language' => 'en-US',
+
+            /*
+             * The view that will render the feed.
+             */
+            'view' => 'feed::atom',
+
+            /*
+             * The type to be used in the <link> tag
+             */
+            'type' => 'application/atom+xml',
+        ],
+    ],
+];

--- a/resources/views/layouts/_footer.blade.php
+++ b/resources/views/layouts/_footer.blade.php
@@ -8,6 +8,8 @@
         <li class="nav-item"><a href="http://deviantart.com/{{ env('DEVIANTART_ACCOUNT') }}" class="nav-link">deviantART</a></li>
         <li class="nav-item"><a href="https://github.com/corowne/lorekeeper" class="nav-link">Lorekeeper</a></li>
         <li class="nav-item"><a href="{{ url('credits') }}" class="nav-link">Credits</a></li>
+        <li class="nav-item"><a href="{{ url('feeds/news') }}" class="nav-link"><i class="fas fa-rss-square"></i> News</a></li>
+        <li class="nav-item"><a href="{{ url('feeds/sales') }}" class="nav-link"><i class="fas fa-rss-square"></i> Sales</a></li>
     </ul>
 </nav>
 <div class="copyright">&copy; {{ config('lorekeeper.settings.site_name', 'Lorekeeper') }} v{{ config('lorekeeper.settings.version') }} {{ Carbon\Carbon::now()->year }}</div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -72,6 +72,7 @@
         <link href="{{ asset('css/custom.css') }}" rel="stylesheet">
     @endif
 
+    @include('feed::links')
 </head>
 <body>
     <div id="app">

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,8 @@ Auth::routes(['verify' => true]);
 # BROWSE
 require_once __DIR__.'/lorekeeper/browse.php';
 
+Route::feeds('feeds');
+
 /**************************************************************************************************
     Routes that require login
 **************************************************************************************************/
@@ -25,7 +27,7 @@ Route::group(['middleware' => ['auth', 'verified']], function() {
 
     # LINK DA ACCOUNT
     Route::get('/link', 'HomeController@getLink')->name('link');
-    
+
     Route::get('/auth/redirect/{driver}', 'HomeController@getAuthRedirect');
     Route::get('/auth/callback/{driver}', 'HomeController@getAuthCallback');
 


### PR DESCRIPTION
Folk in the server indicated interest as well, so putting this forward for inclusion. 
By default sets up for two feeds: one for news, one for sales, which should work automatically. Also adds links to them in the footer, but feed readers should be able to detect all feeds configured for a site regardless.

Tested locally; requires `composer update`.