### PR TITLE
Bug(AliasLogin): Add email and pw after alias registration

### DIFF
--- a/app/Http/Controllers/Users/AccountController.php
+++ b/app/Http/Controllers/Users/AccountController.php
@@ -84,6 +84,7 @@ class AccountController extends Controller {
                 flash($error)->error();
             }
         }
+        
         return redirect()->back();
     }
 

--- a/app/Http/Controllers/Users/AccountController.php
+++ b/app/Http/Controllers/Users/AccountController.php
@@ -84,7 +84,6 @@ class AccountController extends Controller {
                 flash($error)->error();
             }
         }
-
         return redirect()->back();
     }
 
@@ -96,10 +95,15 @@ class AccountController extends Controller {
      * @return \Illuminate\Http\RedirectResponse
      */
     public function postPassword(Request $request, UserService $service) {
+        $user = Auth::user();
+        if (!isset($user->password) && (!isset($user->email) || !isset($user->email_verified_at))) {
+            flash('Please set and verify an email before setting a password for email login.')->error();
+            return redirect()->back();
+        }
+
         $request->validate([
-            'old_password' => 'required|string',
-            'new_password' => 'required|string|min:8|confirmed',
-        ]);
+            'new_password' => 'required|string|min:8|confirmed'
+        ] + (isset($user->password) ? ['old_password' => 'required|string'] : []));
         if ($service->updatePassword($request->only(['old_password', 'new_password', 'new_password_confirmation']), Auth::user())) {
             flash('Password updated successfully.')->success();
         } else {

--- a/app/Http/Controllers/Users/AccountController.php
+++ b/app/Http/Controllers/Users/AccountController.php
@@ -99,11 +99,12 @@ class AccountController extends Controller {
         $user = Auth::user();
         if (!isset($user->password) && (!isset($user->email) || !isset($user->email_verified_at))) {
             flash('Please set and verify an email before setting a password for email login.')->error();
+
             return redirect()->back();
         }
 
         $request->validate([
-            'new_password' => 'required|string|min:8|confirmed'
+            'new_password' => 'required|string|min:8|confirmed',
         ] + (isset($user->password) ? ['old_password' => 'required|string'] : []));
         if ($service->updatePassword($request->only(['old_password', 'new_password', 'new_password_confirmation']), Auth::user())) {
             flash('Password updated successfully.')->success();

--- a/app/Http/Controllers/Users/AccountController.php
+++ b/app/Http/Controllers/Users/AccountController.php
@@ -84,7 +84,7 @@ class AccountController extends Controller {
                 flash($error)->error();
             }
         }
-        
+
         return redirect()->back();
     }
 


### PR DESCRIPTION
Fixes an issue where the validation was keeping users who had registered with alias login from later adding an email and password login if they wanted.