### PR TITLE
fix(inventories): fix for user, home and character inventories

### DIFF
--- a/resources/views/character/inventory.blade.php
+++ b/resources/views/character/inventory.blade.php
@@ -28,9 +28,9 @@
         <div class="card mb-3 inventory-category">
             <h5 class="card-header inventory-header">
                 {!! isset($categories[$categoryId]) ? '<a href="' . $categories[$categoryId]->searchUrl . '">' . $categories[$categoryId]->name . '</a>' : 'Miscellaneous' !!}
-                <a class="small inventory-collapse-toggle collapse-toggle" href="#categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id) : 'miscellaneous' !!}" data-toggle="collapse">Show</a>
+                <a class="small inventory-collapse-toggle collapse-toggle" href="#categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}" data-toggle="collapse">Show</a>
             </h5>
-            <div class="card-body inventory-body collapse show" id="categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id) : 'miscellaneous' !!}">
+            <div class="card-body inventory-body collapse show" id="categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}">
                 @foreach ($categoryItems->chunk(4) as $chunk)
                     <div class="row mb-3">
                         @foreach ($chunk as $itemId => $stack)

--- a/resources/views/character/inventory.blade.php
+++ b/resources/views/character/inventory.blade.php
@@ -28,8 +28,9 @@
         <div class="card mb-3 inventory-category">
             <h5 class="card-header inventory-header">
                 {!! isset($categories[$categoryId]) ? '<a href="' . $categories[$categoryId]->searchUrl . '">' . $categories[$categoryId]->name . '</a>' : 'Miscellaneous' !!}
+                <a class="small inventory-collapse-toggle collapse-toggle" href="#categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id) : 'miscellaneous' !!}" data-toggle="collapse">Show</a>
             </h5>
-            <div class="card-body inventory-body">
+            <div class="card-body inventory-body collapse show" id="categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id) : 'miscellaneous' !!}">
                 @foreach ($categoryItems->chunk(4) as $chunk)
                     <div class="row mb-3">
                         @foreach ($chunk as $itemId => $stack)

--- a/resources/views/home/inventory.blade.php
+++ b/resources/views/home/inventory.blade.php
@@ -21,9 +21,9 @@
         <div class="card mb-3 inventory-category">
             <h5 class="card-header inventory-header">
                 {!! isset($categories[$categoryId]) ? '<a href="' . $categories[$categoryId]->searchUrl . '">' . $categories[$categoryId]->name . '</a>' : 'Miscellaneous' !!}
-                <a class="small inventory-collapse-toggle collapse-toggle collapsed" href="#{!! isset($categories[$categoryId]) ? str_replace(' ', '', $categories[$categoryId]->name) : 'miscellaneous' !!}" data-toggle="collapse">Show</a></h3>
+                <a class="small inventory-collapse-toggle collapse-toggle" href="#categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}" data-toggle="collapse">Show</a>
             </h5>
-            <div class="card-body inventory-body collapse show" id="{!! isset($categories[$categoryId]) ? str_replace(' ', '', $categories[$categoryId]->name) : 'miscellaneous' !!}">
+            <div class="card-body inventory-body collapse show" id="categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id) : 'miscellaneous' !!}">
                 @foreach ($categoryItems->chunk(4) as $chunk)
                     <div class="row mb-3">
                         @foreach ($chunk as $itemId => $stack)

--- a/resources/views/home/inventory.blade.php
+++ b/resources/views/home/inventory.blade.php
@@ -23,7 +23,7 @@
                 {!! isset($categories[$categoryId]) ? '<a href="' . $categories[$categoryId]->searchUrl . '">' . $categories[$categoryId]->name . '</a>' : 'Miscellaneous' !!}
                 <a class="small inventory-collapse-toggle collapse-toggle" href="#categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}" data-toggle="collapse">Show</a>
             </h5>
-            <div class="card-body inventory-body collapse show" id="categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id) : 'miscellaneous' !!}">
+            <div class="card-body inventory-body collapse show" id="categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}">
                 @foreach ($categoryItems->chunk(4) as $chunk)
                     <div class="row mb-3">
                         @foreach ($chunk as $itemId => $stack)

--- a/resources/views/user/inventory.blade.php
+++ b/resources/views/user/inventory.blade.php
@@ -15,9 +15,9 @@
         <div class="card mb-3 inventory-category">
             <h5 class="card-header inventory-header">
                 {!! isset($categories[$categoryId]) ? '<a href="' . $categories[$categoryId]->searchUrl . '">' . $categories[$categoryId]->name . '</a>' : 'Miscellaneous' !!}
-                <a class="small inventory-collapse-toggle collapse-toggle collapsed" href="#{!! isset($categories[$categoryId]) ? str_replace(' ', '', $categories[$categoryId]->name) : 'miscellaneous' !!}" data-toggle="collapse">Show</a></h3>
+                <a class="small inventory-collapse-toggle collapse-toggle" href="#categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}" data-toggle="collapse">Show</a>
             </h5>
-            <div class="card-body inventory-body collapse show" id="{!! isset($categories[$categoryId]) ? str_replace(' ', '', $categories[$categoryId]->name) : 'miscellaneous' !!}">
+            <div class="card-body inventory-body collapse show" id="categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}">
                 @foreach ($categoryItems->chunk(4) as $chunk)
                     <div class="row mb-3">
                         @foreach ($chunk as $itemId => $stack)


### PR DESCRIPTION
- Are now equivalent in being able to open and close per category.
- Categories are now id'd by.. category id, rather than name, which lead to a few problems.
- Arrow now correctly shows as open rather than closed, which was a minor pet peeve that bothered me.

I did this mostly for consistency between the three types of inventory pages, and also.. one of the sites I work on has a category that's like `Named Character's Items` .. and the `'` broke the collapse.

And yes, the arrows started as 'collapsed' bothered me to no end. So I also fixed that. They now start as 'open', as categories are, by default, open.