### PR TITLE
Fix(world): Wrong entry type for rarity

### DIFF
--- a/resources/views/admin/rarities/create_edit_rarity.blade.php
+++ b/resources/views/admin/rarities/create_edit_rarity.blade.php
@@ -59,7 +59,7 @@
         <h3>Preview</h3>
         <div class="card mb-3">
             <div class="card-body">
-                @include('world._entry', ['imageUrl' => $rarity->rarityImageUrl, 'name' => $rarity->displayName, 'description' => $rarity->parsed_description])
+                @include('world._rarity_entry', ['imageUrl' => $rarity->rarityImageUrl, 'name' => $rarity->displayName, 'description' => $rarity->parsed_description, 'searchFeaturesUrl' => $rarity->searchFeaturesUrl, 'searchCharactersUrl' => $rarity->searchCharactersUrl])
             </div>
         </div>
     @endif

--- a/resources/views/admin/rarities/create_edit_rarity.blade.php
+++ b/resources/views/admin/rarities/create_edit_rarity.blade.php
@@ -59,7 +59,13 @@
         <h3>Preview</h3>
         <div class="card mb-3">
             <div class="card-body">
-                @include('world._rarity_entry', ['imageUrl' => $rarity->rarityImageUrl, 'name' => $rarity->displayName, 'description' => $rarity->parsed_description, 'searchFeaturesUrl' => $rarity->searchFeaturesUrl, 'searchCharactersUrl' => $rarity->searchCharactersUrl])
+                @include('world._rarity_entry', [
+                    'imageUrl' => $rarity->rarityImageUrl,
+                    'name' => $rarity->displayName,
+                    'description' => $rarity->parsed_description,
+                    'searchFeaturesUrl' => $rarity->searchFeaturesUrl,
+                    'searchCharactersUrl' => $rarity->searchCharactersUrl,
+                ])
             </div>
         </div>
     @endif


### PR DESCRIPTION
Used world._entry when world._rarity_entry is more commonly used- also added the two variables that are passed along normally as well.