### PR TITLE
Minor fixes and updates

### DIFF
--- a/app/Http/Controllers/SalesController.php
+++ b/app/Http/Controllers/SalesController.php
@@ -25,7 +25,7 @@ class SalesController extends Controller
      *
      * @return \Illuminate\Contracts\Support\Renderable
      */
-    public function getIndex()
+    public function getIndex(Request $request)
     {
         if(Auth::check() && Auth::user()->is_sales_unread) Auth::user()->update(['is_sales_unread' => 0]);
         return view('sales.index', ['saleses' => Sales::visible()->orderBy('id', 'DESC')->paginate(10)]);

--- a/app/Http/Controllers/Users/InventoryController.php
+++ b/app/Http/Controllers/Users/InventoryController.php
@@ -173,7 +173,7 @@ class InventoryController extends Controller
     }
 
     /**
-     * Transfers inventory items to another user.
+     * Transfers inventory items to a character.
      *
      * @param  \Illuminate\Http\Request       $request
      * @param  App\Services\InventoryManager  $service

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -92,7 +92,7 @@ class Comment extends Model
     }
 
     /**
-     * Gets / Creates permalink for comments - allows user to go directly to comment
+     * Gets / Creates permalink for comments - allows user to go directly to comment.
      *
      * @return string
      */
@@ -102,7 +102,7 @@ class Comment extends Model
     }
 
     /**
-     * Gets top comment
+     * Gets top comment.
      *
      * @return string
      */

