### PR TITLE
Fix(MYOs): Allows character images to work locally

### DIFF
--- a/app/Services/CharacterManager.php
+++ b/app/Services/CharacterManager.php
@@ -237,8 +237,8 @@ class CharacterManager extends Service
                 // Use default images for MYO slots without an image provided
                 if(!isset($data['image']))
                 {
-                    $data['image'] = asset('images/myo.png');
-                    $data['thumbnail'] = asset('images/myo-th.png');
+                    $data['image'] = public_path('images/myo.png');
+                    $data['thumbnail'] = public_path('images/myo-th.png');
                     $data['extension'] = 'png';
                     $data['default_image'] = true;
                     unset($data['use_cropper']);


### PR DESCRIPTION
Having found that you cannot make MYO slots because of an incorrect url issue, I investigated how this happened and found it was this use of the asset() function as opposed to the public_path() function.
I've done my research and there is not a single service that uses asset(), except the character manager. So I hereby propose this fix.

This admittedly only fixes the use of MYO slots on localhost. On a live site, this change has no effect. But this should make testing easier, at least.