### PR TITLE
Masterlist Image Automation addition

### DIFF
--- a/config/lorekeeper/settings.php
+++ b/config/lorekeeper/settings.php
@@ -191,6 +191,25 @@ return [
     |
     */
     'masterlist_image_automation' => 0,
+	
+    /*
+    |--------------------------------------------------------------------------
+    | Masterlist Image Automation Removing Manual Upload For Users
+    |--------------------------------------------------------------------------
+    |
+	| NOTE: This feature will only function if the above feature, the
+	| Masterlist Image Automation Replacing Cropper, is also enabled.
+	|
+	| The following option is for if you DO want to disable the manual uploading
+	| of thumbnails, to ensure users do not attempt to upload their
+	| own thumbnails regardless of the automation.
+	| This will remove it purely for users, not administration.
+	|
+    | 0: Keeps the manual thumbnail upload for users.
+	| 1: Hides the thumbnail upload for users.
+	|
+	*/
+	'masterlist_image_automation_hide_manual_thumbnail' => 0,
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/views/character/design/image.blade.php
+++ b/resources/views/character/design/image.blade.php
@@ -107,15 +107,15 @@
                 </div>
             </div>
         @endif
-		@if (Config::get('lorekeeper.settings.masterlist_image_automation') === 0 || Config::get('lorekeeper.settings.masterlist_image_automation_hide_manual_thumbnail') === 0 || Auth::user()->hasPower('manage_characters'))
-        <div class="card mb-3" id="thumbnailUpload">
-            <div class="card-body">
-                {!! Form::label('Thumbnail Image') !!} {!! add_help('This image is shown on the masterlist page.') !!}
-                <div>{!! Form::file('thumbnail') !!}</div>
-                <div class="text-muted">Recommended size: {{ Config::get('lorekeeper.settings.masterlist_thumbnails.width') }}px x {{ Config::get('lorekeeper.settings.masterlist_thumbnails.height') }}px</div>
+        @if (Config::get('lorekeeper.settings.masterlist_image_automation') === 0 || Config::get('lorekeeper.settings.masterlist_image_automation_hide_manual_thumbnail') === 0 || Auth::user()->hasPower('manage_characters'))
+            <div class="card mb-3" id="thumbnailUpload">
+                <div class="card-body">
+                    {!! Form::label('Thumbnail Image') !!} {!! add_help('This image is shown on the masterlist page.') !!}
+                    <div>{!! Form::file('thumbnail') !!}</div>
+                    <div class="text-muted">Recommended size: {{ Config::get('lorekeeper.settings.masterlist_thumbnails.width') }}px x {{ Config::get('lorekeeper.settings.masterlist_thumbnails.height') }}px</div>
+                </div>
             </div>
-        </div>
-		@endif
+        @endif
         <p>
             This section is for crediting the image creators. The first box is for the designer or artist's on-site username (if any). The second is for a link to the designer or artist if they don't have an account on the site.
         </p>

--- a/resources/views/character/design/image.blade.php
+++ b/resources/views/character/design/image.blade.php
@@ -107,6 +107,7 @@
                 </div>
             </div>
         @endif
+		@if (Config::get('lorekeeper.settings.masterlist_image_automation') === 0 || Config::get('lorekeeper.settings.masterlist_image_automation_hide_manual_thumbnail') === 0 || Auth::user()->hasPower('manage_characters'))
         <div class="card mb-3" id="thumbnailUpload">
             <div class="card-body">
                 {!! Form::label('Thumbnail Image') !!} {!! add_help('This image is shown on the masterlist page.') !!}
@@ -114,6 +115,7 @@
                 <div class="text-muted">Recommended size: {{ Config::get('lorekeeper.settings.masterlist_thumbnails.width') }}px x {{ Config::get('lorekeeper.settings.masterlist_thumbnails.height') }}px</div>
             </div>
         </div>
+		@endif
         <p>
             This section is for crediting the image creators. The first box is for the designer or artist's on-site username (if any). The second is for a link to the designer or artist if they don't have an account on the site.
         </p>

--- a/resources/views/pages/credits.blade.php
+++ b/resources/views/pages/credits.blade.php
@@ -60,8 +60,10 @@
             <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:User_Transfer_Reasons"><strong>User Transfer Reasons</strong></a> by <a href="https://github.com/snupsplus">Snupsplus</a>
         </p>
         <p class="mb-0 col-md-4">
-            <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:Watermarking"><strong>Watermarking</strong></a> by <a href="https://github.com/itinerare">itinerare</a> with masterlist image automation by <a
-                href="https://github.com/SpeedyD">Speedy</a>
+            <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:Watermarking"><strong>Watermarking</strong></a> by <a href="https://github.com/itinerare">itinerare</a>
+        </p>
+		<p class="mb-0 col-md-4">
+            <strong>Watermarking - Masterlist Image Automation addition</strong></a> by <a href="https://github.com/SpeedyD">Speedy</a> 
         </p>
 
         <p class="mb-0 col-md-4">

--- a/resources/views/pages/credits.blade.php
+++ b/resources/views/pages/credits.blade.php
@@ -62,8 +62,8 @@
         <p class="mb-0 col-md-4">
             <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:Watermarking"><strong>Watermarking</strong></a> by <a href="https://github.com/itinerare">itinerare</a>
         </p>
-		<p class="mb-0 col-md-4">
-            <strong>Watermarking - Masterlist Image Automation addition</strong></a> by <a href="https://github.com/SpeedyD">Speedy</a> 
+        <p class="mb-0 col-md-4">
+            <strong>Watermarking - Masterlist Image Automation addition</strong></a> by <a href="https://github.com/SpeedyD">Speedy</a>
         </p>
 
         <p class="mb-0 col-md-4">


### PR DESCRIPTION
Adds option to hide uploading thumbnails from users, and users only.
Works only if the previous automation feature is also enabled.

Altered credits to separate it from Watermarking, as while this is an addition on top, it always looked off to me that it was all on the same line in the credits.