### PR TITLE
Fix for inventory select visible button

### DIFF
--- a/resources/views/widgets/_inventory_select_js.blade.php
+++ b/resources/views/widgets/_inventory_select_js.blade.php
@@ -53,15 +53,14 @@
         }
         function selectVisible() {
             var $target = $('.user-item:not(.hide)');
-            $target.addClass('category-selected');
             $target.find('.inventory-checkbox').prop('checked', true);
+            $target.find('.inventory-checkbox').trigger('change');
             $('#toggle-checks').prop('checked', true);
-            $target.find('.quantity-select').prop('name', 'stack_quantity[]');
         }
         function deselectVisible() {
             var $target = $('.user-item:not(.hide)');
-            $target.removeClass('category-selected');
             $target.find('.inventory-checkbox').prop('checked', false);
+            $target.find('.inventory-checkbox').trigger('change');
             $('#toggle-checks').prop('checked', false);
             $target.find('.quantity-select').prop('name', '');
         }


### PR DESCRIPTION
Fixes #185 

I changed the way stack_quantity was accessed, but didn't update the js for the button to use this new method, resulting in the bug.

Tested locally.