### PR TITLE
Feat(Inventories): Summarized View

### DIFF
--- a/resources/views/character/inventory.blade.php
+++ b/resources/views/character/inventory.blade.php
@@ -43,15 +43,14 @@
                         <div class="row mb-3">
                             @foreach ($chunk as $itemId => $stack)
                                 <?php
-                                    $canName = $stack->first()->category->can_name;
-                                    $stackName = $stack
-                                        ->first()
-                                        ->pivot->pluck('stack_name', 'id')
-                                        ->toArray()[$stack->first()->pivot->id];
-                                    $stackNameClean = htmlentities($stackName);
+                                $canName = $stack->first()->category->can_name;
+                                $stackName = $stack
+                                    ->first()
+                                    ->pivot->pluck('stack_name', 'id')
+                                    ->toArray()[$stack->first()->pivot->id];
+                                $stackNameClean = htmlentities($stackName);
                                 ?>
-                                <div class="col-sm-3 col-6 text-center inventory-item"
-                                    data-id="{{ $stack->first()->pivot->id }}"
+                                <div class="col-sm-3 col-6 text-center inventory-item" data-id="{{ $stack->first()->pivot->id }}"
                                     data-name="{!! $canName && $stackName ? htmlentities($stackNameClean) . ' [' : null !!}{{ $character->name ? $character->name : $character->slug }}'s {{ $stack->first()->name }}{!! $canName && $stackName ? ']' : null !!}">
                                     <div class="mb-1">
                                         <a href="#" class="inventory-stack">
@@ -94,18 +93,16 @@
                             <ul class="mb-0">
                                 @foreach ($itemtype as $item)
                                     <?php
-                                        $canName = $item->category->can_name;
-                                        $itemNames = $item->pivot->pluck('stack_name', 'id');
-                                        $stackName = $itemNames[$item->pivot->id];
-                                        $stackNameClean = htmlentities($stackName);
-                                    ?> 
-                                    <div
-                                    data-id="{{ $item->pivot->id }}"
-                                    data-name="{!! $canName && $stackName ? htmlentities($stackNameClean) . ' [' : null !!}{{ $character->name ? $character->name : $character->slug }}'s {{ $item->name }}{!! $canName && $stackName ? ']' : null !!}">
+                                    $canName = $item->category->can_name;
+                                    $itemNames = $item->pivot->pluck('stack_name', 'id');
+                                    $stackName = $itemNames[$item->pivot->id];
+                                    $stackNameClean = htmlentities($stackName);
+                                    ?>
+                                    <div data-id="{{ $item->pivot->id }}" data-name="{!! $canName && $stackName ? htmlentities($stackNameClean) . ' [' : null !!}{{ $character->name ? $character->name : $character->slug }}'s {{ $item->name }}{!! $canName && $stackName ? ']' : null !!}">
                                         <li>
                                             <a class="inventory-stack" href="#">
                                                 Stack of x{{ $item->pivot->count }}.
-                                                @if($canName && $stackName)
+                                                @if ($canName && $stackName)
                                                     <span class="text-info m-0" style="font-size:95%; margin:5px;" data-toggle="tooltip" data-placement="top" title='Named stack:<br />"{{ $stackName }}"'>
                                                         &nbsp;<i class="fas fa-tag"></i>
                                                     </span>

--- a/resources/views/character/inventory.blade.php
+++ b/resources/views/character/inventory.blade.php
@@ -24,44 +24,103 @@
         Items
     </h3>
 
-    @foreach ($items as $categoryId => $categoryItems)
-        <div class="card mb-3 inventory-category">
-            <h5 class="card-header inventory-header">
-                {!! isset($categories[$categoryId]) ? '<a href="' . $categories[$categoryId]->searchUrl . '">' . $categories[$categoryId]->name . '</a>' : 'Miscellaneous' !!}
-                <a class="small inventory-collapse-toggle collapse-toggle" href="#categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}" data-toggle="collapse">Show</a>
-            </h5>
-            <div class="card-body inventory-body collapse show" id="categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}">
-                @foreach ($categoryItems->chunk(4) as $chunk)
-                    <div class="row mb-3">
-                        @foreach ($chunk as $itemId => $stack)
-                            <?php
-                            $canName = $stack->first()->category->can_name;
-                            $stackName = $stack
-                                ->first()
-                                ->pivot->pluck('stack_name', 'id')
-                                ->toArray()[$stack->first()->pivot->id];
-                            $stackNameClean = htmlentities($stackName);
-                            ?>
-                            <div class="col-sm-3 col-6 text-center inventory-item" data-id="{{ $stack->first()->pivot->id }}"
-                                data-name="{!! $canName && $stackName ? htmlentities($stackNameClean) . ' [' : null !!}{{ $character->name ? $character->name : $character->slug }}'s {{ $stack->first()->name }}{!! $canName && $stackName ? ']' : null !!}">
-                                <div class="mb-1">
-                                    <a href="#" class="inventory-stack"><img src="{{ $stack->first()->imageUrl }}" alt="{{ $stack->first()->name }}" /></a>
-                                </div>
-                                <div class="{{ $canName ? 'text-muted' : '' }}">
-                                    <a href="#" class="inventory-stack inventory-stack-name">{{ $stack->first()->name }} x{{ $stack->sum('pivot.count') }}</a>
-                                </div>
-                                @if ($canName && $stackName)
-                                    <div>
-                                        <span class="inventory-stack inventory-stack-name badge badge-info" style="font-size:95%; margin:5px;">"{{ $stackName }}"</span>
-                                    </div>
-                                @endif
-                            </div>
-                        @endforeach
-                    </div>
-                @endforeach
-            </div>
+    <div class="text-right mb-3">
+        <div class="btn-group">
+            <button type="button" class="btn btn-secondary active def-view-button" data-toggle="tooltip" title="Default View" alt="Default View"><i class="fas fa-th"></i></button>
+            <button type="button" class="btn btn-secondary sum-view-button" data-toggle="tooltip" title="Summarized View" alt="Summarized View"><i class="fas fa-bars"></i></button>
         </div>
