### PR TITLE
Feat(site): Modifying pagination to allow page select on ...

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -23,7 +23,8 @@ class AppServiceProvider extends ServiceProvider {
     public function boot() {
         //
         Schema::defaultStringLength(191);
-        Paginator::useBootstrap();
+		Paginator::defaultView('layouts._pagination');
+        Paginator::defaultSimpleView('layouts._simple-pagination');
 
         /*
          * Paginate a standard Laravel Collection.

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -23,7 +23,7 @@ class AppServiceProvider extends ServiceProvider {
     public function boot() {
         //
         Schema::defaultStringLength(191);
-		Paginator::defaultView('layouts._pagination');
+        Paginator::defaultView('layouts._pagination');
         Paginator::defaultSimpleView('layouts._simple-pagination');
 
         /*

--- a/public/css/lorekeeper.css
+++ b/public/css/lorekeeper.css
@@ -376,6 +376,18 @@ main > .row {
     flex-wrap: wrap;
 }
 
+/* Chrome, Safari, Edge, Opera */
+.pagination-popover input::-webkit-outer-spin-button,
+.pagination-popover input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+/* Firefox */
+.pagination-popover input[type=number] {
+  -moz-appearance: textfield;
+}
+
 .spoiler {
     border: 1px solid rgba(0,0,0,0.1);
     border-radius: 5px;

--- a/resources/views/layouts/_pagination.blade.php
+++ b/resources/views/layouts/_pagination.blade.php
@@ -1,0 +1,46 @@
+@if ($paginator->hasPages())
+    <nav>
+        <ul class="pagination">
+            {{-- Previous Page Link --}}
+            @if ($paginator->onFirstPage())
+                <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.previous')">
+                    <span class="page-link" aria-hidden="true">&lsaquo;</span>
+                </li>
+            @else
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev" aria-label="@lang('pagination.previous')">&lsaquo;</a>
+                </li>
+            @endif
+
+            {{-- Pagination Elements --}}
+            @foreach ($elements as $element)
+                {{-- "Three Dots" Separator --}}
+                @if (is_string($element))
+                    <li class="page-item disabled" aria-disabled="true"><span class="page-link">{{ $element }}</span></li>
+                @endif
+
+                {{-- Array Of Links --}}
+                @if (is_array($element))
+                    @foreach ($element as $page => $url)
+                        @if ($page == $paginator->currentPage())
+                            <li class="page-item active" aria-current="page"><span class="page-link">{{ $page }}</span></li>
+                        @else
+                            <li class="page-item"><a class="page-link" href="{{ $url }}">{{ $page }}</a></li>
+                        @endif
+                    @endforeach
+                @endif
+            @endforeach
+
+            {{-- Next Page Link --}}
+            @if ($paginator->hasMorePages())
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next" aria-label="@lang('pagination.next')">&rsaquo;</a>
+                </li>
+            @else
+                <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.next')">
+                    <span class="page-link" aria-hidden="true">&rsaquo;</span>
+                </li>
+            @endif
+        </ul>
+    </nav>
+@endif

--- a/resources/views/layouts/_pagination.blade.php
+++ b/resources/views/layouts/_pagination.blade.php
@@ -16,22 +16,16 @@
             @foreach ($elements as $element)
                 {{-- "Three Dots" Separator --}}
                 @if (is_string($element))
-                    @php
-                        $instanceID = mt_rand();
-                    @endphp
-                    <li class="page-item pageSelectPopover{{ $instanceID }}" data-container="body" data-toggle="popover" data-placement="top" data-title="Jump to Page" data-html="true"
+                    <li class="page-item pageSelectPopover" data-container="body" data-toggle="popover" data-placement="top" data-title="Jump to Page" data-html="true"
                         data-content='
-                    <form>
-                    <div class="form-group justify-content-center">
-                            <input type="range" class="form-control-range custom-range" id="paginationPageRange{{ $instanceID }}" min="1" max="{{ $paginator->lastPage() }}" value="{{ $paginator->currentPage() }}" onchange="pageUpdateSelectText{{ $instanceID }}()">
-                            <input type="number" id="paginationPageText{{ $instanceID }}" min="1" max="{{ $paginator->lastPage() }}" value="{{ $paginator->currentPage() }}" onchange="pageUpdateSelectRange{{ $instanceID }}()">
-                            <button type="button" class="btn btn-primary" onclick="pageGo{{ $instanceID }}()">Go</button>
+                        <div class="pagination-popover d-flex align-items-center" style="gap: 10px;">
+                            <input type="range" class="form-control-range custom-range paginationPageRange" min="1" max="{{ $paginator->lastPage() }}" value="{{ $paginator->currentPage() }}" oninput="this.nextElementSibling.value = this.value">
+                            <input type="number" style="flex: 1 0 35px; height: 24px;" class="paginationPageText form-control form-control-sm py-0 px-1" min="1" max="{{ $paginator->lastPage() }}" value="{{ $paginator->currentPage() }}" oninput="this.previousElementSibling.value = this.value">
+                            <span class="badge badge-primary paginator-btn p-1 px-2" style="cursor: pointer; font-size: 14px">Go</span>
                         </div>
-                    </form>
                     '>
                         <span class="page-link">{{ $element }}</span>
                     </li>
-                    @include('layouts._pagination_js')
                 @endif
 
                 {{-- Array Of Links --}}

--- a/resources/views/layouts/_pagination.blade.php
+++ b/resources/views/layouts/_pagination.blade.php
@@ -30,7 +30,7 @@
                     </form>
                     '>
                         <span class="page-link">{{ $element }}</span></li>
-                    @include('layouts._pagination_js', ['ID' => $instanceID])
+                    @include('layouts._pagination_js')
                 @endif
 
                 {{-- Array Of Links --}}

--- a/resources/views/layouts/_pagination.blade.php
+++ b/resources/views/layouts/_pagination.blade.php
@@ -19,7 +19,8 @@
                     @php
                         $instanceID = mt_rand();
                     @endphp
-                    <li class="page-item pageSelectPopover{{ $instanceID }}" data-container="body" data-toggle="popover" data-placement="top" data-title="Jump to Page" data-html="true" data-content='
+                    <li class="page-item pageSelectPopover{{ $instanceID }}" data-container="body" data-toggle="popover" data-placement="top" data-title="Jump to Page" data-html="true"
+                        data-content='
                     <form>
                     <div class="form-group justify-content-center">
                             <input type="range" class="form-control-range custom-range" id="paginationPageRange{{ $instanceID }}" min="1" max="{{ $paginator->lastPage() }}" value="{{ $paginator->currentPage() }}" onchange="pageUpdateSelectText{{ $instanceID }}()">
@@ -27,7 +28,8 @@
                             <button type="button" class="btn btn-primary" onclick="pageGo{{ $instanceID }}()">Go</button>
                         </div>
                     </form>
-                    '><span class="page-link">{{ $element }}</span></li>
+                    '>
+                        <span class="page-link">{{ $element }}</span></li>
                     @include('layouts._pagination_js', ['ID' => $instanceID])
                 @endif
 

--- a/resources/views/layouts/_pagination.blade.php
+++ b/resources/views/layouts/_pagination.blade.php
@@ -29,7 +29,8 @@
                         </div>
                     </form>
                     '>
-                        <span class="page-link">{{ $element }}</span></li>
+                        <span class="page-link">{{ $element }}</span>
+                    </li>
                     @include('layouts._pagination_js')
                 @endif
 

--- a/resources/views/layouts/_pagination.blade.php
+++ b/resources/views/layouts/_pagination.blade.php
@@ -16,7 +16,19 @@
             @foreach ($elements as $element)
                 {{-- "Three Dots" Separator --}}
                 @if (is_string($element))
-                    <li class="page-item disabled" aria-disabled="true"><span class="page-link">{{ $element }}</span></li>
+                    @php
+                        $instanceID = mt_rand();
+                    @endphp
+                    <li class="page-item pageSelectPopover{{ $instanceID }}" data-container="body" data-toggle="popover" data-placement="top" data-title="Jump to Page" data-html="true" data-content='
+                    <form>
+                    <div class="form-group justify-content-center">
+                            <input type="range" class="form-control-range custom-range" id="paginationPageRange{{ $instanceID }}" min="1" max="{{ $paginator->lastPage() }}" value="{{ $paginator->currentPage() }}" onchange="pageUpdateSelectText{{ $instanceID }}()">
+                            <input type="number" id="paginationPageText{{ $instanceID }}" min="1" max="{{ $paginator->lastPage() }}" value="{{ $paginator->currentPage() }}" onchange="pageUpdateSelectRange{{ $instanceID }}()">
+                            <button type="button" class="btn btn-primary" onclick="pageGo{{ $instanceID }}()">Go</button>
+                        </div>
+                    </form>
+                    '><span class="page-link">{{ $element }}</span></li>
+                    @include('layouts._pagination_js', ['ID' => $instanceID])
                 @endif
 
                 {{-- Array Of Links --}}

--- a/resources/views/layouts/_pagination_js.blade.php
+++ b/resources/views/layouts/_pagination_js.blade.php
@@ -1,38 +1,38 @@
 <script>
-var pageSelectPopoverShown{{ $instanceID }} = false;
-var pageSelectRange{{ $instanceID }} = new Object();
-var pageSelectText{{ $instanceID }} = new Object();
+    var pageSelectPopoverShown{{ $instanceID }} = false;
+    var pageSelectRange{{ $instanceID }} = new Object();
+    var pageSelectText{{ $instanceID }} = new Object();
 
-var pageCurrent{{ $instanceID }} = new URL(window.location.href);
+    var pageCurrent{{ $instanceID }} = new URL(window.location.href);
 
-$(function () {
-    $('.pageSelectPopover{{ $instanceID }}').popover()
-});
+    $(function() {
+        $('.pageSelectPopover{{ $instanceID }}').popover()
+    });
 
-$('.pageSelectPopover{{ $instanceID }}').on('shown.bs.popover', function () {
-	pageWorkingPopover{{ $instanceID }} = this;
-    pageSelectPopoverShown{{ $instanceID }} = true;
-    pageSelectRange{{ $instanceID }} = document.getElementById('paginationPageRange{{ $instanceID }}');
-    pageSelectText{{ $instanceID }} = document.getElementById('paginationPageText{{ $instanceID }}');
-});
+    $('.pageSelectPopover{{ $instanceID }}').on('shown.bs.popover', function() {
+        pageWorkingPopover{{ $instanceID }} = this;
+        pageSelectPopoverShown{{ $instanceID }} = true;
+        pageSelectRange{{ $instanceID }} = document.getElementById('paginationPageRange{{ $instanceID }}');
+        pageSelectText{{ $instanceID }} = document.getElementById('paginationPageText{{ $instanceID }}');
+    });
 
-$('.pageSelectPopover{{ $instanceID }}').on('hidden.bs.popover', function () {
-    pageWorkingPopover{{ $instanceID }} = null;
-	pageSelectPopoverShown{{ $instanceID }} = false;
-    pageSelectRange{{ $instanceID }} = null;
-    pageSelectText{{ $instanceID }} = null;
-});
+    $('.pageSelectPopover{{ $instanceID }}').on('hidden.bs.popover', function() {
+        pageWorkingPopover{{ $instanceID }} = null;
+        pageSelectPopoverShown{{ $instanceID }} = false;
+        pageSelectRange{{ $instanceID }} = null;
+        pageSelectText{{ $instanceID }} = null;
+    });
 
-function pageUpdateSelectText{{ $instanceID }}() {
-    pageSelectText{{ $instanceID }}.value = pageSelectRange{{ $instanceID }}.value;
-}
+    function pageUpdateSelectText{{ $instanceID }}() {
+        pageSelectText{{ $instanceID }}.value = pageSelectRange{{ $instanceID }}.value;
+    }
 
-function pageUpdateSelectRange{{ $instanceID }}() {
-    pageSelectRange{{ $instanceID }}.value = pageSelectText{{ $instanceID }}.value;
-}
+    function pageUpdateSelectRange{{ $instanceID }}() {
+        pageSelectRange{{ $instanceID }}.value = pageSelectText{{ $instanceID }}.value;
+    }
 
-function pageGo{{ $instanceID }}() {
-	pageCurrent{{ $instanceID }}.searchParams.set("page", pageSelectRange{{ $instanceID }}.value);
-	 document.location.href = pageCurrent{{ $instanceID }}.href;
-}
+    function pageGo{{ $instanceID }}() {
+        pageCurrent{{ $instanceID }}.searchParams.set("page", pageSelectRange{{ $instanceID }}.value);
+        document.location.href = pageCurrent{{ $instanceID }}.href;
+    }
 </script>

--- a/resources/views/layouts/_pagination_js.blade.php
+++ b/resources/views/layouts/_pagination_js.blade.php
@@ -1,0 +1,38 @@
+<script>
+var pageSelectPopoverShown{{ $instanceID }} = false;
+var pageSelectRange{{ $instanceID }} = new Object();
+var pageSelectText{{ $instanceID }} = new Object();
+
+var pageCurrent{{ $instanceID }} = new URL(window.location.href);
+
+$(function () {
+    $('.pageSelectPopover{{ $instanceID }}').popover()
+});
+
+$('.pageSelectPopover{{ $instanceID }}').on('shown.bs.popover', function () {
+	pageWorkingPopover{{ $instanceID }} = this;
+    pageSelectPopoverShown{{ $instanceID }} = true;
+    pageSelectRange{{ $instanceID }} = document.getElementById('paginationPageRange{{ $instanceID }}');
+    pageSelectText{{ $instanceID }} = document.getElementById('paginationPageText{{ $instanceID }}');
+});
+
+$('.pageSelectPopover{{ $instanceID }}').on('hidden.bs.popover', function () {
+    pageWorkingPopover{{ $instanceID }} = null;
+	pageSelectPopoverShown{{ $instanceID }} = false;
+    pageSelectRange{{ $instanceID }} = null;
+    pageSelectText{{ $instanceID }} = null;
+});
+
+function pageUpdateSelectText{{ $instanceID }}() {
+    pageSelectText{{ $instanceID }}.value = pageSelectRange{{ $instanceID }}.value;
+}
+
+function pageUpdateSelectRange{{ $instanceID }}() {
+    pageSelectRange{{ $instanceID }}.value = pageSelectText{{ $instanceID }}.value;
+}
+
+function pageGo{{ $instanceID }}() {
+	pageCurrent{{ $instanceID }}.searchParams.set("page", pageSelectRange{{ $instanceID }}.value);
+	 document.location.href = pageCurrent{{ $instanceID }}.href;
+}
+</script>

--- a/resources/views/layouts/_pagination_js.blade.php
+++ b/resources/views/layouts/_pagination_js.blade.php
@@ -1,38 +1,15 @@
 <script>
-    var pageSelectPopoverShown{{ $instanceID }} = false;
-    var pageSelectRange{{ $instanceID }} = new Object();
-    var pageSelectText{{ $instanceID }} = new Object();
-
-    var pageCurrent{{ $instanceID }} = new URL(window.location.href);
-
-    $(function() {
-        $('.pageSelectPopover{{ $instanceID }}').popover()
-    });
-
-    $('.pageSelectPopover{{ $instanceID }}').on('shown.bs.popover', function() {
-        pageWorkingPopover{{ $instanceID }} = this;
-        pageSelectPopoverShown{{ $instanceID }} = true;
-        pageSelectRange{{ $instanceID }} = document.getElementById('paginationPageRange{{ $instanceID }}');
-        pageSelectText{{ $instanceID }} = document.getElementById('paginationPageText{{ $instanceID }}');
-    });
-
-    $('.pageSelectPopover{{ $instanceID }}').on('hidden.bs.popover', function() {
-        pageWorkingPopover{{ $instanceID }} = null;
-        pageSelectPopoverShown{{ $instanceID }} = false;
-        pageSelectRange{{ $instanceID }} = null;
-        pageSelectText{{ $instanceID }} = null;
-    });
-
-    function pageUpdateSelectText{{ $instanceID }}() {
-        pageSelectText{{ $instanceID }}.value = pageSelectRange{{ $instanceID }}.value;
+    $('.pageSelectPopover').popover()
+    function onClick(e) {
+        const pageCurrent = new URL(window.location.href);
+        pageCurrent.searchParams.set("page", e.currentTarget.parentElement.querySelector('.paginationPageRange').value);
+        document.location.href = pageCurrent.href;
     }
 
-    function pageUpdateSelectRange{{ $instanceID }}() {
-        pageSelectRange{{ $instanceID }}.value = pageSelectText{{ $instanceID }}.value;
-    }
-
-    function pageGo{{ $instanceID }}() {
-        pageCurrent{{ $instanceID }}.searchParams.set("page", pageSelectRange{{ $instanceID }}.value);
-        document.location.href = pageCurrent{{ $instanceID }}.href;
-    }
+    $('.pageSelectPopover').on('shown.bs.popover', function() {
+        $('.paginator-btn').on('click', onClick);
+        // so you can just hit enter after moving the range bar or entering a number
+        $('.paginationPageRange').on('keypress', (e) => e.which === 13 && onClick(e));
+        $('.paginationPageText').on('keypress', (e) => e.which === 13 ? onClick(e) : true);
+    });
 </script>

--- a/resources/views/layouts/_pagination_js.blade.php
+++ b/resources/views/layouts/_pagination_js.blade.php
@@ -1,5 +1,6 @@
 <script>
     $('.pageSelectPopover').popover()
+
     function onClick(e) {
         const pageCurrent = new URL(window.location.href);
         pageCurrent.searchParams.set("page", e.currentTarget.parentElement.querySelector('.paginationPageRange').value);

--- a/resources/views/layouts/_simple-pagination.blade.php
+++ b/resources/views/layouts/_simple-pagination.blade.php
@@ -1,0 +1,27 @@
+@if ($paginator->hasPages())
+    <nav>
+        <ul class="pagination">
+            {{-- Previous Page Link --}}
+            @if ($paginator->onFirstPage())
+                <li class="page-item disabled" aria-disabled="true">
+                    <span class="page-link">@lang('pagination.previous')</span>
+                </li>
+            @else
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev">@lang('pagination.previous')</a>
+                </li>
+            @endif
+
+            {{-- Next Page Link --}}
+            @if ($paginator->hasMorePages())
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">@lang('pagination.next')</a>
+                </li>
+            @else
+                <li class="page-item disabled" aria-disabled="true">
+                    <span class="page-link">@lang('pagination.next')</span>
+                </li>
+            @endif
+        </ul>
+    </nav>
+@endif

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -141,6 +141,7 @@
         </div>
 
         @yield('scripts')
+        @include('layouts._pagination_js')
         <script>
             $(function() {
                 $('[data-toggle="tooltip"]').tooltip({

--- a/resources/views/pages/credits.blade.php
+++ b/resources/views/pages/credits.blade.php
@@ -48,7 +48,7 @@
             <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:MYO_Item_Tag"><strong>MYO Item Tag</strong></a> by <a href="https://github.com/junijwi">Junijwi</a>
         </p>
         <p class="mb-0 col-md-4">
-            <strong>Pagination Page Selector</strong> by <a href="https://github.com/SpeedyD">Speedy</a> and <a href="https://github.com/AW0005">Moif</a>
+            <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:Pagination_Page_Select"><strong>Pagination Page Selector</strong></a> by <a href="https://github.com/SpeedyD">Speedy</a> and <a href="https://github.com/AW0005">Moif</a>
         </p>
         <p class="mb-0 col-md-4">
             <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:Reports"><strong>Reports</strong></a> by <a href="https://github.com/Ne-wt">Ne-wt</a>

--- a/resources/views/pages/credits.blade.php
+++ b/resources/views/pages/credits.blade.php
@@ -48,6 +48,9 @@
             <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:MYO_Item_Tag"><strong>MYO Item Tag</strong></a> by <a href="https://github.com/junijwi">Junijwi</a>
         </p>
         <p class="mb-0 col-md-4">
+            <strong>Pagination Page Selector</strong> by <a href="https://github.com/SpeedyD">Speedy</a> and <a href="https://github.com/AW0005">Moif</a>
+        </p>
+        <p class="mb-0 col-md-4">
             <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:Reports"><strong>Reports</strong></a> by <a href="https://github.com/Ne-wt">Ne-wt</a>
         </p>
         <p class="mb-0 col-md-4">


### PR DESCRIPTION
~~All this PR does so far is replace the bootstrap defaults with.. the same views from the vendor.~~

~~However, that makes it accessible to modify, which was the goal.~~

As of commit https://github.com/corowne/lorekeeper/pull/614/commits/43681fcc80f5365f0fd6d105b971f8658908c04f, each '...' block now opens a popover where you can change the page.

The functionality itself wasn't too bad, but the fact that each popover had to be unique.. whew.