--- a/app/Services/SubmissionManager.php
+++ b/app/Services/SubmissionManager.php
@@ -34,6 +34,16 @@ class SubmissionManager extends Service
     */
 
     /**
+     * Helper function to remove all empty/zero/falsey values.
+     *
+     * @param  array $value
+     * @return array
+     */
+    private function innerNull($value){
+        return array_values(array_filter($value));
+    }
+
+    /**
      * Creates a new submission.
      *
      * @param  array                  $data
@@ -177,10 +187,6 @@ class SubmissionManager extends Service
             $this->setError('error', $e->getMessage());
         }
         return $this->rollbackReturn(false);
-    }
-
-    private function innerNull($value){
-        return array_values(array_filter($value));
     }
 
     /**

--- a/resources/views/admin/reports/report.blade.php
+++ b/resources/views/admin/reports/report.blade.php
@@ -7,15 +7,15 @@
 
 @if($report->status !== 'Closed')
     @if($report->status == 'Assigned' && auth::user()->id !== $report->staff_id)
-    <div class="alert alert-danger">This report is not assigned to you</div>
+        <div class="alert alert-danger">This report is not assigned to you.</div>
     @elseif($report->status == 'Pending')
-    <div class="alert alert-warning">This report needs assigning</div>
+        <div class="alert alert-warning">This report needs assigning.</div>
     @endif
+
     <h1>
         Report (#{{ $report->id }})
         <span class="float-right badge badge-{{ $report->status == 'Pending' ? 'secondary' : ($report->status == 'Closed' ? 'success' : 'danger') }}">{{ $report->status }}</span>
     </h1>
-
     <div class="mb-1">
         <div class="row">
             <div class="col-md-2 col-4"><h5>User</h5></div>
@@ -40,39 +40,44 @@
             <div class="col-md-10 col-8">@if($report->staff != NULL) {!! $report->staff->displayName !!} @endif</div>
         </div>
     </div>
+
     <h2>Report Details</h2>
     <div class="card mb-3"><div class="card-body">{!! nl2br(htmlentities($report->comments)) !!}</div></div>
     @if(Auth::check() && $report->staff_comments && ($report->user_id == Auth::user()->id || Auth::user()->hasPower('manage_reports')))
         <h2>Staff Comments ({!! $report->staff->displayName !!})</h2>
-        <div class="card mb-3"><div class="card-body">
-		    @if(isset($report->parsed_staff_comments))
-                {!! $report->parsed_staff_comments !!}
-            @else
-                {!! $report->staff_comments !!}
-            @endif
-		</div></div>
+        <div class="card mb-3">
+            <div class="card-body">
+                @if(isset($report->parsed_staff_comments))
+                    {!! $report->parsed_staff_comments !!}
+                @else
+                    {!! $report->staff_comments !!}
+                @endif
+		    </div>
+        </div>
     @endif
     
     @if($report->status == 'Assigned' && $report->user_id == Auth::user()->id || Auth::user()->hasPower('manage_reports'))
-    @comments([ 'model' => $report, 'perPage' => 5 ])
+        @comments([ 'model' => $report, 'perPage' => 5 ])
     @endif
     
     {!! Form::open(['url' => url()->current(), 'id' => 'reportForm']) !!}
-    @if($report->status == 'Assigned' && auth::user()->id == $report->staff_id)
-    @if(Auth::user()->hasPower('manage_reports'))<div class="alert alert-warning">Please include a small paragraph on the solution and as many important details as you deem necessary, as the user will no longer be able to view the comments after the report is closed</div>@endif
-		<div class="form-group">
-            {!! Form::label('staff_comments', 'Staff Comments (Optional)') !!}
-			{!! Form::textarea('staff_comments', $report->staffComments, ['class' => 'form-control wysiwyg']) !!}
-        </div>
-    @endif
+        @if($report->status == 'Assigned' && auth::user()->id == $report->staff_id)
+            @if(Auth::user()->hasPower('manage_reports'))
+                <div class="alert alert-warning">Please include a small paragraph on the solution and as many important details as you deem necessary, as the user will no longer be able to view the comments after the report is closed.</div>
+            @endif
+            <div class="form-group">
+                {!! Form::label('staff_comments', 'Staff Comments (Optional)') !!}
+                {!! Form::textarea('staff_comments', $report->staffComments, ['class' => 'form-control wysiwyg']) !!}
+            </div>
+        @endif
         <div class="text-right">
-    @if($report->staff_id == NULL)
-            <a href="#" class="btn btn-danger mr-2" id="assignButton">Assign</a>
-    @endif
-    @if($report->status == 'Assigned' && auth::user()->id == $report->staff_id)
-            <a href="#" class="btn btn-success" id="closalButton">Close</a>
+            @if($report->staff_id == NULL)
+                <a href="#" class="btn btn-danger mr-2" id="assignButton">Assign</a>
+            @endif
+            @if($report->status == 'Assigned' && auth::user()->id == $report->staff_id)
+                <a href="#" class="btn btn-success" id="closalButton">Close</a>
+            @endif
         </div>
-    @endif
     {!! Form::close() !!}
 
     <div class="modal fade" id="confirmationModal" tabindex="-1" role="dialog">
@@ -114,7 +119,6 @@
 @parent 
 @if($report->status !== 'Closed')
     <script>
-        
         $(document).ready(function() {
             var $confirmationModal = $('#confirmationModal');
             var $reportForm = $('#reportForm');

--- a/resources/views/comments/_comment.blade.php
+++ b/resources/views/comments/_comment.blade.php
@@ -3,54 +3,64 @@
     $markdown->setSafeMode(true);
 @endphp
 
-@if(isset($reply) && $reply === true)
-  <div id="comment-{{ $comment->getKey() }}" class="comment_replies border-left col-12 column mw-100 pr-0 pt-4" style="flex-basis: 100%;">
-@else
-  <div id="comment-{{ $comment->getKey() }}"  class="pt-4" style="flex-basis: 100%;">
-@endif
+<div id="comment-{{ $comment->getKey() }}"  class="{{ (isset($reply) && $reply === true) ? 'comment_replies border-left col-12 column mw-100 pr-0 ' : '' }}pt-4" style="flex-basis: 100%;">
+
     <div class="media-body row mw-100 mx-0" style="flex:1;flex-wrap:wrap;">
+        {{-- Show avatar if not compact --}}
         @if(isset($compact) && !$compact)
-        <div class="d-none d-md-block">
-            <img class="mr-3 mt-2" src="/images/avatars/{{ $comment->commenter->avatar }}" style="width:70px; height:70px; border-radius:50%;" alt="{{ $comment->commenter->name }} Avatar">
-        </div>
+            <div class="d-none d-md-block">
+                <img class="mr-3 mt-2" src="/images/avatars/{{ $comment->commenter->avatar }}" style="width:70px; height:70px; border-radius:50%;" alt="{{ $comment->commenter->name }} Avatar">
+            </div>
         @endif
+
+        {{-- Main comment block --}}
         <div class="d-block" style="flex:1">
+
+            {{-- Comment block header --}}
             <div class="row mx-0 px-0 align-items-md-end">
                 <h5 class="mt-0 mb-1 col mx-0 px-0">
                     {!! $comment->commenter->commentDisplayName !!} @if($comment->commenter->isStaff == true)<small class="text-success">Staff Member</small>@endif
                 </h5>
-                @if($comment->is_featured)<div class="ml-1 text-muted text-right col-6 mx-0 pr-1"><small class="text-success">Featured by Owner</small></div> @endif
+                @if($comment->is_featured)
+                    <div class="ml-1 text-muted text-right col-6 mx-0 pr-1"><small class="text-success">Featured by Owner</small></div> 
+                @endif
             </div>
-            <div class="border p-3 rounded {{ $comment->is_featured ? 'border-success bg-light' : '' }} "><p>{!! nl2br($markdown->line($comment->comment)) !!} </p>
-            <p class="border-top pt-1 text-right mb-0">
-                <small class="text-muted">{!! $comment->created_at !!}
-                @if($comment->created_at != $comment->updated_at) 
-                    <span class="text-muted border-left mx-1 px-1">(Edited {!! ($comment->updated_at) !!})</span>
-                @endif
-                </small>
-                @if($comment->type == "User-User")
-                    <a href="{{ url('comment/').'/'.$comment->id }}"><i class="fas fa-link ml-1" style="opacity: 50%;"></i></a>
-                @endif
-                <a href="{{ url('reports/new?url=') . $comment->url }}"><i class="fas fa-exclamation-triangle" data-toggle="tooltip" title="Click here to report this comment." style="opacity: 50%;"></i></a>
-            </p>
-        </div>
-        @if(Auth::check())
-            <div class="my-1">
-                @can('reply-to-comment', $comment)
-                    <button data-toggle="modal" data-target="#reply-modal-{{ $comment->getKey() }}" class="btn btn-sm px-3 py-2 px-sm-2 py-sm-1  btn-faded text-uppercase"><i class="fas fa-comment"></i><span class="ml-2 d-none d-sm-inline-block">Reply</span></button>
-                @endcan
-                @can('edit-comment', $comment)
-                    <button data-toggle="modal" data-target="#comment-modal-{{ $comment->getKey() }}" class="btn btn-sm px-3 py-2 px-sm-2 py-sm-1  btn-faded text-uppercase"><i class="fas fa-edit"></i><span class="ml-2 d-none d-sm-inline-block">Edit</span></button>
-                @endcan
-                @if(((Auth::user()->id == $comment->commentable_id) || Auth::user()->isStaff) && (isset($compact) && !$compact))
-                    <button data-toggle="modal" data-target="#feature-modal-{{ $comment->getKey() }}" class="btn btn-sm px-3 py-2 px-sm-2 py-sm-1  btn-faded text-success text-uppercase"><i class="fas fa-star"></i><span class="ml-2 d-none d-sm-inline-block">{{$comment->is_featured ? 'Unf' : 'F' }}eature Comment</span></button>
-                @endif
-                @can('delete-comment', $comment)
-                    <button data-toggle="modal" data-target="#delete-modal-{{ $comment->getKey() }}" class="btn btn-sm px-3 py-2 px-sm-2 py-sm-1 btn-outline-danger text-uppercase"><i class="fas fa-minus-circle"></i><span class="ml-2 d-none d-sm-inline-block">Delete</span></button>
-                @endcan
+
+            {{-- Comment --}}
+            <div class="border p-3 rounded {{ $comment->is_featured ? 'border-success bg-light' : '' }} ">
+                <p>{!! nl2br($markdown->line($comment->comment)) !!} </p>
+                <p class="border-top pt-1 text-right mb-0">
+                    <small class="text-muted">{!! $comment->created_at !!}
+                        @if($comment->created_at != $comment->updated_at) 
+                            <span class="text-muted border-left mx-1 px-1">(Edited {!! ($comment->updated_at) !!})</span>
+                        @endif
+                    </small>
+                    @if($comment->type == "User-User")
+                        <a href="{{ url('comment/').'/'.$comment->id }}"><i class="fas fa-link ml-1" style="opacity: 50%;"></i></a>
+                    @endif
+                    <a href="{{ url('reports/new?url=') . $comment->url }}"><i class="fas fa-exclamation-triangle" data-toggle="tooltip" title="Click here to report this comment." style="opacity: 50%;"></i></a>
+                </p>
             </div>
-        @endif
-        
+
+            {{-- Action buttons --}}
+            @if(Auth::check())
+                <div class="my-1">
+                    @can('reply-to-comment', $comment)
+                        <button data-toggle="modal" data-target="#reply-modal-{{ $comment->getKey() }}" class="btn btn-sm px-3 py-2 px-sm-2 py-sm-1  btn-faded text-uppercase"><i class="fas fa-comment"></i><span class="ml-2 d-none d-sm-inline-block">Reply</span></button>
+                    @endcan
+                    @can('edit-comment', $comment)
+                        <button data-toggle="modal" data-target="#comment-modal-{{ $comment->getKey() }}" class="btn btn-sm px-3 py-2 px-sm-2 py-sm-1  btn-faded text-uppercase"><i class="fas fa-edit"></i><span class="ml-2 d-none d-sm-inline-block">Edit</span></button>
+                    @endcan
+                    @if(((Auth::user()->id == $comment->commentable_id) || Auth::user()->isStaff) && (isset($compact) && !$compact))
+                        <button data-toggle="modal" data-target="#feature-modal-{{ $comment->getKey() }}" class="btn btn-sm px-3 py-2 px-sm-2 py-sm-1  btn-faded text-success text-uppercase"><i class="fas fa-star"></i><span class="ml-2 d-none d-sm-inline-block">{{$comment->is_featured ? 'Unf' : 'F' }}eature Comment</span></button>
+                    @endif
+                    @can('delete-comment', $comment)
+                        <button data-toggle="modal" data-target="#delete-modal-{{ $comment->getKey() }}" class="btn btn-sm px-3 py-2 px-sm-2 py-sm-1 btn-outline-danger text-uppercase"><i class="fas fa-minus-circle"></i><span class="ml-2 d-none d-sm-inline-block">Delete</span></button>
+                    @endcan
+                </div>
+            @endif
+            
+            {{-- Modals --}}
             @can('edit-comment', $comment)
                 <div class="modal fade" id="comment-modal-{{ $comment->getKey() }}" tabindex="-1" role="dialog">
                     <div class="modal-dialog" role="document">
@@ -61,7 +71,7 @@
                                 <div class="modal-header">
                                     <h5 class="modal-title">Edit Comment</h5>
                                     <button type="button" class="close" data-dismiss="modal">
-                                    <span>&times;</span>
+                                        <span>&times;</span>
                                     </button>
                                 </div>
                                 <div class="modal-body">
@@ -90,7 +100,7 @@
                                 <div class="modal-header">
                                     <h5 class="modal-title">Reply to Comment</h5>
                                     <button type="button" class="close" data-dismiss="modal">
-                                    <span>&times;</span>
+                                        <span>&times;</span>
                                     </button>
                                 </div>
                                 <div class="modal-body">
@@ -118,16 +128,22 @@
                                 <h5 class="modal-title">Delete Comment</h5>
                                 <button type="button" class="close" data-dismiss="modal">
                                     <span>&times;</span>
-                                    </button>
-                                        </div>
-                                <div class="modal-body">
-                                    <div class="form-group">Are you sure you want to delete this comment?</div></div>
-                                    <div class="alert alert-warning"><strong>Comments can be restored in the database.</strong> <br> Deleting a comment does not delete the comment record.</div>
+                                </button>
+                            </div>
+                            <div class="modal-body">
+                                <div class="form-group">Are you sure you want to delete this comment?</div>
+                                <div class="alert alert-warning">
+                                    <strong>Comments can be restored in the database.</strong> 
+                                    <br> Deleting a comment does not delete the comment record.
+                                </div>
+                                <div class="text-right">
                                     <a href="{{ route('comments.destroy', $comment->getKey()) }}" onclick="event.preventDefault();document.getElementById('comment-delete-form-{{ $comment->getKey() }}').submit();" class="btn btn-danger text-uppercase">Delete</a>
-                            <form id="comment-delete-form-{{ $comment->getKey() }}" action="{{ route('comments.destroy', $comment->getKey()) }}" method="POST" style="display: none;">
-                                @method('DELETE')
-                                @csrf
-                            </form>
+                                    <form id="comment-delete-form-{{ $comment->getKey() }}" action="{{ route('comments.destroy', $comment->getKey()) }}" method="POST" style="display: none;">
+                                        @method('DELETE')
+                                        @csrf
+                                    </form>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -139,7 +155,7 @@
                         <div class="modal-header">
                             <h5 class="modal-title">{{ $comment->is_featured ? 'Unf' : 'F' }}eature Comment</h5>
                             <button type="button" class="close" data-dismiss="modal">
-                            <span>&times;</span>
+                                <span>&times;</span>
                             </button>
                         </div>
                         <div class="modal-body">
@@ -154,30 +170,26 @@
                     </div>
                 </div>
             </div>
-
-            
         </div>
 
-            <br /><br />{{-- Margin bottom --}}
-            {{-- Recursion for children --}}
-            <div class="w-100 mw-100">
-                @if($grouped_comments->has($comment->getKey()))
-                    @foreach($grouped_comments[$comment->getKey()] as $child)
-                        @php $limit++; @endphp
+        {{-- Recursion for children --}}
+        <div class="mt-3 w-100 mw-100">
+            @if($grouped_comments->has($comment->getKey()))
+                @foreach($grouped_comments[$comment->getKey()] as $child)
+                    @php $limit++; @endphp
 
-                        @if($limit >= 3) 
-                            <a href="{{ url('comment/').'/'.$comment->id }}"><span class="btn btn-secondary w-100 my-2">See More Replies</span></a>
-                            @break
-                        @endif
+                    @if($limit >= 3) 
+                        <a href="{{ url('comment/').'/'.$comment->id }}"><span class="btn btn-secondary w-100 my-2">See More Replies</span></a>
+                        @break
+                    @endif
 
-                        @include('comments::_comment', [
-                            'comment' => $child,
-                            'reply' => true,
-                            'grouped_comments' => $grouped_comments
-                        ])
-                    @endforeach
-                @endif
-            </div>
-
+                    @include('comments::_comment', [
+                        'comment' => $child,
+                        'reply' => true,
+                        'grouped_comments' => $grouped_comments
+                    ])
+                @endforeach
+            @endif
+        </div>
     </div>
-  </div>
+</div>

--- a/resources/views/comments/_form.blade.php
+++ b/resources/views/comments/_form.blade.php
@@ -1,4 +1,4 @@
-<div class="card">
+<div class="card mt-3">
     <div class="card-body">
         @if($errors->has('commentable_type'))
             <div class="alert alert-danger" role="alert">

--- a/resources/views/comments/comments.blade.php
+++ b/resources/views/comments/comments.blade.php
@@ -8,12 +8,8 @@
     }
 @endphp
 
-@if($comments->count() < 1)
-    <div class="alert alert-warning">There are no comments yet.</div>
-@endif
-
 @if(!isset($type) || $type == "User-User")
-<h2>Comments</h2>
+    <h2>Comments</h2>
 @endif
 <div class="d-flex mw-100 row mx-0" style="overflow:hidden;">
     @php
@@ -60,15 +56,18 @@
     @endforeach
 </div>
 
+@if($comments->count() < 1)
+    <div class="alert alert-warning">There are no comments yet.</div>
+@endif
+
 @isset ($perPage)
-    {{ $grouped_comments->links() }}
+    <div class="ml-auto mt-2">{{ $grouped_comments->links() }}</div>
 @endisset
 
-<br><br><br>
 @auth
     @include('comments._form')
 @else
-    <div class="card">
+    <div class="card mt-3">
         <div class="card-body">
             <h5 class="card-title">Authentication required</h5>
             <p class="card-text">You must log in to post a comment.</p>

--- a/resources/views/home/_inventory_stack.blade.php
+++ b/resources/views/home/_inventory_stack.blade.php
@@ -21,111 +21,111 @@
     @endif
 
     {!! Form::open(['url' => 'inventory/edit']) !!}
-    <div class="card" style="border: 0px">
-        <table class="table table-sm">
-            <thead class="thead">
-                <tr class="d-flex">
-                    @if($user && !$readOnly && ($stack->first()->user_id == $user->id || $user->hasPower('edit_inventories')))
-                        <th class="col-1"><input id="toggle-checks" type="checkbox" onclick="toggleChecks(this)"></th>
-                        <th class="col-4">Source</th>
-                    @else
-                        <th class="col-5">Source</th>
-                    @endif
-                    <th class="col-3">Notes</th>
-                    <th class="col-3">Quantity</th>
-                    <th class="col-1"><i class="fas fa-lock invisible"></i></th>
-                </tr>
-            </thead>
-            <tbody>
-                @foreach($stack as $itemRow)
-                    <tr id ="itemRow{{ $itemRow->id }}" class="d-flex {{ $itemRow->isTransferrable ? '' : 'accountbound' }}">
+        <div class="card" style="border: 0px">
+            <table class="table table-sm">
+                <thead class="thead">
+                    <tr class="d-flex">
                         @if($user && !$readOnly && ($stack->first()->user_id == $user->id || $user->hasPower('edit_inventories')))
-                            <td class="col-1">{!! Form::checkbox('ids[]', $itemRow->id, false, ['class' => 'item-check', 'onclick' => 'updateQuantities(this)']) !!}</td>
-                            <td class="col-4">{!! array_key_exists('data', $itemRow->data) ? ($itemRow->data['data'] ? $itemRow->data['data'] : 'N/A') : 'N/A' !!}</td>
+                            <th class="col-1"><input id="toggle-checks" type="checkbox" onclick="toggleChecks(this)"></th>
+                            <th class="col-4">Source</th>
                         @else
-                            <td class="col-5">{!! array_key_exists('data', $itemRow->data) ? ($itemRow->data['data'] ? $itemRow->data['data'] : 'N/A') : 'N/A' !!}</td>
+                            <th class="col-5">Source</th>
                         @endif
-                        <td class="col-3">{!! array_key_exists('notes', $itemRow->data) ? ($itemRow->data['notes'] ? $itemRow->data['notes'] : 'N/A') : 'N/A' !!}</td>
-                        @if($user && !$readOnly && ($stack->first()->user_id == $user->id || $user->hasPower('edit_inventories')))
-                            @if($itemRow->availableQuantity)
-                                <td class="col-3">{!! Form::selectRange('', 1, $itemRow->availableQuantity, 1, ['class' => 'quantity-select', 'type' => 'number', 'style' => 'min-width:40px;']) !!} /{{ $itemRow->availableQuantity }} @if($itemRow->getOthers()) {{ $itemRow->getOthers() }} @endif</td>
-                            @else
-                                <td class="col-3">{!! Form::selectRange('', 0, 0, 0, ['class' => 'quantity-select', 'type' => 'number', 'style' => 'min-width:40px;', 'disabled']) !!} /{{ $itemRow->availableQuantity }} @if($itemRow->getOthers()) {{ $itemRow->getOthers() }} @endif</td>
-                            @endif
-                        @else
-                            <td class="col-3">{!! $itemRow->count !!}</td>
-                        @endif
-                        <td class="col-1">
-                            @if(!$itemRow->isTransferrable)
-                                <i class="fas fa-lock" data-toggle="tooltip" title="Account-bound items cannot be transferred but can be deleted."></i>
-                            @endif
-                        </td>
+                        <th class="col-3">Notes</th>
+                        <th class="col-3">Quantity</th>
+                        <th class="col-1"><i class="fas fa-lock invisible"></i></th>
                     </tr>
-                @endforeach
-            </tbody>
-        </table>
-    </div>
-
-    @if($user && !$readOnly && ($stack->first()->user_id == $user->id || $user->hasPower('edit_inventories')))
-        <div class="card mt-3">
-            <ul class="list-group list-group-flush">
-                @if(count($item->tags))
-                    @foreach($item->tags as $tag)
-                        @if(View::exists('inventory._'.$tag->tag))
-                            @include('inventory._'.$tag->tag, ['stack' => $stack, 'tag' => $tag])
-                        @endif
+                </thead>
+                <tbody>
+                    @foreach($stack as $itemRow)
+                        <tr id ="itemRow{{ $itemRow->id }}" class="d-flex {{ $itemRow->isTransferrable ? '' : 'accountbound' }}">
+                            @if($user && !$readOnly && ($stack->first()->user_id == $user->id || $user->hasPower('edit_inventories')))
+                                <td class="col-1">{!! Form::checkbox('ids[]', $itemRow->id, false, ['class' => 'item-check', 'onclick' => 'updateQuantities(this)']) !!}</td>
+                                <td class="col-4">{!! array_key_exists('data', $itemRow->data) ? ($itemRow->data['data'] ? $itemRow->data['data'] : 'N/A') : 'N/A' !!}</td>
+                            @else
+                                <td class="col-5">{!! array_key_exists('data', $itemRow->data) ? ($itemRow->data['data'] ? $itemRow->data['data'] : 'N/A') : 'N/A' !!}</td>
+                            @endif
+                            <td class="col-3">{!! array_key_exists('notes', $itemRow->data) ? ($itemRow->data['notes'] ? $itemRow->data['notes'] : 'N/A') : 'N/A' !!}</td>
+                            @if($user && !$readOnly && ($stack->first()->user_id == $user->id || $user->hasPower('edit_inventories')))
+                                @if($itemRow->availableQuantity)
+                                    <td class="col-3">{!! Form::selectRange('', 1, $itemRow->availableQuantity, 1, ['class' => 'quantity-select', 'type' => 'number', 'style' => 'min-width:40px;']) !!} /{{ $itemRow->availableQuantity }} @if($itemRow->getOthers()) {{ $itemRow->getOthers() }} @endif</td>
+                                @else
+                                    <td class="col-3">{!! Form::selectRange('', 0, 0, 0, ['class' => 'quantity-select', 'type' => 'number', 'style' => 'min-width:40px;', 'disabled']) !!} /{{ $itemRow->availableQuantity }} @if($itemRow->getOthers()) {{ $itemRow->getOthers() }} @endif</td>
+                                @endif
+                            @else
+                                <td class="col-3">{!! $itemRow->count !!}</td>
+                            @endif
+                            <td class="col-1">
+                                @if(!$itemRow->isTransferrable)
+                                    <i class="fas fa-lock" data-toggle="tooltip" title="Account-bound items cannot be transferred but can be deleted."></i>
+                                @endif
+                            </td>
+                        </tr>
                     @endforeach
-                @endif
-
-                @if(isset($item->category) && $item->category->is_character_owned)
-                    <li class="list-group-item">
-                        <a class="card-title h5 collapse-title" data-toggle="collapse" href="#characterTransferForm">@if($stack->first()->user_id != $user->id) [ADMIN] @endif Transfer Item to Character</a>
-                        <div id="characterTransferForm" class="collapse">
-                            <p>This will transfer this stack or stacks to this character's inventory.</p>
-                            <div class="form-group">
-                                {!! Form::select('character_id', $characterOptions, null, ['class' => 'form-control mr-2 default character-select', 'placeholder' => 'Select Character']) !!}
-                            </div>
-                            <div class="text-right">
-                                {!! Form::button('Transfer', ['class' => 'btn btn-primary', 'name' => 'action', 'value' => 'characterTransfer', 'type' => 'submit']) !!}
-                            </div>
-                        </div>
-                    </li>
-                @endif
-                @if(isset($item->data['resell']) && App\Models\Currency\Currency::where('id', $item->resell->flip()->pop())->first() && Config::get('lorekeeper.extensions.item_entry_expansion.resale_function'))
-                    <li class="list-group-item">
-                        <a class="card-title h5 collapse-title" data-toggle="collapse" href="#resellForm">@if($stack->first()->user_id != $user->id) [ADMIN] @endif Sell Item</a>
-                        <div id="resellForm" class="collapse">
-                            <p>This item can be sold for <strong>{!! App\Models\Currency\Currency::find($item->resell->flip()->pop())->display($item->resell->pop()) !!}</strong>. This action is not reversible. Are you sure you want to sell this item?</p>
-                            <div class="text-right">
-                                {!! Form::button('Sell', ['class' => 'btn btn-danger', 'name' => 'action', 'value' => 'resell', 'type' => 'submit']) !!}
-                            </div>
-                        </div>
-                    </li>
-                @endif
-                <li class="list-group-item">
-                    <a class="card-title h5 collapse-title" data-toggle="collapse" href="#transferForm">@if($stack->first()->user_id != $user->id) [ADMIN] @endif Transfer Item</a>
-                    <div id="transferForm" class="collapse">
-                        <div class="form-group">
-                            {!! Form::label('user_id', 'Recipient') !!} {!! add_help('You can only transfer items to verified users.') !!}
-                            {!! Form::select('user_id', $userOptions, null, ['class'=>'form-control']) !!}
-                        </div>
-                        <div class="text-right">
-                            {!! Form::button('Transfer', ['class' => 'btn btn-primary', 'name' => 'action', 'value' => 'transfer', 'type' => 'submit']) !!}
-                        </div>
-                    </div>
-                </li>
-                <li class="list-group-item">
-                    <a class="card-title h5 collapse-title" data-toggle="collapse" href="#deleteForm">@if($stack->first()->user_id != $user->id) [ADMIN] @endif Delete Item</a>
-                    <div id="deleteForm" class="collapse">
-                        <p>This action is not reversible. Are you sure you want to delete this item?</p>
-                        <div class="text-right">
-                            {!! Form::button('Delete', ['class' => 'btn btn-danger', 'name' => 'action', 'value' => 'delete', 'type' => 'submit']) !!}
-                        </div>
-                    </div>
-                </li>
-            </ul>
+                </tbody>
+            </table>
         </div>
-    @endif
+
+        @if($user && !$readOnly && ($stack->first()->user_id == $user->id || $user->hasPower('edit_inventories')))
+            <div class="card mt-3">
+                <ul class="list-group list-group-flush">
+                    @if(count($item->tags))
+                        @foreach($item->tags as $tag)
+                            @if(View::exists('inventory._'.$tag->tag))
+                                @include('inventory._'.$tag->tag, ['stack' => $stack, 'tag' => $tag])
+                            @endif
+                        @endforeach
+                    @endif
+
+                    @if(isset($item->category) && $item->category->is_character_owned)
+                        <li class="list-group-item">
+                            <a class="card-title h5 collapse-title" data-toggle="collapse" href="#characterTransferForm">@if($stack->first()->user_id != $user->id) [ADMIN] @endif Transfer Item to Character</a>
+                            <div id="characterTransferForm" class="collapse">
+                                <p>This will transfer this stack or stacks to this character's inventory.</p>
+                                <div class="form-group">
+                                    {!! Form::select('character_id', $characterOptions, null, ['class' => 'form-control mr-2 default character-select', 'placeholder' => 'Select Character']) !!}
+                                </div>
+                                <div class="text-right">
+                                    {!! Form::button('Transfer', ['class' => 'btn btn-primary', 'name' => 'action', 'value' => 'characterTransfer', 'type' => 'submit']) !!}
+                                </div>
+                            </div>
+                        </li>
+                    @endif
+                    @if(isset($item->data['resell']) && App\Models\Currency\Currency::where('id', $item->resell->flip()->pop())->first() && Config::get('lorekeeper.extensions.item_entry_expansion.resale_function'))
+                        <li class="list-group-item">
+                            <a class="card-title h5 collapse-title" data-toggle="collapse" href="#resellForm">@if($stack->first()->user_id != $user->id) [ADMIN] @endif Sell Item</a>
+                            <div id="resellForm" class="collapse">
+                                <p>This item can be sold for <strong>{!! App\Models\Currency\Currency::find($item->resell->flip()->pop())->display($item->resell->pop()) !!}</strong>. This action is not reversible. Are you sure you want to sell this item?</p>
+                                <div class="text-right">
+                                    {!! Form::button('Sell', ['class' => 'btn btn-danger', 'name' => 'action', 'value' => 'resell', 'type' => 'submit']) !!}
+                                </div>
+                            </div>
+                        </li>
+                    @endif
+                    <li class="list-group-item">
+                        <a class="card-title h5 collapse-title" data-toggle="collapse" href="#transferForm">@if($stack->first()->user_id != $user->id) [ADMIN] @endif Transfer Item</a>
+                        <div id="transferForm" class="collapse">
+                            <div class="form-group">
+                                {!! Form::label('user_id', 'Recipient') !!} {!! add_help('You can only transfer items to verified users.') !!}
+                                {!! Form::select('user_id', $userOptions, null, ['class'=>'form-control']) !!}
+                            </div>
+                            <div class="text-right">
+                                {!! Form::button('Transfer', ['class' => 'btn btn-primary', 'name' => 'action', 'value' => 'transfer', 'type' => 'submit']) !!}
+                            </div>
+                        </div>
+                    </li>
+                    <li class="list-group-item">
+                        <a class="card-title h5 collapse-title" data-toggle="collapse" href="#deleteForm">@if($stack->first()->user_id != $user->id) [ADMIN] @endif Delete Item</a>
+                        <div id="deleteForm" class="collapse">
+                            <p>This action is not reversible. Are you sure you want to delete this item?</p>
+                            <div class="text-right">
+                                {!! Form::button('Delete', ['class' => 'btn btn-danger', 'name' => 'action', 'value' => 'delete', 'type' => 'submit']) !!}
+                            </div>
+                        </div>
+                    </li>
+                </ul>
+            </div>
+        @endif
     {!! Form::close() !!}
 @endif
 

--- a/resources/views/home/_report_content.blade.php
+++ b/resources/views/home/_report_content.blade.php
@@ -28,24 +28,26 @@
         </div>
     @endif
 </div>
+
 <h2>Report Details</h2>
 <div class="card mb-3"><div class="card-body">{!! nl2br(htmlentities($report->comments)) !!}</div></div>
-
 @if(Auth::check() && $report->status == 'Assigned' && $report->user == Auth::user() || Auth::user()->hasPower('manage_reports'))
-<div class="alert alert-danger">Admins will be alerted by new comments, however to keep the conversation organised we ask that you please reply to the admin comment.</div>
+    <div class="alert alert-danger">Admins will be alerted by new comments, however to keep the conversation organised we ask that you please reply to the admin comment.</div>
     @comments([ 'model' => $report, 'perPage' => 5 ])
 @elseif($report->status == 'Closed')
-<div class="alert alert-danger"> You cannot comment on a closed ticket. </div>
+    <div class="alert alert-danger"> You cannot comment on a closed ticket. </div>
 @else
-<div class="alert alert-danger"> Please await admin assignment. </div>
+    <div class="alert alert-danger"> Please await admin assignment. </div>
 @endif
 @if(Auth::check() && $report->staff_comments && ($report->user_id == Auth::user()->id || Auth::user()->hasPower('manage_reports')))
     <h2>Staff Comments</h2>
-    <div class="card mb-3"><div class="card-body">
-	    @if(isset($report->parsed_staff_comments))
-            {!! $report->parsed_staff_comments !!}
-        @else
-            {!! $report->staff_comments !!}
-        @endif
-		</div></div>
+    <div class="card mb-3">
+        <div class="card-body">
+            @if(isset($report->parsed_staff_comments))
+                {!! $report->parsed_staff_comments !!}
+            @else
+                {!! $report->staff_comments !!}
+            @endif
+		</div>
+    </div>
 @endif

--- a/resources/views/news/news.blade.php
+++ b/resources/views/news/news.blade.php
@@ -5,8 +5,7 @@
 @section('content')
     {!! breadcrumbs(['Site News' => 'news', $news->title => $news->url]) !!}
     @include('news._news', ['news' => $news, 'page' => TRUE])
-<hr>
-<br><br>
+<hr class="mb-5" />
 
 @comments(['model' => $news,
         'perPage' => 5

--- a/resources/views/sales/sales.blade.php
+++ b/resources/views/sales/sales.blade.php
@@ -9,11 +9,10 @@
 @if((isset($sales->comments_open_at) && $sales->comments_open_at < Carbon\Carbon::now() || 
     (Auth::check() && Auth::user()->hasPower('edit_pages'))) || 
     !isset($sales->comments_open_at))
-        <hr>
-        <br><br>
-        @comments(['model' => $sales,
-                'perPage' => 5
-            ])
+    <hr class="mb-5" />
+    @comments(['model' => $sales,
+            'perPage' => 5
+        ])
 @else
     <div class="alert alert-warning text-center">
         <p>Comments for this sale aren't open yet! They will open {!! pretty_date($sales->comments_open_at) !!}.</p>

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -11,7 +11,7 @@
     <div class="alert alert-danger">This user has been banned.</div>
 @endif
 <h1>
-    <img src="/images/avatars/{{ $user->avatar }}" style="width:125px; height:125px; float:left; border-radius:50%; margin-right:25px;">
+    <img src="/images/avatars/{{ $user->avatar }}" style="width:125px; height:125px; float:left; border-radius:50%; margin-right:25px;" />
     {!! $user->displayName !!}
     <a href="{{ url('reports/new?url=') . $user->url }}"><i class="fas fa-exclamation-triangle fa-xs" data-toggle="tooltip" title="Click here to report this user." style="opacity: 50%; font-size:0.5em;"></i></a>
 
@@ -112,8 +112,7 @@
 @endforeach
 
 <div class="text-right"><a href="{{ $user->url.'/characters' }}">View all...</a></div>
-<hr>
-<br><br>
+<hr class="mb-5" />
 
 @comments(['model' => $user->profile,
         'perPage' => 5


### PR DESCRIPTION
Reviewing the code body in general, putting in some minor changes that are mostly small fixes and stylistic changes for consistency (coding/visually/English; will be...quite...pedantic). Still WIP.

- Fix SalesController index
- Indentation
- Remove consecutive <br>s in favour of margins
- A few visual changes

Todo:

- Pull large chunks of PHP code out of the views (primarily noticed in comments)
- Add a top_comment_id to all comments (and an update script to process existing comments which will hopefully not kill anyone's site) to remove recursive querying
- Pull out comment modals so that the number of modals on the page are reduced
- Reduce duplicated code (just noticed that _perma_comments.blade.php is almost identical to _comment.blade.php)
- Rename controller functions to match the getSomething/postSomething pattern?
- Script to process stacking items to compress existing inventory
- Fix the active sidebar item on the /user/{username}/favorites/own-characters route
- Log page visuals ("table" styling)

Notes on consistency:

- Variables should be camelCase unless it's a model property
- Technically there's no issue with leaving them out, but I used trailing slashes for self-closing tags in the original HTML code so adding them for consistency (<hr />, <br />, <img src="" /> rather than <hr>, <br>, <img src="">)
- Can let single <br> slide, but use margins in place of <br><br> (the Bootstrap mt-3, mb-3 classes can be used for this)
- Indentation is 4 spaces. The `{!! Form::open() !!}` and `{!! Form::close() !!}` tags should be counted as open/close tags.
- `{!! Form::open() !!}` and `{!! Form::close() !!}` preferred to `<form></form>` tags; the former also automatically includes the CSRF token so it's not needed.
- Avoid using the `style` attribute in HTML tags (this will override custom CSS), make it classes as far as possible (would say that elements that use a lot of Bootstrap classes should also be converted to CSS in lorekeeper.css, as the Bootstrap classes have !important on them and may be annoying for users to customise)
- Use full-stops for sentences.