### PR TITLE
refactor: move loot_select info fetching to views

### DIFF
--- a/app/Http/Controllers/Admin/Data/PromptController.php
+++ b/app/Http/Controllers/Admin/Data/PromptController.php
@@ -182,10 +182,6 @@ class PromptController extends Controller
         return view('admin.prompts.create_edit_prompt', [
             'prompt' => new Prompt,
             'categories' => ['none' => 'No category'] + PromptCategory::orderBy('sort', 'DESC')->pluck('name', 'id')->toArray(),
-            'items' => Item::orderBy('name')->pluck('name', 'id'),
-            'currencies' => Currency::where('is_user_owned', 1)->orderBy('name')->pluck('name', 'id'),
-            'tables' => LootTable::orderBy('name')->pluck('name', 'id'),
-            'raffles' => Raffle::where('rolled_at', null)->where('is_active', 1)->orderBy('name')->pluck('name', 'id'),
         ]);
     }
 
@@ -202,10 +198,6 @@ class PromptController extends Controller
         return view('admin.prompts.create_edit_prompt', [
             'prompt' => $prompt,
             'categories' => ['none' => 'No category'] + PromptCategory::orderBy('sort', 'DESC')->pluck('name', 'id')->toArray(),
-            'items' => Item::orderBy('name')->pluck('name', 'id'),
-            'currencies' => Currency::where('is_user_owned', 1)->orderBy('name')->pluck('name', 'id'),
-            'tables' => LootTable::orderBy('name')->pluck('name', 'id'),
-            'raffles' => Raffle::where('rolled_at', null)->where('is_active', 1)->orderBy('name')->pluck('name', 'id'),
         ]);
     }
 

--- a/app/Http/Controllers/Admin/SubmissionController.php
+++ b/app/Http/Controllers/Admin/SubmissionController.php
@@ -72,11 +72,6 @@ class SubmissionController extends Controller
             'page' => 'submission',
             'expanded_rewards' => Config::get('lorekeeper.extensions.character_reward_expansion.expanded'),
         ] + ($submission->status == 'Pending' ? [
-            'characterCurrencies' => Currency::where('is_character_owned', 1)->orderBy('sort_character', 'DESC')->pluck('name', 'id'),
-            'items' => Item::orderBy('name')->pluck('name', 'id'),
-            'currencies' => Currency::where('is_user_owned', 1)->orderBy('name')->pluck('name', 'id'),
-            'tables' => LootTable::orderBy('name')->pluck('name', 'id'),
-            'raffles' => Raffle::where('rolled_at', null)->where('is_active', 1)->orderBy('name')->pluck('name', 'id'),
             'count' => Submission::where('prompt_id', $submission->prompt_id)->where('status', 'Approved')->where('user_id', $submission->user_id)->count()
         ] : []));
     }
@@ -126,11 +121,6 @@ class SubmissionController extends Controller
             'itemsrow' => Item::all()->keyBy('id'),
             'expanded_rewards' => Config::get('lorekeeper.extensions.character_reward_expansion.expanded'),
         ] + ($submission->status == 'Pending' ? [
-            'characterCurrencies' => Currency::where('is_character_owned', 1)->orderBy('sort_character', 'DESC')->pluck('name', 'id'),
-            'items' => Item::orderBy('name')->pluck('name', 'id'),
-            'currencies' => Currency::where('is_user_owned', 1)->orderBy('name')->pluck('name', 'id'),
-            'tables' => LootTable::orderBy('name')->pluck('name', 'id'),
-            'raffles' => Raffle::where('rolled_at', null)->where('is_active', 1)->orderBy('name')->pluck('name', 'id'),
             'count' => Submission::where('prompt_id', $id)->where('status', 'Approved')->where('user_id', $submission->user_id)->count(),
             'rewardsData' => isset($submission->data['rewards']) ? parseAssetData($submission->data['rewards']) : null
         ] : []));

