### PR TITLE
add queries/sorting to Sales

### DIFF
--- a/app/Http/Controllers/SalesController.php
+++ b/app/Http/Controllers/SalesController.php
@@ -28,7 +28,42 @@ class SalesController extends Controller
     public function getIndex()
     {
         if(Auth::check() && Auth::user()->is_sales_unread) Auth::user()->update(['is_sales_unread' => 0]);
-        return view('sales.index', ['saleses' => Sales::visible()->orderBy('id', 'DESC')->paginate(10)]);
+        
+        $query = Sales::visible();
+        $data = $request->only(['title', 'is_open', 'sort']);
+        if(isset($data['is_open']) && $data['is_open'] != 'none') 
+            $query->where('is_open', $data['is_open']);
+        if(isset($data['title'])) 
+            $query->where('title', 'LIKE', '%'.$data['title'].'%');
+
+        if(isset($data['sort'])) 
+        {
+            switch($data['sort']) {
+                case 'alpha':
+                    $query->sortAlphabetical();
+                    break;
+                case 'alpha-reverse':
+                    $query->sortAlphabetical(true);
+                    break;
+                case 'newest':
+                    $query->sortNewest();
+                    break;
+                case 'oldest':
+                    $query->sortOldest();
+                    break;
+                case 'bump':
+                    $query->sortBump();
+                    break;
+                case 'bump-reverse':
+                    $query->sortBump(true);
+                    break;
+            }
+        } 
+        else $query->sortBump();
+
+        return view('sales.index', [
+            'saleses' => $query->paginate(10)->appends($request->query()),
+        ]);
     }
 
     /**

--- a/app/Models/Sales/Sales.php
+++ b/app/Models/Sales/Sales.php
@@ -98,7 +98,7 @@ class Sales extends Model
      */
     public function scopeVisible($query)
     {
-        return $query->orderBy('updated_at', 'DESC')->where('is_visible', 1);
+        return $query->where('is_visible', 1);
     }
 
     /**
@@ -110,6 +110,53 @@ class Sales extends Model
     public function scopeShouldBeVisible($query)
     {
         return $query->whereNotNull('post_at')->where('post_at', '<', Carbon::now())->where('is_visible', 0);
+    }
+
+    
+    /**
+     * Scope a query to sort sales in alphabetical order.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  bool                                   $reverse
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeSortAlphabetical($query, $reverse = false)
+    {
+        return $query->orderBy('title', $reverse ? 'DESC' : 'ASC');
+    }
+
+    /**
+     * Scope a query to sort sales by newest first.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeSortNewest($query)
+    {
+        return $query->orderBy('id', 'DESC');
+    }
+
+    /**
+     * Scope a query to sort sales oldest first.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeSortOldest($query)
+    {
+        return $query->orderBy('id');
+    }
+
+    /**
+     * Scope a query to sort sales by bump date.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  bool                                   $reverse
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeSortBump($query, $reverse = false)
+    {
+        return $query->orderBy('updated_at', $reverse ? 'DESC' : 'ASC');
     }
 
     /**********************************************************************************************

--- a/resources/views/sales/index.blade.php
+++ b/resources/views/sales/index.blade.php
@@ -5,6 +5,35 @@
 @section('content')
 {!! breadcrumbs(['Site Sales' => 'sales']) !!}
 <h1>Site Sales</h1>
+
+<div>
+    {!! Form::open(['method' => 'GET', 'class' => '']) !!}
+        <div class="form-inline justify-content-end">
+            <div class="form-group ml-3 mb-3">
+                {!! Form::text('title', Request::get('title'), ['class' => 'form-control', 'placeholder' => 'Name']) !!}
+            </div>
+            <div class="form-group ml-3 mb-3">
+                {!! Form::select('is_open', ['1' => 'Open', '0' => 'Closed'], Request::get('is_open'), ['class' => 'form-control', 'placeholder' => 'Status']) !!}
+            </div>
+        </div>
+        <div class="form-inline justify-content-end">
+            <div class="form-group ml-3 mb-3">
+                {!! Form::select('sort', [
+                    'bump-reverse'    => 'Updated Newest',
+                    'bump'            => 'Updated Oldest',
+                    'newest'         => 'Created Newest',
+                    'oldest'         => 'Created Oldest',
+                    'alpha'          => 'Sort Alphabetically (A-Z)',
+                    'alpha-reverse'  => 'Sort Alphabetically (Z-A)'
+                ], Request::get('sort') ? : 'Updated First', ['class' => 'form-control']) !!}
+            </div>
+            <div class="form-group ml-3 mb-3">
+                {!! Form::submit('Search', ['class' => 'btn btn-primary']) !!}
+            </div>
+        </div>
+    {!! Form::close() !!}
+</div>
+
 @if(count($saleses))
     {!! $saleses->render() !!}
     @foreach($saleses as $sales)


### PR DESCRIPTION
Add queries/sorting to sales, allowing to filter by title, by open/closed status, and to order by bump date, post date, or title.