### PR TITLE
Bug(Shops): Shops with no image will show broken image icon

### DIFF
--- a/resources/views/shops/shop.blade.php
+++ b/resources/views/shops/shop.blade.php
@@ -13,7 +13,7 @@
     </h1>
 
     <div class="text-center">
-        <img src="{{ $shop->shopImageUrl }}" style="max-width:100%" alt="{{ $shop->name }}" />
+        @if($shop->has_image) <img src="{{ $shop->shopImageUrl }}" style="max-width:100%" alt="{{ $shop->name }}" /> @endif
         <p>{!! $shop->parsed_description !!}</p>
     </div>
 


### PR DESCRIPTION
Shops with no image specified were still adding the image html and showing a broken image icon instead of hiding it.