### PR TITLE
Bug:: Transfer log has errors if Character was Deleted

### DIFF
--- a/resources/views/admin/masterlist/_transfer.blade.php
+++ b/resources/views/admin/masterlist/_transfer.blade.php
@@ -1,9 +1,13 @@
 <div class="transfer-row mb-2">
-    <div class="transfer-thumbnail"><a href="{{ $transfer->character->url }}"><img src="{{ $transfer->character->image->thumbnailUrl }}" class="img-thumbnail" alt="Thumbnail for {{ $transfer->character->fullName }}" /></a></div>
+@if($transfer->character) <div class="transfer-thumbnail"><a href="{{ $transfer->character->url }}"><img src="{{ $transfer->character->image->thumbnailUrl }}" class="img-thumbnail" alt="Thumbnail for {{ $transfer->character->fullName }}" /></a></div> @endif
     <div class="transfer-info card ml-2">
         <div class="card-body">
             <div class="transfer-info-content">
-                <h3 class="mb-0 transfer-info-header"><a href="{{ $transfer->character->url }}">{{ $transfer->character->fullName }}</a></h3>
+                @if($transfer->character)
+                    <h3 class="mb-0 transfer-info-header"><a href="{{ $transfer->character->url }}">{{ $transfer->character->fullName }}</a></h3>
+                @else
+                    <h3 class="mb-0 transfer-info-header">Character Deleted</h3>
+                @endif
                 <div class="transfer-info-body mb-3">
                     <p>Transfer from {!! $transfer->sender->displayName !!} to {!! $transfer->recipient->displayName !!}, {!! format_date($transfer->created_at) !!}</p>
                     <p>Reason stated: {!! $transfer->user_reason !!}</p>

--- a/resources/views/home/_transfer.blade.php
+++ b/resources/views/home/_transfer.blade.php
@@ -1,9 +1,13 @@
 <div class="transfer-row mb-2">
-    <div class="transfer-thumbnail"><a href="{{ $transfer->character->url }}"><img src="{{ $transfer->character->image->thumbnailUrl }}" class="img-thumbnail" alt="Thumbnail for {{ $transfer->character->fullName }}" /></a></div>
+    @if(isset($transfer->character)) <div class="transfer-thumbnail"><a href="{{ $transfer->character->url }}"><img src="{{ $transfer->character->image->thumbnailUrl }}" class="img-thumbnail" alt="Thumbnail for {{ $transfer->character->fullName }}" /></a></div> @endif
     <div class="transfer-info card ml-2">
         <div class="card-body">
             <div class="transfer-info-content">
-                <h3 class="mb-0 transfer-info-header"><a href="{{ $transfer->character->url }}">{{ $transfer->character->fullName }}</a></h3>
+                @if(isset($transfer->character))
+                    <h3 class="mb-0 transfer-info-header"><a href="{{ $transfer->character->url }}">{{ $transfer->character->fullName }}</a></h3>
+                @else
+                    <h3 class="mb-0 transfer-info-header">Character Deleted</h3>
+                @endif
                 <div class="transfer-info-body mb-3">
                     @if(Auth::user()->id == $transfer->recipient_id)
                         <p>Transfer sent by {!! $transfer->sender->displayName !!}, {!! format_date($transfer->created_at) !!}</p>

--- a/resources/views/home/_transfer.blade.php
+++ b/resources/views/home/_transfer.blade.php
@@ -1,9 +1,9 @@
 <div class="transfer-row mb-2">
-    @if(isset($transfer->character)) <div class="transfer-thumbnail"><a href="{{ $transfer->character->url }}"><img src="{{ $transfer->character->image->thumbnailUrl }}" class="img-thumbnail" alt="Thumbnail for {{ $transfer->character->fullName }}" /></a></div> @endif
+    @if($transfer->character) <div class="transfer-thumbnail"><a href="{{ $transfer->character->url }}"><img src="{{ $transfer->character->image->thumbnailUrl }}" class="img-thumbnail" alt="Thumbnail for {{ $transfer->character->fullName }}" /></a></div> @endif
     <div class="transfer-info card ml-2">
         <div class="card-body">
             <div class="transfer-info-content">
-                @if(isset($transfer->character))
+                @if($transfer->character)
                     <h3 class="mb-0 transfer-info-header"><a href="{{ $transfer->character->url }}">{{ $transfer->character->fullName }}</a></h3>
                 @else
                     <h3 class="mb-0 transfer-info-header">Character Deleted</h3>


### PR DESCRIPTION
This fixes an issue where the Transfer Log will no longer load up and gives an error
"Trying to get property 'url' of non-object" if a character that had been in a transfer was later deleted (and therefore no longer exists to pull information from).

I hide the thumbnail entirely if the character doesn't exist and swap out the `h3` content with "Character Deleted".