### PR TITLE
feat(prompts): staff-only prompt toggle

### DIFF
--- a/app/Http/Controllers/Admin/Data/PromptController.php
+++ b/app/Http/Controllers/Admin/Data/PromptController.php
@@ -222,7 +222,7 @@ class PromptController extends Controller
     {
         $id ? $request->validate(Prompt::$updateRules) : $request->validate(Prompt::$createRules);
         $data = $request->only([
-            'name', 'prompt_category_id', 'summary', 'description', 'start_at', 'end_at', 'hide_before_start', 'hide_after_end', 'is_active', 'rewardable_type', 'rewardable_id', 'quantity', 'image', 'remove_image', 'prefix', 'hide_submissions',
+            'name', 'prompt_category_id', 'summary', 'description', 'start_at', 'end_at', 'hide_before_start', 'hide_after_end', 'is_active', 'rewardable_type', 'rewardable_id', 'quantity', 'image', 'remove_image', 'prefix', 'hide_submissions', 'staff_only',
         ]);
         if ($id && $service->updatePrompt(Prompt::find($id), $data, Auth::user())) {
             flash('Prompt updated successfully.')->success();

--- a/app/Http/Controllers/PromptsController.php
+++ b/app/Http/Controllers/PromptsController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Prompt\Prompt;
 use App\Models\Prompt\PromptCategory;
+use Auth;
 use Illuminate\Http\Request;
 
 class PromptsController extends Controller
@@ -53,7 +54,7 @@ class PromptsController extends Controller
      */
     public function getPrompts(Request $request)
     {
-        $query = Prompt::active()->with('category');
+        $query = Prompt::active()->staffOnly(Auth::check() ? Auth::user() : null)->with('category');
         $data = $request->only(['prompt_category_id', 'name', 'sort']);
         if (isset($data['prompt_category_id']) && $data['prompt_category_id'] != 'none') {
             $query->where('prompt_category_id', $data['prompt_category_id']);

--- a/app/Models/Prompt/Prompt.php
+++ b/app/Models/Prompt/Prompt.php
@@ -15,7 +15,7 @@ class Prompt extends Model
     protected $fillable = [
         'prompt_category_id', 'name', 'summary', 'description', 'parsed_description', 'is_active',
         'start_at', 'end_at', 'hide_before_start', 'hide_after_end', 'has_image', 'prefix',
-        'hide_submissions',
+        'hide_submissions', 'staff_only',
     ];
 
     /**
@@ -106,6 +106,23 @@ class Prompt extends Model
                     $query->where('end_at', '<=', Carbon::now())->where('hide_after_end', 0);
                 });
             });
+    }
+
+    /**
+     * Scope a query to include or exclude staff-only prompts.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param \App\Models\User\User                 $user
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeStaffOnly($query, $user)
+    {
+        if ($user && $user->isStaff) {
+            return $query;
+        }
+
+        return $query->where('staff_only', 0);
     }
 
     /**

--- a/app/Services/PromptService.php
+++ b/app/Services/PromptService.php
@@ -205,7 +205,7 @@ class PromptService extends Service
                 $data['hide_submissions'] = 0;
             }
 
-            $prompt = Prompt::create(Arr::only($data, ['prompt_category_id', 'name', 'summary', 'description', 'parsed_description', 'is_active', 'start_at', 'end_at', 'hide_before_start', 'hide_after_end', 'has_image', 'prefix', 'hide_submissions']));
+            $prompt = Prompt::create(Arr::only($data, ['prompt_category_id', 'name', 'summary', 'description', 'parsed_description', 'is_active', 'start_at', 'end_at', 'hide_before_start', 'hide_after_end', 'has_image', 'prefix', 'hide_submissions', 'staff_only']));
 
             if ($image) {
                 $this->handleImage($image, $prompt->imagePath, $prompt->imageFileName);
@@ -263,7 +263,7 @@ class PromptService extends Service
                 $data['hide_submissions'] = 0;
             }
 
-            $prompt->update(Arr::only($data, ['prompt_category_id', 'name', 'summary', 'description', 'parsed_description', 'is_active', 'start_at', 'end_at', 'hide_before_start', 'hide_after_end', 'has_image', 'prefix', 'hide_submissions']));
+            $prompt->update(Arr::only($data, ['prompt_category_id', 'name', 'summary', 'description', 'parsed_description', 'is_active', 'start_at', 'end_at', 'hide_before_start', 'hide_after_end', 'has_image', 'prefix', 'hide_submissions', 'staff_only']));
 
             if ($prompt) {
                 $this->handleImage($image, $prompt->imagePath, $prompt->imageFileName);
@@ -359,6 +359,9 @@ class PromptService extends Service
         }
         if (!isset($data['is_active'])) {
             $data['is_active'] = 0;
+        }
+        if (!isset($data['staff_only'])) {
+            $data['staff_only'] = 0;
         }
 
         if (isset($data['remove_image'])) {

--- a/app/Services/SubmissionManager.php
+++ b/app/Services/SubmissionManager.php
@@ -50,6 +50,10 @@ class SubmissionManager extends Service
                 if (!$prompt) {
                     throw new \Exception('Invalid prompt selected.');
                 }
+
+                if ($prompt->staff_only && !$user->isStaff) {
+                    throw new \Exception('This prompt may only be submitted to by staff members.');
+                }
             } else {
                 $prompt = null;
             }

--- a/database/migrations/2022_02_19_014311_add_admin_only_to_prompts.php
+++ b/database/migrations/2022_02_19_014311_add_admin_only_to_prompts.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddAdminOnlyToPrompts extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+        Schema::table('prompts', function (Blueprint $table) {
+            //
+            $table->boolean('staff_only')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down()
+    {
+        Schema::table('prompts', function (Blueprint $table) {
+            //
+            $table->dropColumn('staff_only');
+        });
+    }
+}

--- a/resources/views/admin/prompts/create_edit_prompt.blade.php
+++ b/resources/views/admin/prompts/create_edit_prompt.blade.php
@@ -85,11 +85,18 @@
             {!! Form::label('hide_after_end', 'Hide After End Time', ['class' => 'form-check-label ml-3']) !!} {!! add_help('If hidden, the prompt will not be shown on the prompt list after the ending time is reached. An end time needs to be set.') !!}
         </div>
     </div>
-</div>
-
-<div class="form-group">
-    {!! Form::checkbox('is_active', 1, $prompt->id ? $prompt->is_active : 1, ['class' => 'form-check-input', 'data-toggle' => 'toggle']) !!}
-    {!! Form::label('is_active', 'Is Active', ['class' => 'form-check-label ml-3']) !!} {!! add_help('Prompts that are not active will be hidden from the prompt list. The start/end time hide settings override this setting, i.e. if this is set to active, it will still be hidden outside of the start/end times.') !!}
+    <div class="col-md-6">
+        <div class="form-group">
+            {!! Form::checkbox('is_active', 1, $prompt->id ? $prompt->is_active : 1, ['class' => 'form-check-input', 'data-toggle' => 'toggle']) !!}
+            {!! Form::label('is_active', 'Is Active', ['class' => 'form-check-label ml-3']) !!} {!! add_help('Prompts that are not active will be hidden from the prompt list. The start/end time hide settings override this setting, i.e. if this is set to active, it will still be hidden outside of the start/end times.') !!}
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="form-group">
+            {!! Form::checkbox('staff_only', 1, $prompt->id ? $prompt->staff_only : 0, ['class' => 'form-check-input', 'data-toggle' => 'toggle']) !!}
+            {!! Form::label('staff_only', 'Staff Only', ['class' => 'form-check-label ml-3']) !!} {!! add_help('If this is set, the prompt will only be visible to staff, and only they will be able to submit to it.') !!}
+        </div>
+    </div>
 </div>
 
 <div class="form-group">

--- a/resources/views/admin/prompts/prompts.blade.php
+++ b/resources/views/admin/prompts/prompts.blade.php
@@ -76,8 +76,8 @@
                         </div>
                     </div>
                 </div>
-            </div>
-        @endforeach
+            @endforeach
+        </div>
     </div>
 
     {!! $prompts->render() !!}


### PR DESCRIPTION
Adds a toggle to prompt creation/editing to make a prompt visible and submittable to only by staff. Might be niche, but the changes are very minor, so I figured it'd be worth PRing.

Tested locally/live, requires `php artisan migrate`.