-    @endforeach
+    </div>
+
+    <div id="defView" class="hide">
+        @foreach ($items as $categoryId => $categoryItems)
+            <div class="card mb-3 inventory-category">
+                <h5 class="card-header inventory-header">
+                    {!! isset($categories[$categoryId]) ? '<a href="' . $categories[$categoryId]->searchUrl . '">' . $categories[$categoryId]->name . '</a>' : 'Miscellaneous' !!}
+                    <a class="small inventory-collapse-toggle collapse-toggle" href="#categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}" data-toggle="collapse">Show</a>
+                </h5>
+                <div class="card-body inventory-body collapse show" id="categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}">
+                    @foreach ($categoryItems->chunk(4) as $chunk)
+                        <div class="row mb-3">
+                            @foreach ($chunk as $itemId => $stack)
+                                <?php
+                                    $canName = $stack->first()->category->can_name;
+                                    $stackName = $stack
+                                        ->first()
+                                        ->pivot->pluck('stack_name', 'id')
+                                        ->toArray()[$stack->first()->pivot->id];
+                                    $stackNameClean = htmlentities($stackName);
+                                ?>
+                                <div class="col-sm-3 col-6 text-center inventory-item"
+                                    data-id="{{ $stack->first()->pivot->id }}"
+                                    data-name="{!! $canName && $stackName ? htmlentities($stackNameClean) . ' [' : null !!}{{ $character->name ? $character->name : $character->slug }}'s {{ $stack->first()->name }}{!! $canName && $stackName ? ']' : null !!}">
+                                    <div class="mb-1">
+                                        <a href="#" class="inventory-stack">
+                                            <img src="{{ $stack->first()->imageUrl }}" alt="{{ $stack->first()->name }}" />
+                                        </a>
+                                    </div>
+                                    <div class="{{ $canName ? 'text-muted' : '' }}">
+                                        <a href="#" class="inventory-stack inventory-stack-name">
+                                            {{ $stack->first()->name }} x{{ $stack->sum('pivot.count') }}
+                                        </a>
+                                    </div>
+                                    @if ($canName && $stackName)
+                                        <div>
+                                            <span class="inventory-stack inventory-stack-name badge badge-info" style="font-size:95%; margin:5px;">"{{ $stackName }}"</span>
+                                        </div>
+                                    @endif
+                                </div>
+                            @endforeach
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        @endforeach
+    </div>
+
+    <div id="sumView" class="hide">
+        @foreach ($items as $categoryId => $categoryItems)
+            <div class="card mb-2">
+                <h5 class="card-header">
+                    {!! isset($categories[$categoryId]) ? '<a href="' . $categories[$categoryId]->searchUrl . '">' . $categories[$categoryId]->name . '</a>' : 'Miscellaneous' !!}
+                    <a class="small inventory-collapse-toggle collapse-toggle" href="#categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}" data-toggle="collapse">Show</a>
+                </h5>
+                <div class="card-body p-2 collapse show row" id="categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}">
+                    @foreach ($categoryItems as $itemtype)
+                        <div class="col-lg-3 col-sm-4 col-12">
+                            @if ($itemtype->first()->has_image)
+                                <img src="{{ $itemtype->first()->imageUrl }}" style="height: 25px;" alt="{{ $itemtype->first()->name }}" />
+                            @endif
+                            <a href="{{ $itemtype->first()->idUrl }}">{{ $itemtype->first()->name }}</a>
+                            <ul class="mb-0">
+                                @foreach ($itemtype as $item)
+                                    <?php
+                                        $canName = $item->category->can_name;
+                                        $itemNames = $item->pivot->pluck('stack_name', 'id');
+                                        $stackName = $itemNames[$item->pivot->id];
+                                        $stackNameClean = htmlentities($stackName);
+                                    ?> 
+                                    <div
+                                    data-id="{{ $item->pivot->id }}"
+                                    data-name="{!! $canName && $stackName ? htmlentities($stackNameClean) . ' [' : null !!}{{ $character->name ? $character->name : $character->slug }}'s {{ $item->name }}{!! $canName && $stackName ? ']' : null !!}">
+                                        <li>
+                                            <a class="inventory-stack" href="#">
+                                                Stack of x{{ $item->pivot->count }}.
+                                                @if($canName && $stackName)
+                                                    <span class="text-info m-0" style="font-size:95%; margin:5px;" data-toggle="tooltip" data-placement="top" title='Named stack:<br />"{{ $stackName }}"'>
+                                                        &nbsp;<i class="fas fa-tag"></i>
+                                                    </span>
+                                                @endif
+                                            </a>
+                                        </li>
+                                    </div>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        @endforeach
+    </div>
 
     <h3>Latest Activity</h3>
     <div class="mb-4 logs-table">
