### PR TITLE
Bug(Design Submission): Duplicated Credits & Saving Credits w/o image

### DIFF
--- a/app/Services/DesignUpdateManager.php
+++ b/app/Services/DesignUpdateManager.php
@@ -215,8 +215,8 @@ class DesignUpdateManager extends Service {
             }
 
             // Save thumbnail, if we have an image set
-            if ((!$isAdmin && isset($data['image'])) || ($isAdmin && isset($data['modify_thumbnail']))) {
-                if (isset($data['use_cropper'])) {
+            if ((!$isAdmin) || ($isAdmin && isset($data['modify_thumbnail']))) {
+                if (isset($data['use_cropper']) && isset($data['image'])) {
                     (new CharacterManager)->cropThumbnail(Arr::only($data, ['x0', 'x1', 'y0', 'y1']), $request);
                 } elseif (isset($data['thumbnail'])) {
                     $this->handleImage($data['thumbnail'], $request->imageDirectory, $request->thumbnailFileName);

--- a/app/Services/DesignUpdateManager.php
+++ b/app/Services/DesignUpdateManager.php
@@ -214,8 +214,8 @@ class DesignUpdateManager extends Service {
                 $this->handleImage($data['image'], $request->imageDirectory, $request->imageFileName, null, isset($data['default_image']));
             }
 
-            // Save thumbnail
-            if (!$isAdmin || ($isAdmin && isset($data['modify_thumbnail']))) {
+            // Save thumbnail, if we have an image set
+            if ((!$isAdmin && isset($data['image'])) || ($isAdmin && isset($data['modify_thumbnail']))) {
                 if (isset($data['use_cropper'])) {
                     (new CharacterManager)->cropThumbnail(Arr::only($data, ['x0', 'x1', 'y0', 'y1']), $request);
                 } elseif (isset($data['thumbnail'])) {

--- a/resources/views/character/design/image.blade.php
+++ b/resources/views/character/design/image.blade.php
@@ -141,11 +141,6 @@
                     </div>
                 @endif
             </div>
-            <div class="designer-row hide mb-2">
-                {!! Form::select('designer_id[]', $users, null, ['class' => 'form-control mr-2 designer-select', 'placeholder' => 'Select a Designer']) !!}
-                {!! Form::text('designer_url[]', null, ['class' => 'form-control mr-2', 'placeholder' => 'Designer URL']) !!}
-                <a href="#" class="add-designer btn btn-link" data-toggle="tooltip" title="Add another designer">+</a>
-            </div>
         </div>
         <div class="form-group">
             {!! Form::label('Artist(s)') !!}
@@ -166,11 +161,6 @@
                     </div>
                 @endif
             </div>
-            <div class="artist-row hide mb-2">
-                {!! Form::select('artist_id[]', $users, null, ['class' => 'form-control mr-2 artist-select', 'placeholder' => 'Select an Artist']) !!}
-                {!! Form::text('artist_url[]', null, ['class' => 'form-control mr-2', 'placeholder' => 'Artist URL']) !!}
-                <a href="#" class="add-artist btn btn-link mb-2" data-toggle="tooltip" title="Add another artist">+</a>
-            </div>
         </div>
         <div class="text-right">
             {!! Form::submit('Save', ['class' => 'btn btn-primary']) !!}
@@ -178,6 +168,18 @@
 
         {!! Form::close() !!}
     @endif
+    
+    
+    <div class="designer-row hide mb-2">
+        {!! Form::select('designer_id[]', $users, null, ['class' => 'form-control mr-2 designer-select', 'placeholder' => 'Select a Designer']) !!}
+        {!! Form::text('designer_url[]', null, ['class' => 'form-control mr-2', 'placeholder' => 'Designer URL']) !!}
+        <a href="#" class="add-designer btn btn-link" data-toggle="tooltip" title="Add another designer">+</a>
+    </div>
+    <div class="artist-row hide mb-2">
+        {!! Form::select('artist_id[]', $users, null, ['class' => 'form-control mr-2 artist-select', 'placeholder' => 'Select an Artist']) !!}
+        {!! Form::text('artist_url[]', null, ['class' => 'form-control mr-2', 'placeholder' => 'Artist URL']) !!}
+        <a href="#" class="add-artist btn btn-link mb-2" data-toggle="tooltip" title="Add another artist">+</a>
+    </div>
 
 @endsection
 


### PR DESCRIPTION
This fixes two things:
1. If you were in design submission and had supplied an image and artist credits but you got an error (for example by providing an image with a wrong format or an image that was too large) the browser auto-populates the hidden form elements for the credits with what had been previously picked and since those hidden elements were kept inside the form, they would be duplicated on hitting the submit button the second time. So I moved them to be outside of the form.

2. In the process of fixing the above I realized that I'd get an error if I attempted to only change the credits without uploading a new image, so I fixed that with a better if check on thumbnail processing as well.