### PR TITLE
Bug(Sales): MYO made characters show old MYO image

### DIFF
--- a/app/Models/Sales/SalesCharacter.php
+++ b/app/Models/Sales/SalesCharacter.php
@@ -178,6 +178,6 @@ class SalesCharacter extends Model {
      * @return App\Models\Character\CharacterImage
      */
     public function getImageAttribute() {
-        return CharacterImage::where('is_visible', 1)->where('character_id', $this->character_id)->orderBy('created_at')->first();
+        return $this->character->image;
     }
 }

--- a/app/Models/Sales/SalesCharacter.php
+++ b/app/Models/Sales/SalesCharacter.php
@@ -2,7 +2,6 @@
 
 namespace App\Models\Sales;
 
-use App\Models\Character\CharacterImage;
 use App\Models\Model;
 use Config;
 


### PR DESCRIPTION
Sales image attribute references the "first" image for a character, which means that if you have a character made on a MYO slot with the default image still attached to them, that's what shows up in the sale image instead of the correctly updated active image.

Switching the attribute to reference the attached character's set active image instead fixes it up.

This is somewhere in the grey area of being a bug vs a feature enhancement but I figured it was close enough to unwanted behavior to title it a bug.