### PR TITLE
Adds sidebars to News and Sales

### DIFF
--- a/app/Http/Controllers/NewsController.php
+++ b/app/Http/Controllers/NewsController.php
@@ -16,6 +16,14 @@ class NewsController extends Controller {
     */
 
     /**
+     * Create a new controller instance.
+     */
+    public function __construct()
+    {
+		View::share('recentnews', News::visible()->orderBy('updated_at', 'DESC')->take(10)->get());
+    }
+
+    /**
      * Shows the news index.
      *
      * @return \Illuminate\Contracts\Support\Renderable

--- a/app/Http/Controllers/NewsController.php
+++ b/app/Http/Controllers/NewsController.php
@@ -18,9 +18,8 @@ class NewsController extends Controller {
     /**
      * Create a new controller instance.
      */
-    public function __construct()
-    {
-		View::share('recentnews', News::visible()->orderBy('updated_at', 'DESC')->take(10)->get());
+    public function __construct() {
+        View::share('recentnews', News::visible()->orderBy('updated_at', 'DESC')->take(10)->get());
     }
 
     /**

--- a/app/Http/Controllers/SalesController.php
+++ b/app/Http/Controllers/SalesController.php
@@ -19,10 +19,9 @@ class SalesController extends Controller {
     /**
      * Create a new controller instance.
      */
-    public function __construct()
-    {
+    public function __construct() {
         View::share('forsale', Sales::visible()->orderBy('updated_at', 'DESC')->where('is_open', 1)->get());
-		View::share('recentsales', Sales::visible()->orderBy('updated_at', 'DESC')->take(10)->get());
+        View::share('recentsales', Sales::visible()->orderBy('updated_at', 'DESC')->take(10)->get());
     }
 
     /**

--- a/app/Http/Controllers/SalesController.php
+++ b/app/Http/Controllers/SalesController.php
@@ -17,6 +17,15 @@ class SalesController extends Controller {
     */
 
     /**
+     * Create a new controller instance.
+     */
+    public function __construct()
+    {
+        View::share('forsale', Sales::visible()->orderBy('updated_at', 'DESC')->where('is_open', 1)->get());
+		View::share('recentsales', Sales::visible()->orderBy('updated_at', 'DESC')->take(10)->get());
+    }
+
+    /**
      * Shows the sales index.
      *
      * @return \Illuminate\Contracts\Support\Renderable

--- a/resources/views/news/_sidebar.blade.php
+++ b/resources/views/news/_sidebar.blade.php
@@ -1,0 +1,20 @@
+<ul>
+    <li class="sidebar-header"><a href="{{ url('news') }}" class="card-link">News</a></li>
+    @if(isset($newses))
+       <li class="sidebar-section">
+        <div class="sidebar-section-header">On This Page</div>
+        @foreach($newses as $news)
+			@php $newslink = 'news/'.$news->slug; @endphp
+            <div class="sidebar-item"><a href="{{ $news->url }}" class="{{ set_active($newslink) }}">{{ $news->title }}</a></div>
+        @endforeach
+        </li>
+    @else
+    <li class="sidebar-section">
+        <div class="sidebar-section-header">Recent News</div>
+        @foreach(App\Models\News::visible()->orderBy('updated_at', 'DESC')->take(10)->get() as $news)
+			@php $newslink = 'news/'.$news->slug; @endphp
+            <div class="sidebar-item"><a href="{{ $news->url }}" class="{{ set_active($newslink) }}">{{ $news->title }}</a></div>
+        @endforeach
+    </li>
+    @endif
+</ul>

--- a/resources/views/news/_sidebar.blade.php
+++ b/resources/views/news/_sidebar.blade.php
@@ -11,7 +11,7 @@
     @else
         <li class="sidebar-section">
             <div class="sidebar-section-header">Recent News</div>
-            @foreach (App\Models\News::visible()->orderBy('updated_at', 'DESC')->take(10)->get() as $news)
+            @foreach ($recentnews as $news)
                 @php $newslink = 'news/'.$news->slug; @endphp
                 <div class="sidebar-item"><a href="{{ $news->url }}" class="{{ set_active($newslink) }}">{{ $news->title }}</a></div>
             @endforeach

--- a/resources/views/news/_sidebar.blade.php
+++ b/resources/views/news/_sidebar.blade.php
@@ -1,20 +1,20 @@
 <ul>
     <li class="sidebar-header"><a href="{{ url('news') }}" class="card-link">News</a></li>
-    @if(isset($newses))
-       <li class="sidebar-section">
-        <div class="sidebar-section-header">On This Page</div>
-        @foreach($newses as $news)
-			@php $newslink = 'news/'.$news->slug; @endphp
-            <div class="sidebar-item"><a href="{{ $news->url }}" class="{{ set_active($newslink) }}">{{ $news->title }}</a></div>
-        @endforeach
+    @if (isset($newses))
+        <li class="sidebar-section">
+            <div class="sidebar-section-header">On This Page</div>
+            @foreach ($newses as $news)
+                @php $newslink = 'news/'.$news->slug; @endphp
+                <div class="sidebar-item"><a href="{{ $news->url }}" class="{{ set_active($newslink) }}">{{ $news->title }}</a></div>
+            @endforeach
         </li>
     @else
-    <li class="sidebar-section">
-        <div class="sidebar-section-header">Recent News</div>
-        @foreach(App\Models\News::visible()->orderBy('updated_at', 'DESC')->take(10)->get() as $news)
-			@php $newslink = 'news/'.$news->slug; @endphp
-            <div class="sidebar-item"><a href="{{ $news->url }}" class="{{ set_active($newslink) }}">{{ $news->title }}</a></div>
-        @endforeach
-    </li>
+        <li class="sidebar-section">
+            <div class="sidebar-section-header">Recent News</div>
+            @foreach (App\Models\News::visible()->orderBy('updated_at', 'DESC')->take(10)->get() as $news)
+                @php $newslink = 'news/'.$news->slug; @endphp
+                <div class="sidebar-item"><a href="{{ $news->url }}" class="{{ set_active($newslink) }}">{{ $news->title }}</a></div>
+            @endforeach
+        </li>
     @endif
 </ul>

--- a/resources/views/news/index.blade.php
+++ b/resources/views/news/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app')
+@extends('news.layout')
 
 @section('title')
     Site News

--- a/resources/views/news/index.blade.php
+++ b/resources/views/news/index.blade.php
@@ -4,7 +4,7 @@
     Site News
 @endsection
 
-@section('content')
+@section('news-content')
     {!! breadcrumbs(['Site News' => 'news']) !!}
     <h1>Site News</h1>
     @if (count($newses))

--- a/resources/views/news/layout.blade.php
+++ b/resources/views/news/layout.blade.php
@@ -1,0 +1,13 @@
+@extends('layouts.app')
+
+@section('title') 
+    Site News :: @yield('news-title')
+@endsection
+
+@section('sidebar')
+    @include('news._sidebar')
+@endsection
+
+@section('content')
+	@yield('news-content')
+@endsection

--- a/resources/views/news/layout.blade.php
+++ b/resources/views/news/layout.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 
-@section('title') 
+@section('title')
     Site News :: @yield('news-title')
 @endsection
 
@@ -9,5 +9,5 @@
 @endsection
 
 @section('content')
-	@yield('news-content')
+    @yield('news-content')
 @endsection

--- a/resources/views/news/news.blade.php
+++ b/resources/views/news/news.blade.php
@@ -1,10 +1,10 @@
-@extends('layouts.app')
+@extends('news.layout')
 
-@section('title')
+@section('news-title')
     {{ $news->title }}
 @endsection
 
-@section('content')
+@section('news-content')
     {!! breadcrumbs(['Site News' => 'news', $news->title => $news->url]) !!}
     @include('news._news', ['news' => $news, 'page' => true])
     <hr class="mb-5" />

--- a/resources/views/sales/_sidebar.blade.php
+++ b/resources/views/sales/_sidebar.blade.php
@@ -2,7 +2,7 @@
     <li class="sidebar-header"><a href="{{ url('sales') }}" class="card-link">Sales</a></li>
     <li class="sidebar-section">
         <div class="sidebar-section-header">For Sale</div>
-        @foreach (App\Models\Sales\Sales::visible()->orderBy('updated_at', 'DESC')->where('is_open', 1)->get() as $sales)
+        @foreach ($forsale as $sales)
             @php $salelink = 'sales/'.$sales->slug; @endphp
             <div class="sidebar-item"><a href="{{ $sales->url }}" class="{{ set_active($salelink) }}">{{ $sales->title }}</a></div>
         @endforeach
@@ -17,7 +17,7 @@
 @else
     <li class="sidebar-section">
         <div class="sidebar-section-header">Recent Sales</div>
-        @foreach (App\Models\Sales\Sales::visible()->orderBy('updated_at', 'DESC')->take(10)->get() as $sales)
+        @foreach ($recentsales as $sales)
             @php $salelink = 'sales/'.$sales->slug; @endphp
             <div class="sidebar-item"><a href="{{ $sales->url }}" class="{{ set_active($salelink) }}">{{ '[' . ($sales->is_open ? 'OPEN' : 'CLOSED') . '] ' . $sales->title }}</a></div>
         @endforeach

--- a/resources/views/sales/_sidebar.blade.php
+++ b/resources/views/sales/_sidebar.blade.php
@@ -1,26 +1,26 @@
 <ul>
     <li class="sidebar-header"><a href="{{ url('sales') }}" class="card-link">Sales</a></li>
-        <li class="sidebar-section">
+    <li class="sidebar-section">
         <div class="sidebar-section-header">For Sale</div>
-        @foreach(App\Models\Sales\Sales::visible()->orderBy('updated_at', 'DESC')->where('is_open', 1)->get() as $sales)
-			@php $salelink = 'sales/'.$sales->slug; @endphp
+        @foreach (App\Models\Sales\Sales::visible()->orderBy('updated_at', 'DESC')->where('is_open', 1)->get() as $sales)
+            @php $salelink = 'sales/'.$sales->slug; @endphp
             <div class="sidebar-item"><a href="{{ $sales->url }}" class="{{ set_active($salelink) }}">{{ $sales->title }}</a></div>
         @endforeach
-    @if(isset($saleses))
-        <li class="sidebar-section">
+        @if (isset($saleses))
+    <li class="sidebar-section">
         <div class="sidebar-section-header">On This Page</div>
-        @foreach($saleses as $sales)
-			@php $salelink = 'sales/'.$sales->slug; @endphp
-            <div class="sidebar-item"><a href="{{ $sales->url }}" class="{{ set_active($salelink) }}">{{ '['.($sales->is_open ? 'OPEN' : 'CLOSED').'] '.$sales->title }}</a></div>
+        @foreach ($saleses as $sales)
+            @php $salelink = 'sales/'.$sales->slug; @endphp
+            <div class="sidebar-item"><a href="{{ $sales->url }}" class="{{ set_active($salelink) }}">{{ '[' . ($sales->is_open ? 'OPEN' : 'CLOSED') . '] ' . $sales->title }}</a></div>
         @endforeach
-        </li>
-    @else
-		<li class="sidebar-section">
+    </li>
+@else
+    <li class="sidebar-section">
         <div class="sidebar-section-header">Recent Sales</div>
-        @foreach(App\Models\Sales\Sales::visible()->orderBy('updated_at', 'DESC')->take(10)->get() as $sales)
-			@php $salelink = 'sales/'.$sales->slug; @endphp
-            <div class="sidebar-item"><a href="{{ $sales->url }}" class="{{ set_active($salelink) }}">{{ '['.($sales->is_open ? 'OPEN' : 'CLOSED').'] '.$sales->title }}</a></div>
+        @foreach (App\Models\Sales\Sales::visible()->orderBy('updated_at', 'DESC')->take(10)->get() as $sales)
+            @php $salelink = 'sales/'.$sales->slug; @endphp
+            <div class="sidebar-item"><a href="{{ $sales->url }}" class="{{ set_active($salelink) }}">{{ '[' . ($sales->is_open ? 'OPEN' : 'CLOSED') . '] ' . $sales->title }}</a></div>
         @endforeach
-		</li>
+    </li>
     @endif
 </ul>

--- a/resources/views/sales/_sidebar.blade.php
+++ b/resources/views/sales/_sidebar.blade.php
@@ -1,0 +1,26 @@
+<ul>
+    <li class="sidebar-header"><a href="{{ url('sales') }}" class="card-link">Sales</a></li>
+        <li class="sidebar-section">
+        <div class="sidebar-section-header">For Sale</div>
+        @foreach(App\Models\Sales\Sales::visible()->orderBy('updated_at', 'DESC')->where('is_open', 1)->get() as $sales)
+			@php $salelink = 'sales/'.$sales->slug; @endphp
+            <div class="sidebar-item"><a href="{{ $sales->url }}" class="{{ set_active($salelink) }}">{{ $sales->title }}</a></div>
+        @endforeach
+    @if(isset($saleses))
+        <li class="sidebar-section">
+        <div class="sidebar-section-header">On This Page</div>
+        @foreach($saleses as $sales)
+			@php $salelink = 'sales/'.$sales->slug; @endphp
+            <div class="sidebar-item"><a href="{{ $sales->url }}" class="{{ set_active($salelink) }}">{{ '['.($sales->is_open ? 'OPEN' : 'CLOSED').'] '.$sales->title }}</a></div>
+        @endforeach
+        </li>
+    @else
+		<li class="sidebar-section">
+        <div class="sidebar-section-header">Recent Sales</div>
+        @foreach(App\Models\Sales\Sales::visible()->orderBy('updated_at', 'DESC')->take(10)->get() as $sales)
+			@php $salelink = 'sales/'.$sales->slug; @endphp
+            <div class="sidebar-item"><a href="{{ $sales->url }}" class="{{ set_active($salelink) }}">{{ '['.($sales->is_open ? 'OPEN' : 'CLOSED').'] '.$sales->title }}</a></div>
+        @endforeach
+		</li>
+    @endif
+</ul>

--- a/resources/views/sales/index.blade.php
+++ b/resources/views/sales/index.blade.php
@@ -1,10 +1,10 @@
-@extends('layouts.app')
+@extends('sales.layout')
 
 @section('title')
     Site Sales
 @endsection
 
-@section('content')
+@section('sales-content')
     {!! breadcrumbs(['Site Sales' => 'sales']) !!}
     <h1>Site Sales</h1>
 

--- a/resources/views/sales/layout.blade.php
+++ b/resources/views/sales/layout.blade.php
@@ -1,0 +1,13 @@
+@extends('layouts.app')
+
+@section('title') 
+    Site Sales :: @yield('sales-title')
+@endsection
+
+@section('sidebar')
+    @include('sales._sidebar')
+@endsection
+
+@section('content')
+	@yield('sales-content')
+@endsection

--- a/resources/views/sales/layout.blade.php
+++ b/resources/views/sales/layout.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 
-@section('title') 
+@section('title')
     Site Sales :: @yield('sales-title')
 @endsection
 
@@ -9,5 +9,5 @@
 @endsection
 
 @section('content')
-	@yield('sales-content')
+    @yield('sales-content')
 @endsection

--- a/resources/views/sales/sales.blade.php
+++ b/resources/views/sales/sales.blade.php
@@ -1,10 +1,10 @@
-@extends('layouts.app')
+@extends('sales.layout')
 
-@section('title')
+@section('sales-title')
     {{ $sales->title }}
 @endsection
 
-@section('content')
+@section('sales-content')
     {!! breadcrumbs(['Site Sales' => 'sales', $sales->title => $sales->url]) !!}
     @include('sales._sales', ['sales' => $sales, 'page' => true])
 


### PR DESCRIPTION
Sidebars display Recent News/Sales on posts, and 'On This Page' on the index pages.
For Sales specifically, both posts and the index pages also have a section 'For Sale', which are only __open__ sales.

Original inspiration, most of the code and idea by @itinerare.