### PR TITLE
bug(items): item images weren't deleting

### DIFF
--- a/app/Services/ItemService.php
+++ b/app/Services/ItemService.php
@@ -259,7 +259,7 @@ class ItemService extends Service {
                 throw new \Exception('The selected item category is invalid.');
             }
 
-            $data = $this->populateData($data);
+            $data = $this->populateData($data, $item);
 
             $image = null;
             if (isset($data['image']) && $data['image']) {


### PR DESCRIPTION
Since the `$image` variable wasn't being passed to the `populateData` function the code to delete an existing image on an item was never being run.