### PR TITLE
feat(raffles): optional ticket cap per individual

### DIFF
--- a/app/Http/Controllers/Admin/RaffleController.php
+++ b/app/Http/Controllers/Admin/RaffleController.php
@@ -67,7 +67,7 @@ class RaffleController extends Controller
      */
     public function postCreateEditRaffle(Request $request, RaffleService $service, $id = null)
     {
-        $data = $request->only(['name', 'is_active', 'winner_count', 'group_id', 'order']);
+        $data = $request->only(['name', 'is_active', 'winner_count', 'group_id', 'order', 'ticket_cap']);
         $raffle = null;
         if (!$id) $raffle = $service->createRaffle($data);
         else if ($id) $raffle = $service->updateRaffle($data, Raffle::find($id));
@@ -77,10 +77,10 @@ class RaffleController extends Controller
         }
         else {
             flash('Couldn\'t create raffle.')->error();
-            return redirect()->back()->withInput();  
+            return redirect()->back()->withInput();
         }
     }
-    
+
     /**
      * Shows the create/edit raffle group modal.
      *
@@ -120,7 +120,7 @@ class RaffleController extends Controller
         }
         else {
             flash('Couldn\'t create raffle group.')->error();
-            return redirect()->back()->withInput();  
+            return redirect()->back()->withInput();
         }
     }
 
@@ -160,7 +160,7 @@ class RaffleController extends Controller
         }
         else {
             flash('Couldn\'t add tickets.')->error();
-            return redirect()->back()->withInput();  
+            return redirect()->back()->withInput();
         }
     }
 
@@ -180,7 +180,7 @@ class RaffleController extends Controller
         }
         else {
             flash('Couldn\'t remove ticket.')->error();
-            return redirect()->back()->withInput();  
+            return redirect()->back()->withInput();
         }
     }
 
@@ -215,7 +215,7 @@ class RaffleController extends Controller
         }
         else {
             flash('Error in rolling winners.')->error();
-            return redirect()->back()->withInput();  
+            return redirect()->back()->withInput();
         }
     }
 
@@ -250,7 +250,7 @@ class RaffleController extends Controller
         }
         else {
             flash('Error in rolling winners.')->error();
-            return redirect()->back()->withInput();  
+            return redirect()->back()->withInput();
         }
     }
 }

--- a/app/Models/Raffle/Raffle.php
+++ b/app/Models/Raffle/Raffle.php
@@ -11,7 +11,7 @@ class Raffle extends Model
      * @var array
      */
     protected $fillable = [
-        'name', 'is_active', 'winner_count', 'group_id', 'order'
+        'name', 'is_active', 'winner_count', 'group_id', 'order', 'ticket_cap'
     ];
 
     /**
@@ -40,14 +40,14 @@ class Raffle extends Model
      *
      * @var string
      */
-    public $timestamps = false; 
+    public $timestamps = false;
 
     /**********************************************************************************************
-    
+
         RELATIONS
 
     **********************************************************************************************/
-    
+
     /**
      * Get the raffle tickets attached to this raffle.
      */
@@ -55,7 +55,7 @@ class Raffle extends Model
     {
         return $this->hasMany('App\Models\Raffle\RaffleTicket');
     }
-    
+
     /**
      * Get the group that this raffle belongs to.
      */
@@ -65,7 +65,7 @@ class Raffle extends Model
     }
 
     /**********************************************************************************************
-    
+
         ACCESSORS
 
     **********************************************************************************************/
@@ -91,7 +91,7 @@ class Raffle extends Model
     }
 
     /**
-     * Gets the raffle's asset type for asset management. 
+     * Gets the raffle's asset type for asset management.
      *
      * @return string
      */
@@ -101,7 +101,7 @@ class Raffle extends Model
     }
 
     /**
-     * Gets the raffle's url. 
+     * Gets the raffle's url.
      *
      * @return string
      */
@@ -111,7 +111,7 @@ class Raffle extends Model
     }
 
     /**********************************************************************************************
-    
+
         OTHER FUNCTIONS
 
     **********************************************************************************************/

