### PR TITLE
Add flex-wrap to pagination to keep it from breaking mobile view.

### DIFF
--- a/public/css/lorekeeper.css
+++ b/public/css/lorekeeper.css
@@ -370,6 +370,10 @@ main > .row {
     cursor: not-allowed;
 }
 
+.pagination {
+    flex-wrap: wrap;
+}
+
 .spoiler {
     border: 1px solid rgba(0,0,0,0.1);
     border-radius: 5px;


### PR DESCRIPTION
Currently, if pagination gets too long it breaks the width of the mobile view. Adding flex-wrap to the pagination property in css fixes that!