### PR TITLE
Tiny fix for the Tumblr alias

### DIFF
--- a/app/Models/User/UserAlias.php
+++ b/app/Models/User/UserAlias.php
@@ -68,7 +68,7 @@ class UserAlias extends Model
      */
     public function getUrlAttribute()
     {
-        if($this->site == 'tumblr') return 'https://'.$this->alias.Config::get('lorekeeper.sites.tumblr.link');
+        if($this->site == 'tumblr') return 'https://'.$this->alias.'.'.Config::get('lorekeeper.sites.tumblr.link');
         elseif($this->site == 'discord') return null;
         else return 'https://'.Config::get('lorekeeper.sites.'.$this->site.'.link').'/'.$this->alias;
     }


### PR DESCRIPTION
Without this, links were simply not working because of the dot missing in the URL.