### PR TITLE
Adjust Prev and Next Buttons to respect when 'character_pull_number' is 'all',

### DIFF
--- a/app/Http/Controllers/Characters/CharacterController.php
+++ b/app/Http/Controllers/Characters/CharacterController.php
@@ -21,6 +21,7 @@ use App\Services\DesignUpdateManager;
 use App\Services\InventoryManager;
 use Auth;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\View;
 use Route;
 use Settings;
@@ -52,8 +53,11 @@ class CharacterController extends Controller {
 
             $this->character->updateOwner();
 
-            // Get only characters of this category
-            $query = Character::myo(0)->where('character_category_id', $this->character->character_category_id);
+            $query = Character::myo(0);
+            // Get only characters of this category if pull number is limited to category
+            if (Config::get('lorekeeper.settings.character_pull_number') === 'category')
+                $query->where('character_category_id', $this->character->character_category_id);
+            
             if (!(Auth::check() && Auth::user()->hasPower('manage_characters'))) {
                 $query->where('is_visible', 1);
             }

--- a/app/Http/Controllers/Characters/CharacterController.php
+++ b/app/Http/Controllers/Characters/CharacterController.php
@@ -55,9 +55,10 @@ class CharacterController extends Controller {
 
             $query = Character::myo(0);
             // Get only characters of this category if pull number is limited to category
-            if (Config::get('lorekeeper.settings.character_pull_number') === 'category')
+            if (Config::get('lorekeeper.settings.character_pull_number') === 'category') {
                 $query->where('character_category_id', $this->character->character_category_id);
-            
+            }
+
             if (!(Auth::check() && Auth::user()->hasPower('manage_characters'))) {
                 $query->where('is_visible', 1);
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "lorekeeper",
+    "name": "lorekeeper-extensions",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "lorekeeper-extensions",
+    "name": "lorekeeper",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {


### PR DESCRIPTION
If a LK site was using `'character_pull_number' => 'all'` in settings and tried to use the new previous and next buttons a lot of characters would have oddly missing buttons to the non-sequential numbers between categories. This adjusts the prev and next buttons to respect the LK setting and only filter by category if it's set that way.