### PR TITLE
Bug:: Issue fix for ItemSlots not being usable

### DIFF
--- a/app/Services/CharacterManager.php
+++ b/app/Services/CharacterManager.php
@@ -170,7 +170,9 @@ class CharacterManager extends Service
                 ));
             }
 
-            $this->logAdminAction($user, 'Created Character', 'Created '.$character->displayName);
+            if (!$this->logAdminAction($user, 'Created Character', 'Created '.$character->displayName)) {
+                throw new \Exception('Failed to log admin action.');
+            }
 
             return $this->commitReturn($character);
         } catch (\Exception $e) {

--- a/app/Services/CharacterManager.php
+++ b/app/Services/CharacterManager.php
@@ -170,9 +170,7 @@ class CharacterManager extends Service
                 ));
             }
 
-            if (!$this->logAdminAction($user, 'Created Character', 'Created '.$character->displayName)) {
-                throw new \Exception('Failed to log admin action.');
-            }
+            $this->logAdminAction($user, 'Created Character', 'Created '.$character->displayName);
 
             return $this->commitReturn($character);
         } catch (\Exception $e) {

--- a/app/Services/Service.php
+++ b/app/Services/Service.php
@@ -235,7 +235,7 @@ abstract class Service
             } else {
                 return false;
             }
-        }
+        } else return true;
     }
 
     /**


### PR DESCRIPTION
Fixes the following situation:

1. Non-Staff user has an item with the slot tag
2. Non-Staff user attempts to use item with the slot tag to get a slot
3. SlotService attempts to call `createCharacter` in the CharacterManager to create the slot
4. User passed to `createCharacter` is not staff, so when it tries to log it as an adminAction, it fails.