--- a/app/Services/RaffleManager.php
+++ b/app/Services/RaffleManager.php
@@ -8,7 +8,7 @@ use App\Models\Raffle\Raffle;
 use App\Models\Raffle\RaffleTicket;
 use App\Models\User\User;
 
-class RaffleManager extends Service 
+class RaffleManager extends Service
 {
     /*
     |--------------------------------------------------------------------------
@@ -20,7 +20,7 @@ class RaffleManager extends Service
     */
 
     /**
-     * Adds tickets to a raffle. 
+     * Adds tickets to a raffle.
      * One ticket is added per name in $names, which is a
      * string containing comma-separated names.
      *
@@ -58,6 +58,8 @@ class RaffleManager extends Service
         else if (!$raffle) return 0;
         else if ($count == 0) return 0;
         else if ($raffle->rolled_at != null) return 0;
+        else if ($raffle->ticket_cap > 0 && ((is_string($user) ? $raffle->tickets()->where('alias', $user)->count() : $raffle->tickets()->where('user_id', $user->id)->count()) > $raffle->ticket_cap || (is_string($user) ? $raffle->tickets()->where('alias', $user)->count() : $raffle->tickets()->where('user_id', $user->id)->count()) + $count > $raffle->ticket_cap)) return 0;
+
         else {
             DB::beginTransaction();
             $data = ["raffle_id" => $raffle->id, 'created_at' => Carbon::now()] + (is_string($user) ? ['alias' => $user] : ['user_id' => $user->id]);
@@ -99,7 +101,7 @@ class RaffleManager extends Service
         DB::beginTransaction();
         foreach($raffleGroup->raffles()->orderBy('order')->get() as $raffle)
         {
-            if (!$this->rollRaffle($raffle, $updateGroup)) 
+            if (!$this->rollRaffle($raffle, $updateGroup))
             {
                 DB::rollback();
                 return false;
@@ -120,7 +122,7 @@ class RaffleManager extends Service
      * @param  bool                      $updateGroup
      * @return bool
      */
-    public function rollRaffle($raffle, $updateGroup = false) 
+    public function rollRaffle($raffle, $updateGroup = false)
     {
         if(!$raffle) return null;
         DB::beginTransaction();
@@ -179,7 +181,7 @@ class RaffleManager extends Service
             // remove tickets for the same user...I'm unsure how this is going to hold up with 3000 tickets,
             foreach($ticketPool as $key=>$ticket)
             {
-                if(($ticket->user_id != null && $ticket->user_id == $winner->user_id) || ($ticket->user_id == null && $ticket->alias == $winner->alias)) 
+                if(($ticket->user_id != null && $ticket->user_id == $winner->user_id) || ($ticket->user_id == null && $ticket->alias == $winner->alias))
                 {
                     $ticketPool->forget($key);
                 }
@@ -205,8 +207,8 @@ class RaffleManager extends Service
         $raffles = $raffleGroup->raffles()->where('is_active', '!=', 2)->where('id', '!=', $raffle->id)->get();
         foreach($raffles as $r)
         {
-            $r->tickets()->where(function($query) use ($winners) { 
-                $query->whereIn('user_id', $winners['ids'])->orWhereIn('alias', $winners['aliases']); 
+            $r->tickets()->where(function($query) use ($winners) {
+                $query->whereIn('user_id', $winners['ids'])->orWhereIn('alias', $winners['aliases']);
             })->delete();
         }
         return true;

--- a/app/Services/RaffleService.php
+++ b/app/Services/RaffleService.php
@@ -8,7 +8,7 @@ use App\Services\Service;
 use App\Models\Raffle\RaffleGroup;
 use App\Models\Raffle\Raffle;
 
-class RaffleService  extends Service 
+class RaffleService  extends Service
 {
     /*
     |--------------------------------------------------------------------------
@@ -35,35 +35,35 @@ class RaffleService  extends Service
     }
 
     /**
-     * Updates a raffle. 
+     * Updates a raffle.
      *
      * @param  array                     $data
      * @param  \App\Models\Raffle\Raffle $raffle
      * @return \App\Models\Raffle\Raffle
      */
-    public function updateRaffle($data, $raffle) 
+    public function updateRaffle($data, $raffle)
     {
         DB::beginTransaction();
         if(!isset($data['is_active'])) $data['is_active'] = 0;
-        $raffle->update(Arr::only($data, ['name', 'is_active', 'winner_count', 'group_id', 'order']));
+        $raffle->update(Arr::only($data, ['name', 'is_active', 'winner_count', 'group_id', 'order', 'ticket_cap']));
         DB::commit();
         return $raffle;
-    }    
+    }
 
     /**
-     * Deletes a raffle. 
+     * Deletes a raffle.
      *
      * @param  \App\Models\Raffle\Raffle $raffle
      * @return bool
      */
-    public function deleteRaffle($raffle) 
+    public function deleteRaffle($raffle)
     {
         DB::beginTransaction();
         foreach($raffle->tickets as $ticket) $ticket->delete();
         $raffle->delete();
         DB::commit();
         return true;
-    }   
+    }
 
     /**
      * Creates a raffle group.
@@ -81,13 +81,13 @@ class RaffleService  extends Service
     }
 
     /**
-     * Updates a raffle group. 
+     * Updates a raffle group.
      *
      * @param  array                          $data
      * @param  \App\Models\Raffle\RaffleGroup $raffle
      * @return \App\Models\Raffle\Raffle
      */
-    public function updateRaffleGroup($data, $group) 
+    public function updateRaffleGroup($data, $group)
     {
         DB::beginTransaction();
         if(!isset($data['is_active'])) $data['is_active'] = 0;
@@ -95,20 +95,20 @@ class RaffleService  extends Service
         foreach($group->raffles as $raffle) $raffle->update(['is_active' => $data['is_active']]);
         DB::commit();
         return $group;
-    }  
+    }
 
     /**
-     * Deletes a raffle group. 
+     * Deletes a raffle group.
      *
      * @param  \App\Models\Raffle\RaffleGroup $raffle
      * @return bool
      */
-    public function deleteRaffleGroup($group) 
+    public function deleteRaffleGroup($group)
     {
         DB::beginTransaction();
         foreach($group->raffles as $raffle) $raffle->update(['group_id' => null]);
         $group->delete();
         DB::commit();
         return true;
-    }   
+    }
 }

--- a/database/migrations/2021_09_29_222559_add_ticket_cap_to_raffles.php
+++ b/database/migrations/2021_09_29_222559_add_ticket_cap_to_raffles.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddTicketCapToRaffles extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('raffles', function (Blueprint $table) {
+            //
+            $table->integer('ticket_cap')->nullable()->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('raffles', function (Blueprint $table) {
+            //
+            $table->dropColumn('ticket_cap');
+        });
+    }
+}

--- a/resources/views/admin/raffle/_raffle_create_edit.blade.php
+++ b/resources/views/admin/raffle/_raffle_create_edit.blade.php
@@ -21,6 +21,10 @@
         {!! Form::text('order', $raffle->order ? : 0, ['class' => 'form-control']) !!}
     </div>
     <div class="form-group">
+        {!! Form::label('ticket_cap', 'Ticket Cap (Optional)') !!} {!! add_help('A number of tickets per individual to cap at. Leave empty or unset to have no cap.') !!}
+        {!! Form::text('ticket_cap', $raffle->ticket_cap ? : null, ['class' => 'form-control']) !!}
+    </div>
+    <div class="form-group">
         <label class="control-label">
             {!! Form::checkbox('is_active', 1, $raffle->is_active, ['class' => 'form-check-input mr-2', 'data-toggle' => 'toggle']) !!}
             {!! Form::label('is_displayed', 'Active (visible to users)', ['class' => 'form-check-label ml-3']) !!}


### PR DESCRIPTION
As on the tin. If an attempt is made to give tickets to a user (including offsite, in the case of directly adding tickets) by any means that would place them over the cap, it will error. Error messaging can be a bit confusing, especially with boxes or other similar rewarded tickets, but there's not really a clean way around this without ripping up a bunch of stuff that doesn't really need that kind of trouble.

Tested locally, requires `php artisan migrate`.