--- a/app/Services/Item/BoxService.php
+++ b/app/Services/Item/BoxService.php
@@ -29,13 +29,7 @@ class BoxService extends Service
      */
     public function getEditData()
     {
-        return [
-            'characterCurrencies' => Currency::where('is_character_owned', 1)->orderBy('sort_character', 'DESC')->pluck('name', 'id'),
-            'items' => Item::orderBy('name')->pluck('name', 'id'),
-            'currencies' => Currency::where('is_user_owned', 1)->orderBy('name')->pluck('name', 'id'),
-            'tables' => LootTable::orderBy('name')->pluck('name', 'id'),
-            'raffles' => Raffle::where('rolled_at', null)->where('is_active', 1)->orderBy('name')->pluck('name', 'id'),
-        ];
+        return [];
     }
 
     /**
@@ -79,8 +73,8 @@ class BoxService extends Service
         try {
             // If there's no data, return.
             if(!isset($data['rewardable_type'])) return true;
-            
-            // The data will be stored as an asset table, json_encode()d. 
+
+            // The data will be stored as an asset table, json_encode()d.
             // First build the asset table, then prepare it for storage.
             $assets = createAssetsArray();
             foreach($data['rewardable_type'] as $key => $r) {
@@ -107,7 +101,7 @@ class BoxService extends Service
             $tag->update(['data' => json_encode($assets)]);
 
             return $this->commitReturn(true);
-        } catch(\Exception $e) { 
+        } catch(\Exception $e) {
             $this->setError('error', $e->getMessage());
         }
         return $this->rollbackReturn(false);
@@ -129,12 +123,12 @@ class BoxService extends Service
         try {
             foreach($stacks as $key=>$stack) {
                 // We don't want to let anyone who isn't the owner of the box open it,
-                // so do some validation... 
+                // so do some validation...
                 if($stack->user_id != $user->id) throw new \Exception("This item does not belong to you.");
 
                 // Next, try to delete the box item. If successful, we can start distributing rewards.
                 if((new InventoryManager)->debitStack($stack->user, 'Box Opened', ['data' => ''], $stack, $data['quantities'][$key])) {
-                    
+
                     for($q=0; $q<$data['quantities'][$key]; $q++) {
                         // Distribute user rewards
                         if(!$rewards = fillUserAssets(parseAssetData($stack->item->tag('box')->data), $user, $user, 'Box Rewards', [
@@ -145,7 +139,7 @@ class BoxService extends Service
                 }
             }
             return $this->commitReturn(true);
-        } catch(\Exception $e) { 
+        } catch(\Exception $e) {
             $this->setError('error', $e->getMessage());
         }
         return $this->rollbackReturn(false);

--- a/resources/views/admin/items/tags/box_post.blade.php
+++ b/resources/views/admin/items/tags/box_post.blade.php
@@ -1,1 +1,1 @@
-@include('widgets._loot_select_row', ['items' => $items, 'currencies' => $currencies, 'showLootTables' => true, 'showRaffles' => true])
+@include('widgets._loot_select_row', ['showLootTables' => true, 'showRaffles' => true])

--- a/resources/views/admin/prompts/create_edit_prompt.blade.php
+++ b/resources/views/admin/prompts/create_edit_prompt.blade.php
@@ -108,7 +108,7 @@
 
 {!! Form::close() !!}
 
-@include('widgets._loot_select_row', ['items' => $items, 'currencies' => $currencies, 'tables' => $tables, 'raffles' => $raffles, 'showLootTables' => true, 'showRaffles' => true])
+@include('widgets._loot_select_row', ['showLootTables' => true, 'showRaffles' => true])
 
 @if($prompt->id)
     <h3>Preview</h3>
@@ -125,17 +125,17 @@
 @parent
 @include('js._loot_js', ['showLootTables' => true, 'showRaffles' => true])
 <script>
-$( document ).ready(function() {    
+$( document ).ready(function() {
     $('.delete-prompt-button').on('click', function(e) {
         e.preventDefault();
         loadModal("{{ url('admin/data/prompts/delete') }}/{{ $prompt->id }}", 'Delete Prompt');
     });
-    
+
     $( ".datepicker" ).datetimepicker({
         dateFormat: "yy-mm-dd",
         timeFormat: 'HH:mm:ss',
     });
 });
-    
+
 </script>
 @endsection

--- a/resources/views/admin/submissions/submission.blade.php
+++ b/resources/views/admin/submissions/submission.blade.php
@@ -198,7 +198,7 @@
             </tr>
         </table>
     </div>
-    @include('widgets._loot_select_row', ['items' => $items, 'currencies' => $currencies, 'showLootTables' => true, 'showRaffles' => true])
+    @include('widgets._loot_select_row', ['showLootTables' => true, 'showRaffles' => true])
 
     <div class="modal fade" id="confirmationModal" tabindex="-1" role="dialog">
         <div class="modal-dialog" role="document">

--- a/resources/views/home/create_submission.blade.php
+++ b/resources/views/home/create_submission.blade.php
@@ -82,9 +82,9 @@
 
     @include('widgets._character_select', ['characterCurrencies' => $characterCurrencies, 'showLootTables' => false])
     @if($isClaim)
-        @include('widgets._loot_select_row', ['items' => $items, 'currencies' => $currencies, 'showLootTables' => false, 'showRaffles' => true])
+        @include('widgets._loot_select_row', ['showLootTables' => false, 'showRaffles' => true])
     @else
-        @include('widgets._loot_select_row', ['items' => $items, 'currencies' => $currencies, 'showLootTables' => false, 'showRaffles' => false])
+        @include('widgets._loot_select_row', ['showLootTables' => false, 'showRaffles' => false])
     @endif
 
     <div class="modal fade" id="confirmationModal" tabindex="-1" role="dialog">

--- a/resources/views/home/submissions_closed.blade.php
+++ b/resources/views/home/submissions_closed.blade.php
@@ -25,11 +25,11 @@
         </div>
     @endif
     <div class="form-group">
-        {!! Form::label('url', $isClaim ? 'URL' : 'Submission URL') !!} 
-        @if($isClaim) 
-            {!! add_help('Enter a URL relevant to your claim (for example, a comment proving you may make this claim). This field cannot be left blank.') !!} 
-        @else 
-            {!! add_help('Enter the URL of your submission (whether uploaded to dA or some other hosting service). This field cannot be left blank.') !!} 
+        {!! Form::label('url', $isClaim ? 'URL' : 'Submission URL') !!}
+        @if($isClaim)
+            {!! add_help('Enter a URL relevant to your claim (for example, a comment proving you may make this claim). This field cannot be left blank.') !!}
+        @else
+            {!! add_help('Enter the URL of your submission (whether uploaded to dA or some other hosting service). This field cannot be left blank.') !!}
         @endif
         {!! Form::text('url', null, ['class' => 'form-control', 'required']) !!}
     </div>
@@ -41,7 +41,7 @@
     <h2>Rewards</h2>
     @if($isClaim)
         <p>Select the rewards you would like to claim.</p>
-    @else 
+    @else
         <p>Note that any rewards added here are <u>in addition</u> to the default prompt rewards. If you do not require any additional rewards, you can leave this blank.</p>
     @endif
     @include('widgets._loot_select', ['loots' => null, 'showLootTables' => false])
@@ -64,8 +64,8 @@
     </div>
 {!! Form::close() !!}
 
-@include('widgets._character_select', ['characterCurrencies' => $characterCurrencies])
-@include('widgets._loot_select_row', ['items' => $items, 'currencies' => $currencies, 'showLootTables' => false])
+@include('widgets._character_select', ['characterCurrencies' => \App\Models\Currency\Currency::where('is_character_owned', 1)->orderBy('sort_character', 'DESC')->pluck('name', 'id')])
+@include('widgets._loot_select_row', ['showLootTables' => false])
 
 
 <div class="modal fade" id="confirmationModal" tabindex="-1" role="dialog">

--- a/resources/views/widgets/_loot_select.blade.php
+++ b/resources/views/widgets/_loot_select.blade.php
@@ -1,3 +1,16 @@
+@php
+    // This file represents a common source and definition for assets used in loot_select
+    // While it is not per se as tidy as defining these in the controller(s),
+    // doing so this way enables better compatibility across disparate extensions
+    $characterCurrencies = \App\Models\Currency\Currency::where('is_character_owned', 1)->orderBy('sort_character', 'DESC')->pluck('name', 'id');
+    $items = \App\Models\Item\Item::orderBy('name')->pluck('name', 'id');
+    $currencies = \App\Models\Currency\Currency::where('is_user_owned', 1)->orderBy('name')->pluck('name', 'id');
+    if($showLootTables)
+        $tables = \App\Models\Loot\LootTable::orderBy('name')->pluck('name', 'id');
+    if($showRaffles)
+        $raffles = \App\Models\Raffle\Raffle::where('rolled_at', null)->where('is_active', 1)->orderBy('name')->pluck('name', 'id');
+@endphp
+
 <div class="text-right mb-3">
     <a href="#" class="btn btn-outline-info" id="addLoot">Add Reward</a>
 </div>

--- a/resources/views/widgets/_loot_select_row.blade.php
+++ b/resources/views/widgets/_loot_select_row.blade.php
@@ -1,3 +1,16 @@
+@php
+    // This file represents a common source and definition for assets used in loot_select
+    // While it is not per se as tidy as defining these in the controller(s),
+    // doing so this way enables better compatibility across disparate extensions
+    $characterCurrencies = \App\Models\Currency\Currency::where('is_character_owned', 1)->orderBy('sort_character', 'DESC')->pluck('name', 'id');
+    $items = \App\Models\Item\Item::orderBy('name')->pluck('name', 'id');
+    $currencies = \App\Models\Currency\Currency::where('is_user_owned', 1)->orderBy('name')->pluck('name', 'id');
+    if($showLootTables)
+        $tables = \App\Models\Loot\LootTable::orderBy('name')->pluck('name', 'id');
+    if($showRaffles)
+        $raffles = \App\Models\Raffle\Raffle::where('rolled_at', null)->where('is_active', 1)->orderBy('name')->pluck('name', 'id');
+@endphp
+
 <div id="lootRowData" class="hide">
     <table class="table table-sm">
         <tbody id="lootRow">


### PR DESCRIPTION
- this is in the name of compatibility between different exts
- and to reduce support time demanded by issues with that

Going forward, ext authors can merely add support for a new entity to the `_loot_select` and `_loot _select_row` views... It's a "messy" fix but I think it's worthwhile.

Tested locally, no further action required.
