### PR TITLE
fix(comments): more robust handling for non user-user comments

### DIFF
--- a/app/Console/Commands/UpdateCommentTypes.php
+++ b/app/Console/Commands/UpdateCommentTypes.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Comment;
+use Illuminate\Console\Command;
+
+class UpdateCommentTypes extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'update-comment-types';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Updates comment types.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $comments = Comment::where('commentable_type', 'App\Models\Report\Report')->where('type', 'User-User');
+
+        if($comments->count()) {
+            $this->line('Updating comment types...');
+            $comments->update(['type' => 'Staff-User']);
+        } else {
+            $this->info('No comments to update!');
+        }
+
+        return 0;
+    }
+}

--- a/app/Http/Controllers/PermalinkController.php
+++ b/app/Http/Controllers/PermalinkController.php
@@ -62,8 +62,6 @@ class PermalinkController extends Controller
                         break;
                 }
                 break;
-            default:
-                break;
         }
 
         if($comment->commentable_type == 'App\Models\User\UserProfile') $comment->location = $comment->commentable->user->url;

--- a/app/Http/Controllers/PermalinkController.php
+++ b/app/Http/Controllers/PermalinkController.php
@@ -49,7 +49,7 @@ class PermalinkController extends Controller
                         if(!$isMod && !$isOwner) abort(404);
                         break;
                     default:
-                        abort(404);
+                        if(!Auth::user()->isStaff) abort(404);
                         break;
                 }
             case "Staff-Staff":

--- a/app/Http/Controllers/PermalinkController.php
+++ b/app/Http/Controllers/PermalinkController.php
@@ -12,6 +12,7 @@ use App\Models\Gallery\GallerySubmission;
 use App\Models\Model;
 
 use App\Models\Comment;
+use App\Models\Report\Report;
 
 class PermalinkController extends Controller
 {
@@ -25,7 +26,7 @@ class PermalinkController extends Controller
         $comments = Comment::all();
         //$comments = $comments->sortByDesc('created_at');
         $comment = $comments->find($id);
-         
+
         if(!$comment) abort(404);
         if(!$comment->commentable) abort(404);
 
@@ -33,15 +34,33 @@ class PermalinkController extends Controller
         switch($comment->type) {
             case "Staff-User":
                 if(!Auth::check()) abort(404);
-                $submission = GallerySubmission::find($comment->commentable_id);
-                $isMod = Auth::user()->hasPower('manage_submissions');
-                $isOwner = ($submission->user_id == Auth::user()->id);
-                $isCollaborator = $submission->collaborators->where('user_id', Auth::user()->id)->first() != null ? true : false;
-                if(!$isMod && !$isOwner && !$isCollaborator) abort(404);
-                break;
+                switch($comment->commentable_type) {
+                    case 'App\Models\Gallery\GallerySubmission':
+                        $submission = GallerySubmission::where('id', $comment->commentable_id)->first();
+                        $isMod = Auth::user()->hasPower('manage_submissions');
+                        $isOwner = ($submission->user_id == Auth::user()->id);
+                        $isCollaborator = $submission->collaborators->where('user_id', Auth::user()->id)->first() != null ? true : false;
+                        if(!$isMod && !$isOwner && !$isCollaborator) abort(404);
+                        break;
+                    case 'App\Models\Report\Report':
+                        $report = Report::where('id', $comment->commentable_id)->first();
+                        $isMod = Auth::user()->hasPower('manage_reports');
+                        $isOwner = ($report->user_id == Auth::user()->id);
+                        if(!$isMod && !$isOwner) abort(404);
+                        break;
+                    default:
+                        abort(404);
+                        break;
+                }
             case "Staff-Staff":
                 if(!Auth::check()) abort(404);
-                if(!Auth::user()->hasPower('manage_submissions')) abort(404);
+                if(!Auth::user()->isStaff) abort(404);
+                // More specific filtering depending on circumstance
+                switch($comment->commentable_type) {
+                    case 'App\Models\Gallery\GallerySubmission':
+                        if(!Auth::user()->hasPower('manage_submissions')) abort(404);
+                        break;
+                }
                 break;
             default:
                 break;
@@ -49,9 +68,9 @@ class PermalinkController extends Controller
 
         if($comment->commentable_type == 'App\Models\User\UserProfile') $comment->location = $comment->commentable->user->url;
         else $comment->location = $comment->commentable->url;
-        
+
         return view('comments._perma_layout',[
-            'comment' => $comment,            
+            'comment' => $comment,
         ]);
     }
 }

--- a/resources/views/admin/reports/report.blade.php
+++ b/resources/views/admin/reports/report.blade.php
@@ -52,11 +52,11 @@
             @endif
 		</div></div>
     @endif
-    
+
     @if($report->status == 'Assigned' && $report->user_id == Auth::user()->id || Auth::user()->hasPower('manage_reports'))
-    @comments([ 'model' => $report, 'perPage' => 5 ])
+    @comments([ 'type' => 'Staff-User', 'model' => $report, 'perPage' => 5 ])
     @endif
-    
+
     {!! Form::open(['url' => url()->current(), 'id' => 'reportForm']) !!}
     @if($report->status == 'Assigned' && Auth::user()->id == $report->staff_id)
     @if(Auth::user()->hasPower('manage_reports'))<div class="alert alert-warning">Please include a small paragraph on the solution and as many important details as you deem necessary, as the user will no longer be able to view the comments after the report is closed</div>@endif
@@ -111,10 +111,10 @@
 @endsection
 
 @section('scripts')
-@parent 
+@parent
 @if($report->status !== 'Closed')
     <script>
-        
+
         $(document).ready(function() {
             var $confirmationModal = $('#confirmationModal');
             var $reportForm = $('#reportForm');
@@ -126,14 +126,14 @@
             var $assignButton = $('#assignButton');
             var $assignContent = $('#assignContent');
             var $assignSubmit = $('#assignSubmit');
-            
+
             $closalButton.on('click', function(e) {
                 e.preventDefault();
                 $closalContent.removeClass('hide');
                 $assignContent.addClass('hide');
                 $confirmationModal.modal('show');
             });
-            
+
             $assignButton.on('click', function(e) {
                 e.preventDefault();
                 $assignContent.removeClass('hide');

--- a/resources/views/home/_report_content.blade.php
+++ b/resources/views/home/_report_content.blade.php
@@ -33,7 +33,7 @@
 
 @if(Auth::check() && $report->status == 'Assigned' && $report->user == Auth::user() || Auth::user()->hasPower('manage_reports'))
 <div class="alert alert-danger">Admins will be alerted by new comments, however to keep the conversation organised we ask that you please reply to the admin comment.</div>
-    @comments([ 'model' => $report, 'perPage' => 5 ])
+    @comments([ 'type' => 'Staff-User', 'model' => $report, 'perPage' => 5 ])
 @elseif($report->status == 'Closed')
 <div class="alert alert-danger"> You cannot comment on a closed ticket. </div>
 @else


### PR DESCRIPTION
As on the tin... building on my work wrt gallery submissions but making it... not exclusive to them.... Should be more extensible for the odd instance where these comment types are needed down the road as well.
Also includes a command (`php artisan update-comment-types`) to handle already-extant comments.

Tested a bit on local and looks to work as expected.