### PR TITLE
Feat(character): Updating previous and next buttons to skip the gaps

### DIFF
--- a/app/Http/Controllers/Characters/CharacterController.php
+++ b/app/Http/Controllers/Characters/CharacterController.php
@@ -62,7 +62,6 @@ class CharacterController extends Controller {
             if (!(Auth::check() && Auth::user()->hasPower('manage_characters'))) {
                 $query->where('is_visible', 1);
             }
-            $query->whereBetween('number', [$this->character->number - 1, $this->character->number + 1])->orderBy('number');
 
             // Get the previous and next characters, if they exist
             $prevCharName = null;
@@ -70,14 +69,21 @@ class CharacterController extends Controller {
             $nextCharName = null;
             $nextCharUrl = null;
 
-            $previousCharacter = $query->get()->first();
+            if ($query->count()) {
+                $characters = $query->orderBy('number')->get();
+
+                // Filter
+                $previousCharacter = $characters->where('number', '<', $this->character->number)->last();
+                $nextCharacter = $characters->where('number', '>', $this->character->number)->first();
+            }
+			
             if (!$previousCharacter || $previousCharacter->id == $this->character->id) {
                 $previousCharacter = null;
             } else {
                 $prevCharName = $previousCharacter->fullName;
                 $prevCharUrl = $previousCharacter->url;
             }
-            $nextCharacter = $query->get()->last();
+
             if (!$nextCharacter || $nextCharacter->id == $this->character->id) {
                 $nextCharacter = null;
             } else {

--- a/app/Http/Controllers/Characters/CharacterController.php
+++ b/app/Http/Controllers/Characters/CharacterController.php
@@ -76,7 +76,7 @@ class CharacterController extends Controller {
                 $previousCharacter = $characters->where('number', '<', $this->character->number)->last();
                 $nextCharacter = $characters->where('number', '>', $this->character->number)->first();
             }
-			
+
             if (!$previousCharacter || $previousCharacter->id == $this->character->id) {
                 $previousCharacter = null;
             } else {

--- a/app/Http/Controllers/Characters/CharacterController.php
+++ b/app/Http/Controllers/Characters/CharacterController.php
@@ -54,7 +54,6 @@ class CharacterController extends Controller {
             $this->character->updateOwner();
 
             if (Config::get('lorekeeper.extensions.previous_and_next_characters.display')) {
-
                 $query = Character::myo(0);
                 // Get only characters of this category if pull number is limited to category
                 if (Config::get('lorekeeper.settings.character_pull_number') === 'category') {
@@ -72,7 +71,7 @@ class CharacterController extends Controller {
                 $nextCharUrl = null;
 
                 if ($query->count()) {
-                    $characters = $query->orderBy('number','DESC')->get();
+                    $characters = $query->orderBy('number', 'DESC')->get();
 
                     // Filter
                     $lowerChar = $characters->where('number', '<', $this->character->number)->first();
@@ -80,12 +79,12 @@ class CharacterController extends Controller {
                 }
 
                 if (Config::get('lorekeeper.extensions.previous_and_next_characters.reverse') == 0) {
-				    $nextCharacter = $lowerChar;
-				    $previousCharacter = $higherChar;
-				} else {
-				    $previousCharacter = $lowerChar;
-				    $nextCharacter = $higherChar;
-				}
+                    $nextCharacter = $lowerChar;
+                    $previousCharacter = $higherChar;
+                } else {
+                    $previousCharacter = $lowerChar;
+                    $nextCharacter = $higherChar;
+                }
 
                 if (!$previousCharacter || $previousCharacter->id == $this->character->id) {
                     $previousCharacter = null;
@@ -101,9 +100,10 @@ class CharacterController extends Controller {
                     $nextCharUrl = $nextCharacter->url;
                 }
 
-			    $extPrevAndNextBtns = ['prevCharName' => $prevCharName, 'prevCharUrl' => $prevCharUrl, 'nextCharName' => $nextCharName, 'nextCharUrl' => $nextCharUrl];
+                $extPrevAndNextBtns = ['prevCharName' => $prevCharName, 'prevCharUrl' => $prevCharUrl, 'nextCharName' => $nextCharName, 'nextCharUrl' => $nextCharUrl];
                 View::share('extPrevAndNextBtns', $extPrevAndNextBtns);
-			}
+            }
+
             return $next($request);
         });
     }

--- a/app/Http/Controllers/Characters/CharacterController.php
+++ b/app/Http/Controllers/Characters/CharacterController.php
@@ -53,46 +53,57 @@ class CharacterController extends Controller {
 
             $this->character->updateOwner();
 
-            $query = Character::myo(0);
-            // Get only characters of this category if pull number is limited to category
-            if (Config::get('lorekeeper.settings.character_pull_number') === 'category') {
-                $query->where('character_category_id', $this->character->character_category_id);
-            }
+            if (Config::get('lorekeeper.extensions.previous_and_next_characters.display')) {
 
-            if (!(Auth::check() && Auth::user()->hasPower('manage_characters'))) {
-                $query->where('is_visible', 1);
-            }
+                $query = Character::myo(0);
+                // Get only characters of this category if pull number is limited to category
+                if (Config::get('lorekeeper.settings.character_pull_number') === 'category') {
+                    $query->where('character_category_id', $this->character->character_category_id);
+                }
 
-            // Get the previous and next characters, if they exist
-            $prevCharName = null;
-            $prevCharUrl = null;
-            $nextCharName = null;
-            $nextCharUrl = null;
+                if (!(Auth::check() && Auth::user()->hasPower('manage_characters'))) {
+                    $query->where('is_visible', 1);
+                }
 
-            if ($query->count()) {
-                $characters = $query->orderBy('number')->get();
+                // Get the previous and next characters, if they exist
+                $prevCharName = null;
+                $prevCharUrl = null;
+                $nextCharName = null;
+                $nextCharUrl = null;
 
-                // Filter
-                $previousCharacter = $characters->where('number', '<', $this->character->number)->last();
-                $nextCharacter = $characters->where('number', '>', $this->character->number)->first();
-            }
+                if ($query->count()) {
+                    $characters = $query->orderBy('number','DESC')->get();
 
-            if (!$previousCharacter || $previousCharacter->id == $this->character->id) {
-                $previousCharacter = null;
-            } else {
-                $prevCharName = $previousCharacter->fullName;
-                $prevCharUrl = $previousCharacter->url;
-            }
+                    // Filter
+                    $lowerChar = $characters->where('number', '<', $this->character->number)->first();
+                    $higherChar = $characters->where('number', '>', $this->character->number)->last();
+                }
 
-            if (!$nextCharacter || $nextCharacter->id == $this->character->id) {
-                $nextCharacter = null;
-            } else {
-                $nextCharName = $nextCharacter->fullName;
-                $nextCharUrl = $nextCharacter->url;
-            }
-            $extPrevAndNextBtns = ['prevCharName' => $prevCharName, 'prevCharUrl' => $prevCharUrl, 'nextCharName' => $nextCharName, 'nextCharUrl' => $nextCharUrl];
-            View::share('extPrevAndNextBtns', $extPrevAndNextBtns);
+                if (Config::get('lorekeeper.extensions.previous_and_next_characters.reverse') == 0) {
+				    $nextCharacter = $lowerChar;
+				    $previousCharacter = $higherChar;
+				} else {
+				    $previousCharacter = $lowerChar;
+				    $nextCharacter = $higherChar;
+				}
 
+                if (!$previousCharacter || $previousCharacter->id == $this->character->id) {
+                    $previousCharacter = null;
+                } else {
+                    $prevCharName = $previousCharacter->fullName;
+                    $prevCharUrl = $previousCharacter->url;
+                }
+
+                if (!$nextCharacter || $nextCharacter->id == $this->character->id) {
+                    $nextCharacter = null;
+                } else {
+                    $nextCharName = $nextCharacter->fullName;
+                    $nextCharUrl = $nextCharacter->url;
+                }
+
+			    $extPrevAndNextBtns = ['prevCharName' => $prevCharName, 'prevCharUrl' => $prevCharUrl, 'nextCharName' => $nextCharName, 'nextCharUrl' => $nextCharUrl];
+                View::share('extPrevAndNextBtns', $extPrevAndNextBtns);
+			}
             return $next($request);
         });
     }

--- a/config/lorekeeper/extensions.php
+++ b/config/lorekeeper/extensions.php
@@ -77,7 +77,7 @@ return [
     // Previous & Next buttons on Character pages - Speedy
     // Adds buttons linking to the previous character as well as the next character on all character pages.
     'previous_and_next_characters' => [
-	    'display' => 1,
-		'reverse' => 0, // By default, 0 has the lower number on the 'Next' side and the higher number on the 'Previous' side, reflecting the default masterlist order. Setting this to 1 reverses this.
-	],
+        'display' => 1,
+        'reverse' => 0, // By default, 0 has the lower number on the 'Next' side and the higher number on the 'Previous' side, reflecting the default masterlist order. Setting this to 1 reverses this.
+    ],
 ];

--- a/config/lorekeeper/extensions.php
+++ b/config/lorekeeper/extensions.php
@@ -76,5 +76,8 @@ return [
 
     // Previous & Next buttons on Character pages - Speedy
     // Adds buttons linking to the previous character as well as the next character on all character pages.
-    'display_previous_and_next_characters' => 0,
+    'previous_and_next_characters' => [
+	    'display' => 1,
+		'reverse' => 0, // By default, 0 has the lower number on the 'Next' side and the higher number on the 'Previous' side, reflecting the default masterlist order. Setting this to 1 reverses this.
+	],
 ];

--- a/config/lorekeeper/extensions.php
+++ b/config/lorekeeper/extensions.php
@@ -77,7 +77,7 @@ return [
     // Previous & Next buttons on Character pages - Speedy
     // Adds buttons linking to the previous character as well as the next character on all character pages.
     'previous_and_next_characters' => [
-        'display' => 1,
+        'display' => 0,
         'reverse' => 0, // By default, 0 has the lower number on the 'Next' side and the higher number on the 'Previous' side, reflecting the default masterlist order. Setting this to 1 reverses this.
     ],
 ];

--- a/resources/views/character/_header.blade.php
+++ b/resources/views/character/_header.blade.php
@@ -1,4 +1,4 @@
-@if (!$character->is_myo_slot && Config::get('lorekeeper.extensions.display_previous_and_next_characters') && isset($extPrevAndNextBtnsUrl))
+@if (!$character->is_myo_slot && Config::get('lorekeeper.extensions.previous_and_next_characters.display') && isset($extPrevAndNextBtnsUrl))
     @if ($extPrevAndNextBtns['prevCharName'] || $extPrevAndNextBtns['nextCharName'])
         <div class="row mb-4">
             @if ($extPrevAndNextBtns['prevCharName'])


### PR DESCRIPTION
Have been thinking for a while to update the previous and next buttons.. so they no longer skip over the gaps- displaying no previous or next button just because in a sequence of 1-2-4-5 there is no 3, so no previous on 4 and no next on 2.. that's silly.

Spoke about it with @itinerare who quickly produced code, but it required some testing.. and some fixing. And that's what I did.

Also special mention to @AW0005 whose recent edit to the code made me consider doing this. :)