### PR TITLE
Add Toyhouse OAuth2 authentication

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -81,7 +81,9 @@ class HomeController extends Controller
             return redirect()->to(Auth::user()->has_alias ? 'account/aliases' : 'link');
         }
 
-        $result = Socialite::driver($provider)->stateless()->user();
+        // Toyhouse runs on Laravel Passport for OAuth2 and this has some issues with state exceptions,
+        // admin suggested the easy fix (to use stateless)
+        $result = $provider == 'toyhouse' ? Socialite::driver($provider)->stateless()->user() : Socialite::driver($provider)->user();
         if ($service->saveProvider($provider, $result, Auth::user())) {
             flash('Account has been linked successfully.')->success();
             Auth::user()->updateCharacters();

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -81,7 +81,7 @@ class HomeController extends Controller
             return redirect()->to(Auth::user()->has_alias ? 'account/aliases' : 'link');
         }
 
-        $result = Socialite::driver($provider)->user();
+        $result = Socialite::driver($provider)->stateless()->user();
         if ($service->saveProvider($provider, $result, Auth::user())) {
             flash('Account has been linked successfully.')->success();
             Auth::user()->updateCharacters();

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 
+use App\Providers\Socialite\ToyhouseProvider;
+
 class AppServiceProvider extends ServiceProvider
 {
     /**
@@ -50,5 +52,22 @@ class AppServiceProvider extends ServiceProvider
                 ]
             );
         });
+
+        $this->bootToyhouseSocialite();
+    }
+
+    /**
+     * Boot Toyhouse Socialite provider.
+     */
+    private function bootToyhouseSocialite()
+    {
+        $socialite = $this->app->make('Laravel\Socialite\Contracts\Factory');
+        $socialite->extend(
+            'toyhouse',
+            function ($app) use ($socialite) {
+                $config = $app['config']['services.toyhouse'];
+                return $socialite->buildProvider(ToyhouseProvider::class, $config);
+            }
+        );
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,13 +2,12 @@
 
 namespace App\Providers;
 
+use App\Providers\Socialite\ToyhouseProvider;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
-
-use App\Providers\Socialite\ToyhouseProvider;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -66,6 +65,7 @@ class AppServiceProvider extends ServiceProvider
             'toyhouse',
             function ($app) use ($socialite) {
                 $config = $app['config']['services.toyhouse'];
+
                 return $socialite->buildProvider(ToyhouseProvider::class, $config);
             }
         );

--- a/app/Providers/Socialite/ToyhouseProvider.php
+++ b/app/Providers/Socialite/ToyhouseProvider.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Providers\Socialite;
+
+use Laravel\Socialite\Two\AbstractProvider;
+use Laravel\Socialite\Two\ProviderInterface;
+use Laravel\Socialite\Two\User;
+
+class ToyhouseProvider extends AbstractProvider implements ProviderInterface
+{
+    protected $scopes = [];
+
+    /**
+     * Get the authentication URL for the provider.
+     *
+     * @param  string  $state
+     * @return string
+     */
+    protected function getAuthUrl($state)
+    {
+        return $this->buildAuthUrlFromBase('https://toyhou.se/~oauth/authorize', $state);
+    }
+
+    /**
+     * Get the token URL for the provider.
+     *
+     * @return string
+     */
+    protected function getTokenUrl()
+    {
+        return 'https://toyhou.se/~oauth/token';
+    }
+
+    /**
+     * Get the raw user for the given access token.
+     *
+     * @param  string  $token
+     * @return array
+     */
+    protected function getUserByToken($token)
+    {
+        $response = $this->getHttpClient()->get(
+            'https://toyhou.se/~api/v1/me?access_token='.$token, 
+            [
+                RequestOptions::HEADERS => [
+                    'Authorization' => 'Bearer '.$token,
+                ],
+            ]
+        );
+
+        return json_decode($response->getBody(), true);
+    }
+
+    /**
+     * Map the raw user array to a Socialite User instance.
+     *
+     * @param  array  $user
+     * @return \Laravel\Socialite\Two\User
+     */
+    protected function mapUserToObject(array $user)
+    {
+        return (new User)->setRaw($user)->map([
+            'id' => $user['id'], 'nickname' => $user['username'], 
+            'name' => null, 'email' => null, 'avatar' => $user['avatar_url']
+        ]);
+    }
+}

--- a/app/Providers/Socialite/ToyhouseProvider.php
+++ b/app/Providers/Socialite/ToyhouseProvider.php
@@ -40,7 +40,7 @@ class ToyhouseProvider extends AbstractProvider implements ProviderInterface
     protected function getUserByToken($token)
     {
         $response = $this->getHttpClient()->get(
-            'https://toyhou.se/~api/v1/me?access_token='.$token, 
+            'https://toyhou.se/~api/v1/me', 
             [
                 RequestOptions::HEADERS => [
                     'Authorization' => 'Bearer '.$token,

--- a/app/Providers/Socialite/ToyhouseProvider.php
+++ b/app/Providers/Socialite/ToyhouseProvider.php
@@ -65,35 +65,4 @@ class ToyhouseProvider extends AbstractProvider implements ProviderInterface
             'name' => null, 'email' => null, 'avatar' => $user['avatar_url']
         ]);
     }
-
-
-
-
-
-
-
-
-    
-    public function user()
-    {
-        dd([$this->request->session()->pull('state'), $this->request->input('state')]);
-        if ($this->user) {
-            return $this->user;
-        }
-
-        if ($this->hasInvalidState()) {
-            throw new InvalidStateException;
-        }
-
-        $response = $this->getAccessTokenResponse($this->getCode());
-
-        $this->user = $this->mapUserToObject($this->getUserByToken(
-            $token = Arr::get($response, 'access_token')
-        ));
-
-        return $this->user->setToken($token)
-                    ->setRefreshToken(Arr::get($response, 'refresh_token'))
-                    ->setExpiresIn(Arr::get($response, 'expires_in'))
-                    ->setApprovedScopes(explode($this->scopeSeparator, Arr::get($response, 'scope', '')));
-    }
 }

--- a/app/Providers/Socialite/ToyhouseProvider.php
+++ b/app/Providers/Socialite/ToyhouseProvider.php
@@ -60,6 +60,7 @@ class ToyhouseProvider extends AbstractProvider implements ProviderInterface
      */
     protected function mapUserToObject(array $user)
     {
+        dd($user);
         return (new User)->setRaw($user)->map([
             'id' => $user['id'], 'nickname' => $user['username'], 
             'name' => null, 'email' => null, 'avatar' => $user['avatar_url']

--- a/app/Providers/Socialite/ToyhouseProvider.php
+++ b/app/Providers/Socialite/ToyhouseProvider.php
@@ -65,4 +65,35 @@ class ToyhouseProvider extends AbstractProvider implements ProviderInterface
             'name' => null, 'email' => null, 'avatar' => $user['avatar_url']
         ]);
     }
+
+
+
+
+
+
+
+
+    
+    public function user()
+    {
+        dd($this);
+        if ($this->user) {
+            return $this->user;
+        }
+
+        if ($this->hasInvalidState()) {
+            throw new InvalidStateException;
+        }
+
+        $response = $this->getAccessTokenResponse($this->getCode());
+
+        $this->user = $this->mapUserToObject($this->getUserByToken(
+            $token = Arr::get($response, 'access_token')
+        ));
+
+        return $this->user->setToken($token)
+                    ->setRefreshToken(Arr::get($response, 'refresh_token'))
+                    ->setExpiresIn(Arr::get($response, 'expires_in'))
+                    ->setApprovedScopes(explode($this->scopeSeparator, Arr::get($response, 'scope', '')));
+    }
 }

--- a/app/Providers/Socialite/ToyhouseProvider.php
+++ b/app/Providers/Socialite/ToyhouseProvider.php
@@ -41,7 +41,7 @@ class ToyhouseProvider extends AbstractProvider implements ProviderInterface
     protected function getUserByToken($token)
     {
         $response = $this->getHttpClient()->get(
-            'https://toyhou.se/~api/v1/me'.$token, 
+            'https://toyhou.se/~api/v1/me?access_token='.$token, 
             [
                 RequestOptions::HEADERS => [
                     'Authorization' => 'Bearer '.$token,

--- a/app/Providers/Socialite/ToyhouseProvider.php
+++ b/app/Providers/Socialite/ToyhouseProvider.php
@@ -18,7 +18,7 @@ class ToyhouseProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getAuthUrl($state)
     {
-        dd($state);
+        dd($this->buildAuthUrlFromBase('https://toyhou.se/~oauth/authorize', $state));
         return $this->buildAuthUrlFromBase('https://toyhou.se/~oauth/authorize', $state);
     }
 

--- a/app/Providers/Socialite/ToyhouseProvider.php
+++ b/app/Providers/Socialite/ToyhouseProvider.php
@@ -60,10 +60,9 @@ class ToyhouseProvider extends AbstractProvider implements ProviderInterface
      */
     protected function mapUserToObject(array $user)
     {
-        dd($user);
         return (new User)->setRaw($user)->map([
             'id' => $user['id'], 'nickname' => $user['username'], 
-            'name' => null, 'email' => null, 'avatar' => $user['avatar_url']
+            'name' => null, 'email' => null, 'avatar' => $user['avatar']
         ]);
     }
 }

--- a/app/Providers/Socialite/ToyhouseProvider.php
+++ b/app/Providers/Socialite/ToyhouseProvider.php
@@ -2,10 +2,10 @@
 
 namespace App\Providers\Socialite;
 
+use GuzzleHttp\RequestOptions;
 use Laravel\Socialite\Two\AbstractProvider;
 use Laravel\Socialite\Two\ProviderInterface;
 use Laravel\Socialite\Two\User;
-use GuzzleHttp\RequestOptions;
 
 class ToyhouseProvider extends AbstractProvider implements ProviderInterface
 {
@@ -14,7 +14,8 @@ class ToyhouseProvider extends AbstractProvider implements ProviderInterface
     /**
      * Get the authentication URL for the provider.
      *
-     * @param  string  $state
+     * @param string $state
+     *
      * @return string
      */
     protected function getAuthUrl($state)
@@ -35,13 +36,14 @@ class ToyhouseProvider extends AbstractProvider implements ProviderInterface
     /**
      * Get the raw user for the given access token.
      *
-     * @param  string  $token
+     * @param string $token
+     *
      * @return array
      */
     protected function getUserByToken($token)
     {
         $response = $this->getHttpClient()->get(
-            'https://toyhou.se/~api/v1/me', 
+            'https://toyhou.se/~api/v1/me',
             [
                 RequestOptions::HEADERS => [
                     'Authorization' => 'Bearer '.$token,
@@ -55,14 +57,13 @@ class ToyhouseProvider extends AbstractProvider implements ProviderInterface
     /**
      * Map the raw user array to a Socialite User instance.
      *
-     * @param  array  $user
      * @return \Laravel\Socialite\Two\User
      */
     protected function mapUserToObject(array $user)
     {
         return (new User)->setRaw($user)->map([
-            'id' => $user['id'], 'nickname' => $user['username'], 
-            'name' => null, 'email' => null, 'avatar' => $user['avatar']
+            'id'   => $user['id'], 'nickname' => $user['username'],
+            'name' => null, 'email' => null, 'avatar' => $user['avatar'],
         ]);
     }
 }

--- a/app/Providers/Socialite/ToyhouseProvider.php
+++ b/app/Providers/Socialite/ToyhouseProvider.php
@@ -18,7 +18,6 @@ class ToyhouseProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getAuthUrl($state)
     {
-        dd($this->buildAuthUrlFromBase('https://toyhou.se/~oauth/authorize', $state));
         return $this->buildAuthUrlFromBase('https://toyhou.se/~oauth/authorize', $state);
     }
 

--- a/app/Providers/Socialite/ToyhouseProvider.php
+++ b/app/Providers/Socialite/ToyhouseProvider.php
@@ -76,7 +76,7 @@ class ToyhouseProvider extends AbstractProvider implements ProviderInterface
     
     public function user()
     {
-        dd($this);
+        dd([$this->request->session()->pull('state'), $this->request->input('state')]);
         if ($this->user) {
             return $this->user;
         }

--- a/app/Providers/Socialite/ToyhouseProvider.php
+++ b/app/Providers/Socialite/ToyhouseProvider.php
@@ -41,7 +41,7 @@ class ToyhouseProvider extends AbstractProvider implements ProviderInterface
     protected function getUserByToken($token)
     {
         $response = $this->getHttpClient()->get(
-            'https://toyhou.se/~api/v1/me?access_token='.$token, 
+            'https://toyhou.se/~api/v1/me', 
             [
                 RequestOptions::HEADERS => [
                     'Authorization' => 'Bearer '.$token,

--- a/app/Providers/Socialite/ToyhouseProvider.php
+++ b/app/Providers/Socialite/ToyhouseProvider.php
@@ -18,6 +18,7 @@ class ToyhouseProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getAuthUrl($state)
     {
+        dd($state);
         return $this->buildAuthUrlFromBase('https://toyhou.se/~oauth/authorize', $state);
     }
 
@@ -40,7 +41,7 @@ class ToyhouseProvider extends AbstractProvider implements ProviderInterface
     protected function getUserByToken($token)
     {
         $response = $this->getHttpClient()->get(
-            'https://toyhou.se/~api/v1/me', 
+            'https://toyhou.se/~api/v1/me'.$token, 
             [
                 RequestOptions::HEADERS => [
                     'Authorization' => 'Bearer '.$token,

--- a/app/Providers/Socialite/ToyhouseProvider.php
+++ b/app/Providers/Socialite/ToyhouseProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers\Socialite;
 use Laravel\Socialite\Two\AbstractProvider;
 use Laravel\Socialite\Two\ProviderInterface;
 use Laravel\Socialite\Two\User;
+use GuzzleHttp\RequestOptions;
 
 class ToyhouseProvider extends AbstractProvider implements ProviderInterface
 {

--- a/config/lorekeeper/sites.php
+++ b/config/lorekeeper/sites.php
@@ -38,11 +38,11 @@ return [
     ],
 
     'toyhouse' => [
-        'full_name'    => 'Toyhou.se',
-        'display_name' => 'TH',
-        'regex'        => '/toyhou\.se\/([A-Za-z0-9_-]+)/',
-        'link'         => 'toyhou.se',
-        'icon'         => 'fas fa-home',
+        'full_name'     => 'Toyhou.se',
+        'display_name'  => 'TH',
+        'regex'         => '/toyhou\.se\/([A-Za-z0-9_-]+)/',
+        'link'          => 'toyhou.se',
+        'icon'          => 'fas fa-home',
         'auth'          => 1,
         'primary_alias' => 1,
     ],

--- a/config/lorekeeper/sites.php
+++ b/config/lorekeeper/sites.php
@@ -37,6 +37,16 @@ return [
         'primary_alias' => 1,
     ],
 
+    'toyhouse' => [
+        'full_name'    => 'Toyhou.se',
+        'display_name' => 'TH',
+        'regex'        => '/toyhou\.se\/([A-Za-z0-9_-]+)/',
+        'link'         => 'toyhou.se',
+        'icon'         => 'fas fa-home',
+        'auth'          => 1,
+        'primary_alias' => 1,
+    ],
+
     'twitter' => [
         'full_name'     => 'Twitter',
         'display_name'  => 'twitter',
@@ -101,14 +111,6 @@ return [
         GENERAL
 
     **********************************************************************************************/
-
-    'toyhouse' => [
-        'full_name'    => 'Toyhou.se',
-        'display_name' => 'TH',
-        'regex'        => '/toyhou\.se\/([A-Za-z0-9_-]+)/',
-        'link'         => 'toyhou.se',
-        'icon'         => 'fas fa-home',
-    ],
 
     'artstation' => [
         'full_name'    => 'Artstation',

--- a/config/services.php
+++ b/config/services.php
@@ -44,6 +44,12 @@ return [
         ],
     ],
 
+    'toyhouse' => [
+        'client_id'     => env('TOYHOUSE_CLIENT_ID'),
+        'client_secret' => env('TOYHOUSE_CLIENT_SECRET'),
+        'redirect'      => env('TOYHOUSE_REDIRECT_URI', '/auth/callback/toyhouse'),
+    ],
+
     'deviantart' => [
         'client_id'     => env('DEVIANTART_CLIENT_ID'),
         'client_secret' => env('DEVIANTART_CLIENT_SECRET'),
@@ -84,5 +90,5 @@ return [
         'client_id'     => env('DISCORD_CLIENT_ID'),
         'client_secret' => env('DISCORD_CLIENT_SECRET'),
         'redirect'      => env('DISCORD_REDIRECT_URI', '/auth/callback/discord'),
-      ],
+    ],
 ];


### PR DESCRIPTION
It's here!! Big thank you to TH admin for getting OAuth2 up and working 🙏💖💕

Go to [https://toyhou.se/~developer](https://toyhou.se/~developer) to set up a client and grab your keys.

This setup was a bit more finicky than the others (code-wise), and there are a few things to note while using it:

- This can't be tested from localhost (there might be workarounds but it might still be annoying, I set up an instance on my server to test it)
- When creating a new app, the redirect URL has to be very specifically `http://your-site.com/auth/callback/toyhouse` as it doesn't seem to use wildcard matching. You may have to enter both non-www and www variants if you use them, etc.

Aside from these, no database/composer updates required. Please add to .env:
```
TOYHOUSE_CLIENT_ID=
TOYHOUSE_CLIENT_SECRET=
```

A couple of notes:
- I wrote a custom Socialite provider, but an official one MIGHT be added eventually so I'll change it then.
- Unlike the others, this one uses the Socialite driver stateless - received this recommendation for a stubborn error. It seems to work fine but I'm not entirely sure about the implications of this yet.
- Since TH is widely used within the adoptables community, and with dA sinking like the Titanic, I've opted to make this a primary alias type by default.

On an unrelated note I used the admin account setup to verify/enter an initial deviantART alias, but it still acted like I didn't have an alias attached (redirected me to the link page, and the new alias I authorised got set as a primary alias, so I ended up with 2 primary aliases) so there's probably a bug to look at there.