### PR TITLE
PHP 8.1 upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.4",
+        "php": "~8.1",
         "boxconnect/deviant-php": "dev-master",
         "doctrine/dbal": "2.2",
         "erusev/parsedown": "^1.7",
@@ -22,7 +22,7 @@
         "illuminate/support": "^5.6|^6.0|^7.0|^8.0",
         "intervention/image": "^2.4",
         "laracasts/flash": "^3.0",
-        "laravel/framework": "8.0",
+        "laravel/framework": "^8.0",
         "laravel/helpers": "^1.4",
         "laravel/socialite": "^5.2",
         "laravel/tinker": "^2.0",
@@ -34,7 +34,7 @@
         "socialiteproviders/tumblr": "^4.1",
         "socialiteproviders/twitch": "^5.3",
         "socialiteproviders/twitter": "^4.1",
-        "spatie/laravel-honeypot": "^2.3.0"
+        "spatie/laravel-honeypot": "^4.1"
     },
     "require-dev": {
         "beyondcode/laravel-dump-server": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": "~8.1",
         "boxconnect/deviant-php": "dev-master",
-        "doctrine/dbal": "2.2",
+        "doctrine/dbal": "^2.2",
         "erusev/parsedown": "^1.7",
         "ezyang/htmlpurifier": "^4.10",
         "fideloper/proxy": "^4.0",


### PR DESCRIPTION
Reportedly, Dreamhost is pushing upgrading sites to PHP 8.1 due to support ending for 7.4... which is understandable for security etc reasons, and probably an idea, but annoying from a logistical standpoint.
However this is salvageable without too significant changes since Laravel 8 supports PHP 8.1 at maximum and takes surprisingly few changes to arrive at a compatible set of packages. The main things are just allowing Laravel (within the same major version) and doctrine/dbal (fine since the issue we were prior having with it looks to be resolved anyhow) to update.

This has been tested a bit already, and looks to be working alright, hence the PR, but more is always welcome.
Necessary actions are just updating PHP itself and running composer.