@@ -150,12 +209,13 @@
                     </div>
                 </div>
             </div>
+        </div>
     @endif
 @endsection
 
 @section('scripts')
     @include('widgets._inventory_select_js', ['readOnly' => true])
-
+    @include('widgets._inventory_view_js')
     <script>
         $(document).ready(function() {
             $('.inventory-stack').on('click', function(e) {

--- a/resources/views/character/inventory.blade.php
+++ b/resources/views/character/inventory.blade.php
@@ -36,7 +36,9 @@
             <div class="card mb-3 inventory-category">
                 <h5 class="card-header inventory-header">
                     {!! isset($categories[$categoryId]) ? '<a href="' . $categories[$categoryId]->searchUrl . '">' . $categories[$categoryId]->name . '</a>' : 'Miscellaneous' !!}
-                    <a class="small inventory-collapse-toggle collapse-toggle" href="#categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}" data-toggle="collapse">Show</a>
+                    <a class="small inventory-collapse-toggle collapse-toggle" href="#categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}" data-toggle="collapse">
+                        Show
+                    </a>
                 </h5>
                 <div class="card-body inventory-body collapse show" id="categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}">
                     @foreach ($categoryItems->chunk(4) as $chunk)
@@ -50,7 +52,8 @@
                                     ->toArray()[$stack->first()->pivot->id];
                                 $stackNameClean = htmlentities($stackName);
                                 ?>
-                                <div class="col-sm-3 col-6 text-center inventory-item" data-id="{{ $stack->first()->pivot->id }}"
+                                <div class="col-sm-3 col-6 text-center inventory-item"
+                                    data-id="{{ $stack->first()->pivot->id }}"
                                     data-name="{!! $canName && $stackName ? htmlentities($stackNameClean) . ' [' : null !!}{{ $character->name ? $character->name : $character->slug }}'s {{ $stack->first()->name }}{!! $canName && $stackName ? ']' : null !!}">
                                     <div class="mb-1">
                                         <a href="#" class="inventory-stack">
@@ -81,7 +84,9 @@
             <div class="card mb-2">
                 <h5 class="card-header">
                     {!! isset($categories[$categoryId]) ? '<a href="' . $categories[$categoryId]->searchUrl . '">' . $categories[$categoryId]->name . '</a>' : 'Miscellaneous' !!}
-                    <a class="small inventory-collapse-toggle collapse-toggle" href="#categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}" data-toggle="collapse">Show</a>
+                    <a class="small inventory-collapse-toggle collapse-toggle" href="#categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}" data-toggle="collapse">
+                        Show
+                    </a>
                 </h5>
                 <div class="card-body p-2 collapse show row" id="categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}">
                     @foreach ($categoryItems as $itemtype)
@@ -98,7 +103,9 @@
                                     $stackName = $itemNames[$item->pivot->id];
                                     $stackNameClean = htmlentities($stackName);
                                     ?>
-                                    <div data-id="{{ $item->pivot->id }}" data-name="{!! $canName && $stackName ? htmlentities($stackNameClean) . ' [' : null !!}{{ $character->name ? $character->name : $character->slug }}'s {{ $item->name }}{!! $canName && $stackName ? ']' : null !!}">
+                                    <div
+                                        data-id="{{ $item->pivot->id }}"
+                                        data-name="{!! $canName && $stackName ? htmlentities($stackNameClean) . ' [' : null !!}{{ $character->name ? $character->name : $character->slug }}'s {{ $item->name }}{!! $canName && $stackName ? ']' : null !!}">
                                         <li>
                                             <a class="inventory-stack" href="#">
                                                 Stack of x{{ $item->pivot->count }}.

--- a/resources/views/character/inventory.blade.php
+++ b/resources/views/character/inventory.blade.php
@@ -52,8 +52,7 @@
                                     ->toArray()[$stack->first()->pivot->id];
                                 $stackNameClean = htmlentities($stackName);
                                 ?>
-                                <div class="col-sm-3 col-6 text-center inventory-item"
-                                    data-id="{{ $stack->first()->pivot->id }}"
+                                <div class="col-sm-3 col-6 text-center inventory-item" data-id="{{ $stack->first()->pivot->id }}"
                                     data-name="{!! $canName && $stackName ? htmlentities($stackNameClean) . ' [' : null !!}{{ $character->name ? $character->name : $character->slug }}'s {{ $stack->first()->name }}{!! $canName && $stackName ? ']' : null !!}">
                                     <div class="mb-1">
                                         <a href="#" class="inventory-stack">
@@ -103,9 +102,7 @@
                                     $stackName = $itemNames[$item->pivot->id];
                                     $stackNameClean = htmlentities($stackName);
                                     ?>
-                                    <div
-                                        data-id="{{ $item->pivot->id }}"
-                                        data-name="{!! $canName && $stackName ? htmlentities($stackNameClean) . ' [' : null !!}{{ $character->name ? $character->name : $character->slug }}'s {{ $item->name }}{!! $canName && $stackName ? ']' : null !!}">
+                                    <div data-id="{{ $item->pivot->id }}" data-name="{!! $canName && $stackName ? htmlentities($stackNameClean) . ' [' : null !!}{{ $character->name ? $character->name : $character->slug }}'s {{ $item->name }}{!! $canName && $stackName ? ']' : null !!}">
                                         <li>
                                             <a class="inventory-stack" href="#">
                                                 Stack of x{{ $item->pivot->count }}.

--- a/resources/views/home/inventory.blade.php
+++ b/resources/views/home/inventory.blade.php
@@ -18,39 +18,78 @@
 
     <p>This is your inventory. Click on an item to view more details and actions you can perform on it.</p>
 
-    @foreach ($items as $categoryId => $categoryItems)
-        <div class="card mb-3 inventory-category">
-            <h5 class="card-header inventory-header">
-                {!! isset($categories[$categoryId]) ? '<a href="' . $categories[$categoryId]->searchUrl . '">' . $categories[$categoryId]->name . '</a>' : 'Miscellaneous' !!}
-                <a class="small inventory-collapse-toggle collapse-toggle" href="#categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}" data-toggle="collapse">Show</a>
-            </h5>
-            <div class="card-body inventory-body collapse show" id="categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}">
-                @foreach ($categoryItems->chunk(4) as $chunk)
-                    <div class="row mb-3">
-                        @foreach ($chunk as $itemId => $stack)
-                            <div class="col-sm-3 col-6 text-center inventory-item" data-id="{{ $stack->first()->pivot->id }}" data-name="{{ $user->name }}'s {{ $stack->first()->name }}">
-                                @if ($stack->first()->has_image)
-                                    <div class="mb-1">
-                                        <a href="#" class="inventory-stack">
-                                            <img src="{{ $stack->first()->imageUrl }}" alt="{{ $stack->first()->name }}" />
-                                        </a>
-                                    </div>
-                                @endif
-                                <div>
-                                    <a href="#" class="inventory-stack inventory-stack-name">{{ $stack->first()->name }} x{{ $stack->sum('pivot.count') }}</a>
-                                </div>
-                            </div>
-                        @endforeach
-                    </div>
-                @endforeach
-            </div>
+    <div class="text-right mb-3">
+        <div class="btn-group">
+            <button type="button" class="btn btn-secondary active def-view-button" data-toggle="tooltip" title="Default View" alt="Default View"><i class="fas fa-th"></i></button>
+            <button type="button" class="btn btn-secondary sum-view-button" data-toggle="tooltip" title="Summarized View" alt="Summarized View"><i class="fas fa-bars"></i></button>
         </div>
-    @endforeach
+    </div>
+
+    <div id="defView" class="hide">
+        @foreach ($items as $categoryId => $categoryItems)
+            <div class="card mb-3 inventory-category">
+                <h5 class="card-header inventory-header">
+                    {!! isset($categories[$categoryId]) ? '<a href="' . $categories[$categoryId]->searchUrl . '">' . $categories[$categoryId]->name . '</a>' : 'Miscellaneous' !!}
+                    <a class="small inventory-collapse-toggle collapse-toggle" href="#categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}" data-toggle="collapse">Show</a>
+                </h5>
+                <div class="card-body inventory-body collapse show" id="categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}">
+                    @foreach ($categoryItems->chunk(4) as $chunk)
+                        <div class="row mb-3">
+                            @foreach ($chunk as $stack)
+                                <div class="col-sm-3 col-6 text-center inventory-item" data-id="{{ $stack->first()->pivot->id }}" data-name="{{ $user->name }}'s {{ $stack->first()->name }}">
+                                    @if ($stack->first()->has_image)
+                                        <div class="mb-1">
+                                            <a href="#" class="inventory-stack">
+                                                <img src="{{ $stack->first()->imageUrl }}" alt="{{ $stack->first()->name }}" />
+                                            </a>
+                                        </div>
+                                    @endif
+                                    <div>
+                                        <a href="#" class="inventory-stack inventory-stack-name">{{ $stack->first()->name }} x{{ $stack->sum('pivot.count') }}</a>
+                                    </div>
+                                </div>
+                            @endforeach
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        @endforeach
+    </div>
+
+    <div id="sumView" class="hide">
+        @foreach ($items as $categoryId => $categoryItems)
+            <div class="card mb-2">
+                <h5 class="card-header">
+                    {!! isset($categories[$categoryId]) ? '<a href="' . $categories[$categoryId]->searchUrl . '">' . $categories[$categoryId]->name . '</a>' : 'Miscellaneous' !!}
+                    <a class="small inventory-collapse-toggle collapse-toggle" href="#categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}" data-toggle="collapse">Show</a>
+                </h5>
+                <div class="card-body p-2 collapse show row" id="categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}">
+                    @foreach ($categoryItems as $itemtype)
+                        <div class="col-lg-3 col-sm-4 col-12">
+                            @if ($itemtype->first()->has_image)
+                                <img src="{{ $itemtype->first()->imageUrl }}" style="height: 25px;" alt="{{ $itemtype->first()->name }}" />
+                            @endif
+                            <a href="{{ $itemtype->first()->idUrl }}">{{ $itemtype->first()->name }}</a>
+                            <ul class="mb-0" data-id="{{ $itemtype->first()->pivot->id }}" data-name="{{ $user->name }}'s {{ $itemtype->first()->name }}">
+                                @foreach ($itemtype as $item)
+                                    <li>
+                                        <a class="inventory-stack" href="#">Stack of x{{ $item->pivot->count }}</a>.
+                                    </li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        @endforeach
+    </div>
+
     <div class="text-right mb-4">
         <a href="{{ url(Auth::user()->url . '/item-logs') }}">View logs...</a>
     </div>
 @endsection
 @section('scripts')
+    @include('widgets._inventory_view_js')
     <script>
         $(document).ready(function() {
             $('.inventory-stack').on('click', function(e) {

--- a/resources/views/home/inventory_full.blade.php
+++ b/resources/views/home/inventory_full.blade.php
@@ -45,19 +45,19 @@
                                             @endif
                                         @endforeach
                                         <?php
-                                            $canName = $item->category->can_name;
-                                            $itemNames = $item->pivot->pluck('stack_name', 'id');
-                                            $stackName = $itemNames[$item->pivot->id];
-                                            $stackNameClean = htmlentities($stackName);
-                                        ?> 
-                                        <a class="invchar" data-id="{{ $item->pivot->id }}" data-name="{!! $canName && $stackName ? htmlentities($stackNameClean).' [' : null !!}{{ $charaname }}'s {{ $item->name }}{!! $canName && $stackName ? ']' : null !!}" href="#">
+                                        $canName = $item->category->can_name;
+                                        $itemNames = $item->pivot->pluck('stack_name', 'id');
+                                        $stackName = $itemNames[$item->pivot->id];
+                                        $stackNameClean = htmlentities($stackName);
+                                        ?>
+                                        <a class="invchar" data-id="{{ $item->pivot->id }}" data-name="{!! $canName && $stackName ? htmlentities($stackNameClean) . ' [' : null !!}{{ $charaname }}'s {{ $item->name }}{!! $canName && $stackName ? ']' : null !!}" href="#">
                                             Stack
                                         </a>
                                         of x{{ $item->pivot->count }} in {!! $charavisi !!}
                                         <a href="{{ $charalink }}">
                                             {{ $charaname }}
                                         </a>'s inventory.
-                                        @if($canName && $stackName)
+                                        @if ($canName && $stackName)
                                             <span class="text-info m-0" style="font-size:95%; margin:5px;" data-toggle="tooltip" data-placement="top" title='Named stack:<br />"{{ $stackName }}"'>
                                                 &nbsp;<i class="fas fa-tag"></i>
                                             </span>

--- a/resources/views/home/inventory_full.blade.php
+++ b/resources/views/home/inventory_full.blade.php
@@ -30,7 +30,15 @@
                             @foreach ($itemtype as $item)
                                 <li>
                                     @if (isset($item->pivot->user_id))
-                                        <a class="invuser" data-id="{{ $item->pivot->id }}" data-name="{{ $user->name }}'s {{ $item->name }}" href="#">Stack</a> of x{{ $item->pivot->count }} in <a href="/inventory">your inventory</a>.
+                                        <a class="invuser"
+                                            data-id="{{ $item->pivot->id }}"
+                                            data-name="{{ $user->name }}'s {{ $item->name }}" href="#">
+                                            Stack
+                                        </a>
+                                        of x{{ $item->pivot->count }} in 
+                                        <a href="/inventory">
+                                            your inventory
+                                        </a>.
                                     @else
                                         @foreach ($characters as $char)
                                             @if ($char->id == $item->pivot->character_id)
@@ -50,7 +58,9 @@
                                         $stackName = $itemNames[$item->pivot->id];
                                         $stackNameClean = htmlentities($stackName);
                                         ?>
-                                        <a class="invchar" data-id="{{ $item->pivot->id }}" data-name="{!! $canName && $stackName ? htmlentities($stackNameClean) . ' [' : null !!}{{ $charaname }}'s {{ $item->name }}{!! $canName && $stackName ? ']' : null !!}" href="#">
+                                        <a class="invchar"
+                                            data-id="{{ $item->pivot->id }}"
+                                            data-name="{!! $canName && $stackName ? htmlentities($stackNameClean) . ' [' : null !!}{{ $charaname }}'s {{ $item->name }}{!! $canName && $stackName ? ']' : null !!}" href="#">
                                             Stack
                                         </a>
                                         of x{{ $item->pivot->count }} in {!! $charavisi !!}

--- a/resources/views/home/inventory_full.blade.php
+++ b/resources/views/home/inventory_full.blade.php
@@ -30,12 +30,10 @@
                             @foreach ($itemtype as $item)
                                 <li>
                                     @if (isset($item->pivot->user_id))
-                                        <a class="invuser"
-                                            data-id="{{ $item->pivot->id }}"
-                                            data-name="{{ $user->name }}'s {{ $item->name }}" href="#">
+                                        <a class="invuser" data-id="{{ $item->pivot->id }}" data-name="{{ $user->name }}'s {{ $item->name }}" href="#">
                                             Stack
                                         </a>
-                                        of x{{ $item->pivot->count }} in 
+                                        of x{{ $item->pivot->count }} in
                                         <a href="/inventory">
                                             your inventory
                                         </a>.
@@ -58,9 +56,7 @@
                                         $stackName = $itemNames[$item->pivot->id];
                                         $stackNameClean = htmlentities($stackName);
                                         ?>
-                                        <a class="invchar"
-                                            data-id="{{ $item->pivot->id }}"
-                                            data-name="{!! $canName && $stackName ? htmlentities($stackNameClean) . ' [' : null !!}{{ $charaname }}'s {{ $item->name }}{!! $canName && $stackName ? ']' : null !!}" href="#">
+                                        <a class="invchar" data-id="{{ $item->pivot->id }}" data-name="{!! $canName && $stackName ? htmlentities($stackNameClean) . ' [' : null !!}{{ $charaname }}'s {{ $item->name }}{!! $canName && $stackName ? ']' : null !!}" href="#">
                                             Stack
                                         </a>
                                         of x{{ $item->pivot->count }} in {!! $charavisi !!}

--- a/resources/views/home/inventory_full.blade.php
+++ b/resources/views/home/inventory_full.blade.php
@@ -20,12 +20,12 @@
                 <a class="small inventory-collapse-toggle collapse-toggle" href="#categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}" data-toggle="collapse">Show</a>
             </h5>
             <div class="card-body p-2 collapse show row" id="categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}">
-                @foreach ($categoryItems as $itemId => $itemtype)
+                @foreach ($categoryItems as $itemtype)
                     <div class="col-lg-3 col-sm-4 col-12">
-                        @if ($categoryItems[$itemId]->first()->has_image)
-                            <img src="{{ $categoryItems[$itemId]->first()->imageUrl }}" style="height: 25px;" alt="{{ $categoryItems[$itemId]->first()->name }}" />
+                        @if ($itemtype->first()->has_image)
+                            <img src="{{ $itemtype->first()->imageUrl }}" style="height: 25px;" alt="{{ $itemtype->first()->name }}" />
                         @endif
-                        <a href="{{ $categoryItems[$itemId]->first()->idUrl }}">{{ $categoryItems[$itemId]->first()->name }}</a>
+                        <a href="{{ $itemtype->first()->idUrl }}">{{ $itemtype->first()->name }}</a>
                         <ul class="mb-0">
                             @foreach ($itemtype as $item)
                                 <li>
@@ -44,13 +44,24 @@
                                                 @endphp
                                             @endif
                                         @endforeach
-                                        <a class="invchar" data-id="{{ $item->pivot->id }}" data-name="{{ $charaname }}'s {{ $item->name }}" href="#">
+                                        <?php
+                                            $canName = $item->category->can_name;
+                                            $itemNames = $item->pivot->pluck('stack_name', 'id');
+                                            $stackName = $itemNames[$item->pivot->id];
+                                            $stackNameClean = htmlentities($stackName);
+                                        ?> 
+                                        <a class="invchar" data-id="{{ $item->pivot->id }}" data-name="{!! $canName && $stackName ? htmlentities($stackNameClean).' [' : null !!}{{ $charaname }}'s {{ $item->name }}{!! $canName && $stackName ? ']' : null !!}" href="#">
                                             Stack
                                         </a>
                                         of x{{ $item->pivot->count }} in {!! $charavisi !!}
                                         <a href="{{ $charalink }}">
                                             {{ $charaname }}
                                         </a>'s inventory.
+                                        @if($canName && $stackName)
+                                            <span class="text-info m-0" style="font-size:95%; margin:5px;" data-toggle="tooltip" data-placement="top" title='Named stack:<br />"{{ $stackName }}"'>
+                                                &nbsp;<i class="fas fa-tag"></i>
+                                            </span>
+                                        @endif
                                     @endif
                                 </li>
                             @endforeach

--- a/resources/views/home/inventory_full.blade.php
+++ b/resources/views/home/inventory_full.blade.php
@@ -35,8 +35,8 @@
                                         </a>
                                         of x{{ $item->pivot->count }} in
                                         <a href="/inventory">
-                                            your inventory
-                                        </a>.
+                                            your inventory.
+                                        </a>
                                     @else
                                         @foreach ($characters as $char)
                                             @if ($char->id == $item->pivot->character_id)

--- a/resources/views/user/inventory.blade.php
+++ b/resources/views/user/inventory.blade.php
@@ -11,31 +11,71 @@
         Inventory
     </h1>
 
-    @foreach ($items as $categoryId => $categoryItems)
-        <div class="card mb-3 inventory-category">
-            <h5 class="card-header inventory-header">
-                {!! isset($categories[$categoryId]) ? '<a href="' . $categories[$categoryId]->searchUrl . '">' . $categories[$categoryId]->name . '</a>' : 'Miscellaneous' !!}
-                <a class="small inventory-collapse-toggle collapse-toggle" href="#categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}" data-toggle="collapse">Show</a>
-            </h5>
-            <div class="card-body inventory-body collapse show" id="categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}">
-                @foreach ($categoryItems->chunk(4) as $chunk)
-                    <div class="row mb-3">
-                        @foreach ($chunk as $itemId => $stack)
-                            <div class="col-sm-3 col-6 text-center inventory-item" data-id="{{ $stack->first()->pivot->id }}" data-name="{{ $user->name }}'s {{ $stack->first()->name }}">
-                                <div class="mb-1">
-                                    <a href="#" class="inventory-stack"><img src="{{ $stack->first()->imageUrl }}" alt="{{ $stack->first()->name }}" /></a>
-                                </div>
-                                <div>
-                                    <a href="#" class="inventory-stack inventory-stack-name">{{ $stack->first()->name }} x{{ $stack->sum('pivot.count') }}</a>
-                                </div>
-                            </div>
-                        @endforeach
-                    </div>
-                @endforeach
-            </div>
+    <div class="text-right mb-3">
+        <div class="btn-group">
+            <button type="button" class="btn btn-secondary active def-view-button" data-toggle="tooltip" title="Default View" alt="Default View"><i class="fas fa-th"></i></button>
+            <button type="button" class="btn btn-secondary sum-view-button" data-toggle="tooltip" title="Summarized View" alt="Summarized View"><i class="fas fa-bars"></i></button>
         </div>
-    @endforeach
+    </div>
 
+    <div id="defView" class="hide">
+        @foreach ($items as $categoryId => $categoryItems)
+            <div class="card mb-3 inventory-category">
+                <h5 class="card-header inventory-header">
+                    {!! isset($categories[$categoryId]) ? '<a href="' . $categories[$categoryId]->searchUrl . '">' . $categories[$categoryId]->name . '</a>' : 'Miscellaneous' !!}
+                    <a class="small inventory-collapse-toggle collapse-toggle" href="#categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}" data-toggle="collapse">Show</a>
+                </h5>
+                <div class="card-body inventory-body collapse show" id="categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}">
+                    @foreach ($categoryItems->chunk(4) as $chunk)
+                        <div class="row mb-3">
+                            @foreach ($chunk as $itemId => $stack)
+                                <div class="col-sm-3 col-6 text-center inventory-item" data-id="{{ $stack->first()->pivot->id }}" data-name="{{ $user->name }}'s {{ $stack->first()->name }}">
+                                    <div class="mb-1">
+                                        <a href="#" class="inventory-stack"><img src="{{ $stack->first()->imageUrl }}" alt="{{ $stack->first()->name }}" /></a>
+                                    </div>
+                                    <div>
+                                        <a href="#" class="inventory-stack inventory-stack-name">{{ $stack->first()->name }} x{{ $stack->sum('pivot.count') }}</a>
+                                    </div>
+                                </div>
+                            @endforeach
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        @endforeach
+    </div>
+
+    <div id="sumView" class="hide">
+        @foreach ($items as $categoryId => $categoryItems)
+            <div class="card mb-2">
+                <h5 class="card-header">
+                    {!! isset($categories[$categoryId]) ? '<a href="' . $categories[$categoryId]->searchUrl . '">' . $categories[$categoryId]->name . '</a>' : 'Miscellaneous' !!}
+                    <a class="small inventory-collapse-toggle collapse-toggle" href="#categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}" data-toggle="collapse">Show</a>
+                </h5>
+                <div class="card-body p-2 collapse show row" id="categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}">
+                    @foreach ($categoryItems as $itemtype)
+                        <div class="col-lg-3 col-sm-4 col-12">
+                            @if ($itemtype->first()->has_image)
+                                <img src="{{ $itemtype->first()->imageUrl }}" style="height: 25px;" alt="{{ $itemtype->first()->name }}" />
+                            @endif
+                            <a href="{{ $itemtype->first()->idUrl }}">
+                                {{ $itemtype->first()->name }}
+                            </a>
+                            <ul class="mb-0" data-id="{{ $itemtype->first()->pivot->id }}" data-name="{{ $user->name }}'s {{ $itemtype->first()->name }}">
+                                @foreach ($itemtype as $item)
+                                    <li>
+                                        <a class="inventory-stack" href="#">
+                                            Stack of x{{ $item->pivot->count }}
+                                        </a>.
+                                    </li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        @endforeach
+    </div>
 
     <h3>Latest Activity</h3>
     <div class="mb-4 logs-table">
@@ -66,12 +106,15 @@
             @endforeach
         </div>
     </div>
+    
     <div class="text-right">
         <a href="{{ url($user->url . '/item-logs') }}">View all...</a>
     </div>
+
 @endsection
 
 @section('scripts')
+    @include('widgets._inventory_view_js')
     <script>
         $(document).ready(function() {
             $('.inventory-stack').on('click', function(e) {

--- a/resources/views/user/inventory.blade.php
+++ b/resources/views/user/inventory.blade.php
@@ -23,7 +23,9 @@
             <div class="card mb-3 inventory-category">
                 <h5 class="card-header inventory-header">
                     {!! isset($categories[$categoryId]) ? '<a href="' . $categories[$categoryId]->searchUrl . '">' . $categories[$categoryId]->name . '</a>' : 'Miscellaneous' !!}
-                    <a class="small inventory-collapse-toggle collapse-toggle" href="#categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}" data-toggle="collapse">Show</a>
+                    <a class="small inventory-collapse-toggle collapse-toggle" href="#categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}" data-toggle="collapse">
+                        Show
+                    </a>
                 </h5>
                 <div class="card-body inventory-body collapse show" id="categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}">
                     @foreach ($categoryItems->chunk(4) as $chunk)
@@ -31,10 +33,14 @@
                             @foreach ($chunk as $itemId => $stack)
                                 <div class="col-sm-3 col-6 text-center inventory-item" data-id="{{ $stack->first()->pivot->id }}" data-name="{{ $user->name }}'s {{ $stack->first()->name }}">
                                     <div class="mb-1">
-                                        <a href="#" class="inventory-stack"><img src="{{ $stack->first()->imageUrl }}" alt="{{ $stack->first()->name }}" /></a>
+                                        <a href="#" class="inventory-stack">
+                                            <img src="{{ $stack->first()->imageUrl }}" alt="{{ $stack->first()->name }}" />
+                                        </a>
                                     </div>
                                     <div>
-                                        <a href="#" class="inventory-stack inventory-stack-name">{{ $stack->first()->name }} x{{ $stack->sum('pivot.count') }}</a>
+                                        <a href="#" class="inventory-stack inventory-stack-name">
+                                            {{ $stack->first()->name }} x{{ $stack->sum('pivot.count') }}
+                                        </a>
                                     </div>
                                 </div>
                             @endforeach
@@ -50,7 +56,9 @@
             <div class="card mb-2">
                 <h5 class="card-header">
                     {!! isset($categories[$categoryId]) ? '<a href="' . $categories[$categoryId]->searchUrl . '">' . $categories[$categoryId]->name . '</a>' : 'Miscellaneous' !!}
-                    <a class="small inventory-collapse-toggle collapse-toggle" href="#categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}" data-toggle="collapse">Show</a>
+                    <a class="small inventory-collapse-toggle collapse-toggle" href="#categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}" data-toggle="collapse">
+                        Show
+                    </a>
                 </h5>
                 <div class="card-body p-2 collapse show row" id="categoryId_{!! isset($categories[$categoryId]) ? $categories[$categoryId]->id : 'miscellaneous' !!}">
                     @foreach ($categoryItems as $itemtype)

--- a/resources/views/user/inventory.blade.php
+++ b/resources/views/user/inventory.blade.php
@@ -106,11 +106,10 @@
             @endforeach
         </div>
     </div>
-    
+
     <div class="text-right">
         <a href="{{ url($user->url . '/item-logs') }}">View all...</a>
     </div>
-
 @endsection
 
 @section('scripts')

--- a/resources/views/widgets/_inventory_view_js.blade.php
+++ b/resources/views/widgets/_inventory_view_js.blade.php
@@ -19,25 +19,22 @@
             setView('sum');
         });
 
-        function initView()
-        {
+        function initView() {
             view = window.localStorage.getItem('lorekeeper_inventory_view');
-            if(!view) view = 'def';
+            if (!view) view = 'def';
             setView(view);
         }
 
-        function setView(status)
-        {
+        function setView(status) {
             view = status;
 
-            if(view == 'def') {
+            if (view == 'def') {
                 $defView.removeClass('hide');
                 $defButton.addClass('active');
                 $sumView.addClass('hide');
                 $sumButton.removeClass('active');
                 window.localStorage.setItem('lorekeeper_inventory_view', 'def');
-            }
-            else if (view == 'sum') {
+            } else if (view == 'sum') {
                 $sumView.removeClass('hide');
                 $sumButton.addClass('active');
                 $defView.addClass('hide');

--- a/resources/views/widgets/_inventory_view_js.blade.php
+++ b/resources/views/widgets/_inventory_view_js.blade.php
@@ -1,0 +1,49 @@
+<script>
+    $(document).ready(function() {
+
+        var $defButton = $('.def-view-button');
+        var $defView = $('#defView');
+        var $sumButton = $('.sum-view-button');
+        var $sumView = $('#sumView');
+
+        var view = null;
+
+        initView();
+
+        $defButton.on('click', function(e) {
+            e.preventDefault();
+            setView('def');
+        });
+        $sumButton.on('click', function(e) {
+            e.preventDefault();
+            setView('sum');
+        });
+
+        function initView()
+        {
+            view = window.localStorage.getItem('lorekeeper_inventory_view');
+            if(!view) view = 'def';
+            setView(view);
+        }
+
+        function setView(status)
+        {
+            view = status;
+
+            if(view == 'def') {
+                $defView.removeClass('hide');
+                $defButton.addClass('active');
+                $sumView.addClass('hide');
+                $sumButton.removeClass('active');
+                window.localStorage.setItem('lorekeeper_inventory_view', 'def');
+            }
+            else if (view == 'sum') {
+                $sumView.removeClass('hide');
+                $sumButton.addClass('active');
+                $defView.addClass('hide');
+                $defButton.removeClass('active');
+                window.localStorage.setItem('lorekeeper_inventory_view', 'sum');
+            }
+        }
+    });
+</script>


### PR DESCRIPTION
- Added Summarized View to Home, User and Character inventories, similarly to the Masterlist view.
- Also fixed minor change on Full Inventory, and added a tag symbol for named items.

This kind of view for the other inventories was originally suggested by @AW0005 in https://github.com/corowne/lorekeeper/pull/669#pullrequestreview-1578925415 :)