### PR TITLE
bug(prompts): Category Filter value being set to name

### DIFF
--- a/resources/views/admin/features/features.blade.php
+++ b/resources/views/admin/features/features.blade.php
@@ -31,7 +31,7 @@
             {!! Form::select('rarity_id', $rarities, Request::get('rarity_id'), ['class' => 'form-control']) !!}
         </div>
         <div class="form-group mr-3 mb-3">
-            {!! Form::select('feature_category_id', $categories, Request::get('name'), ['class' => 'form-control']) !!}
+            {!! Form::select('feature_category_id', $categories, Request::get('feature_category_id'), ['class' => 'form-control']) !!}
         </div>
         <div class="form-group mb-3">
             {!! Form::submit('Search', ['class' => 'btn btn-primary']) !!}

--- a/resources/views/admin/items/items.blade.php
+++ b/resources/views/admin/items/items.blade.php
@@ -26,7 +26,7 @@
             {!! Form::text('name', Request::get('name'), ['class' => 'form-control', 'placeholder' => 'Name']) !!}
         </div>
         <div class="form-group mr-3 mb-3">
-            {!! Form::select('item_category_id', $categories, Request::get('name'), ['class' => 'form-control']) !!}
+            {!! Form::select('item_category_id', $categories, Request::get('item_category_id'), ['class' => 'form-control']) !!}
         </div>
         <div class="form-group mb-3">
             {!! Form::submit('Search', ['class' => 'btn btn-primary']) !!}

--- a/resources/views/admin/prompts/prompts.blade.php
+++ b/resources/views/admin/prompts/prompts.blade.php
@@ -22,7 +22,7 @@
             {!! Form::text('name', Request::get('name'), ['class' => 'form-control', 'placeholder' => 'Name']) !!}
         </div>
         <div class="form-group mr-3 mb-3">
-            {!! Form::select('prompt_category_id', $categories, Request::get('name'), ['class' => 'form-control']) !!}
+            {!! Form::select('prompt_category_id', $categories, Request::get('prompt_category_id'), ['class' => 'form-control']) !!}
         </div>
         <div class="form-group mb-3">{!! Form::submit('Search', ['class' => 'btn btn-primary']) !!}</div>
         {!! Form::close() !!}

--- a/resources/views/prompts/prompts.blade.php
+++ b/resources/views/prompts/prompts.blade.php
@@ -15,7 +15,7 @@
                 {!! Form::text('name', Request::get('name'), ['class' => 'form-control', 'placeholder' => 'Name']) !!}
             </div>
             <div class="form-group ml-3 mb-3">
-                {!! Form::select('prompt_category_id', $categories, Request::get('name'), ['class' => 'form-control']) !!}
+                {!! Form::select('prompt_category_id', $categories, Request::get('prompt_category_id'), ['class' => 'form-control']) !!}
             </div>
             <div class="form-group ml-3 mb-3">
                 {!! Form::select('open_prompts', ['any' => 'Any Status', 'open' => 'Open Prompts', 'closed' => 'Closed Prompts'], Request::get('open_prompts') ?? 'any', ['class' => 'form-control selectize']) !!}

--- a/resources/views/world/prompts.blade.php
+++ b/resources/views/world/prompts.blade.php
@@ -15,7 +15,7 @@
                 {!! Form::text('name', Request::get('name'), ['class' => 'form-control', 'placeholder' => 'Name']) !!}
             </div>
             <div class="form-group ml-3 mb-3">
-                {!! Form::select('prompt_category_id', $categories, Request::get('name'), ['class' => 'form-control']) !!}
+                {!! Form::select('prompt_category_id', $categories, Request::get('prompt_category_id'), ['class' => 'form-control']) !!}
             </div>
         </div>
         <div class="form-inline justify-content-end">


### PR DESCRIPTION
Just a teeny bug fix that I noticed, where the selected category on the prompts filter wasn't "sticking" on clicking search because it's value was being set to name instead.