### PR TITLE
Bug(Settings): Fix .gif Avatars causing 500 error

### DIFF
--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -176,7 +176,7 @@ class UserService extends Service {
             $filename = $user->id.'.'.$avatar->getClientOriginalExtension();
 
             if ($user->avatar !== 'default.jpg') {
-                $file = 'images/avatars/'.$user->avatar;
+                $file = 'images/avatars/' . $user->avatar;
                 //$destinationPath = 'uploads/' . $id . '/';
 
                 if (File::exists($file)) {
@@ -188,13 +188,7 @@ class UserService extends Service {
 
             // Checks if uploaded file is a GIF
             if ($avatar->getClientOriginalExtension() == 'gif') {
-                if (!copy($avatar, $file)) {
-                    throw new \Exception('Failed to copy file.');
-                }
-                if (!$file->move(public_path('images/avatars', $filename))) {
-                    throw new \Exception('Failed to move file.');
-                }
-                if (!$avatar->move(public_path('images/avatars', $filename))) {
+                if (!$avatar->move(public_path('images/avatars'), $filename)) {
                     throw new \Exception('Failed to move file.');
                 }
             } else {

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -176,7 +176,7 @@ class UserService extends Service {
             $filename = $user->id.'.'.$avatar->getClientOriginalExtension();
 
             if ($user->avatar !== 'default.jpg') {
-                $file = 'images/avatars/' . $user->avatar;
+                $file = 'images/avatars/'.$user->avatar;
                 //$destinationPath = 'uploads/' . $id . '/';
 
                 if (File::exists($file)) {

--- a/resources/views/account/settings.blade.php
+++ b/resources/views/account/settings.blade.php
@@ -13,7 +13,7 @@
     <div class="card p-3 mb-2">
         <h3>Avatar</h3>
         <div class="text-left">
-            <div class="alert alert-warning">Please note a hard refresh may be required to see your updated avatar. Also please note that uploading a .gif will display a 500 error after; the upload should still work, however.</div>
+            <div class="alert alert-warning">Please note a hard refresh may be required to see your updated avatar.</div>
         </div>
         @if (Auth::user()->isStaff)
             <div class="alert alert-danger">For admins - note that .GIF avatars leave a tmp file in the directory (e.g php2471.tmp). There is an automatic schedule to delete these files.


### PR DESCRIPTION
.gif avatars should upload fine now, whether it's the first avatar, or the second or third, etc, and should not create a 500 error at all.