### PR TITLE
fix: missing image url for cropper on admin design updates

### DIFF
--- a/resources/views/character/design/image.blade.php
+++ b/resources/views/character/design/image.blade.php
@@ -92,7 +92,7 @@
         <div class="card mb-3" id="thumbnailCrop">
             <div class="card-body">
                 <div id="cropSelect">Select an image to use the thumbnail cropper.</div>
-                <img src="#" id="cropper" class="hide" alt="" />
+                <img src="{{$request->imageUrl}}" id="cropper" class="hide" alt="" />
                 {!! Form::hidden('x0', null, ['id' => 'cropX0']) !!}
                 {!! Form::hidden('x1', null, ['id' => 'cropX1']) !!}
                 {!! Form::hidden('y0', null, ['id' => 'cropY0']) !!}


### PR DESCRIPTION
fixes the 404 image for cropper on design updates currently in queue / out of draft phase. Tested locally, works as intended (only edits when modify thumbnail is checked).