### PR TITLE
Bug: Fix the admin create script to set has_alias

### DIFF
--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -51,6 +51,7 @@ class UserService extends Service {
             'rank_id'  => $data['rank_id'],
             'password' => Hash::make($data['password']),
             'birthday' => $formatDate,
+            'has_alias' => isset($data['has_alias']) ? $data['has_alias'] : null,
         ]);
         $user->settings()->create([
             'user_id' => $user->id,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "lorekeeper",
+    "name": "lorekeeper-extensions",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {


### PR DESCRIPTION
Fixes the setup-admin-script not setting has_alias correctly, by updating the UserService call it uses to set has_alias if it's passed.