### PR TITLE
feature/improved image processing

### DIFF
--- a/app/Console/Commands/FillExistingFullsizeExtensions.php
+++ b/app/Console/Commands/FillExistingFullsizeExtensions.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Character\CharacterImage;
+use Illuminate\Console\Command;
+
+class FillExistingFullsizeExtensions extends Command {
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:fill-character-fullsize-extensions';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Supplies file extension information for any stored masterlist full-size images from the existing stored extension.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle() {
+        $images = CharacterImage::whereNotNull('fullsize_hash')->whereNull('fullsize_extension')->get();
+
+        if ($images->count()) {
+            $this->info('Processing '.$images->count().' images...');
+            foreach ($images as $image) {
+                $image->update(['fullsize_extension' => $image->extension]);
+            }
+
+            $this->line('Done!');
+        } else {
+            $this->line('No images need processing!');
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Models/Character/CharacterImage.php
+++ b/app/Models/Character/CharacterImage.php
@@ -17,7 +17,7 @@ class CharacterImage extends Model {
      */
     protected $fillable = [
         'character_id', 'user_id', 'species_id', 'subtype_id', 'rarity_id', 'url',
-        'extension', 'use_cropper', 'hash', 'fullsize_hash', 'sort',
+        'extension', 'use_cropper', 'hash', 'fullsize_hash', 'fullsize_extension', 'sort',
         'x0', 'x1', 'y0', 'y1',
         'description', 'parsed_description',
         'is_valid',
@@ -45,8 +45,8 @@ class CharacterImage extends Model {
     public static $createRules = [
         'species_id' => 'required',
         'rarity_id'  => 'required',
-        'image'      => 'required|mimes:jpeg,jpg,gif,png|max:20000',
-        'thumbnail'  => 'nullable|mimes:jpeg,jpg,gif,png|max:20000',
+        'image'      => 'required|mimes:jpeg,jpg,gif,png,webp|max:20000',
+        'thumbnail'  => 'nullable|mimes:jpeg,jpg,gif,png,webp|max:20000',
     ];
 
     /**
@@ -205,7 +205,7 @@ class CharacterImage extends Model {
      * @return string
      */
     public function getFullsizeFileNameAttribute() {
-        return $this->id.'_'.$this->hash.'_'.$this->fullsize_hash.'_full.'.$this->extension;
+        return $this->id.'_'.$this->hash.'_'.$this->fullsize_hash.'_full.'.$this->fullsize_extension;
     }
 
     /**

--- a/app/Models/Gallery/GallerySubmission.php
+++ b/app/Models/Gallery/GallerySubmission.php
@@ -47,7 +47,7 @@ class GallerySubmission extends Model {
      */
     public static $createRules = [
         'title'       => 'required|between:3,200',
-        'image'       => 'required_without:text|mimes:png,jpeg,jpg,gif|max:3000',
+        'image'       => 'required_without:text|mimes:png,jpeg,jpg,gif,webp|max:3000',
         'text'        => 'required_without:image',
         'description' => 'nullable',
     ];
@@ -60,7 +60,7 @@ class GallerySubmission extends Model {
     public static $updateRules = [
         'title'       => 'required|between:3,200',
         'description' => 'nullable',
-        'image'       => 'mimes:png,jpeg,jpg,gif|max:3000',
+        'image'       => 'mimes:png,jpeg,jpg,gif,webp|max:3000',
     ];
 
     /**********************************************************************************************

--- a/app/Services/CharacterManager.php
+++ b/app/Services/CharacterManager.php
@@ -226,10 +226,7 @@ class CharacterManager extends Service {
             }
 
             if (config('lorekeeper.settings.masterlist_fullsizes_cap') != 0) {
-                $imageWidth = $image->width();
-                $imageHeight = $image->height();
-
-                if ($imageWidth > $imageHeight) {
+                if ($image->width() > $image->height()) {
                     // Landscape
                     $image->resize(config('lorekeeper.settings.masterlist_fullsizes_cap'), null, function ($constraint) {
                         $constraint->aspectRatio();

--- a/app/Services/CharacterManager.php
+++ b/app/Services/CharacterManager.php
@@ -2,6 +2,8 @@
 
 namespace App\Services;
 
+use App\Facades\Notifications;
+use App\Facades\Settings;
 use App\Models\Character\Character;
 use App\Models\Character\CharacterBookmark;
 use App\Models\Character\CharacterCategory;
@@ -13,12 +15,10 @@ use App\Models\Character\CharacterTransfer;
 use App\Models\Species\Subtype;
 use App\Models\User\User;
 use Carbon\Carbon;
-use Config;
-use DB;
 use Illuminate\Support\Arr;
-use Image;
-use Notifications;
-use Settings;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Intervention\Image\Facades\Image;
 
 class CharacterManager extends Service {
     /*
@@ -185,10 +185,17 @@ class CharacterManager extends Service {
      * @param \App\Models\Character\CharacterImage $characterImage
      */
     public function processImage($characterImage) {
+        $imageProperties = getimagesize($characterImage->imagePath.'/'.$characterImage->imageFileName);
+        if ($imageProperties[0] > 2000 || $imageProperties[1] > 2000) {
+            // For large images (in terms of dimensions),
+            // use imagick instead, as it's better at handling them
+            Config::set('image.driver', 'imagick');
+        }
+
         // Trim transparent parts of image.
         $image = Image::make($characterImage->imagePath.'/'.$characterImage->imageFileName)->trim('transparent');
 
-        if (Config::get('lorekeeper.settings.masterlist_image_automation') == 1) {
+        if (config('lorekeeper.settings.masterlist_image_automation') == 1) {
             // Make the image be square
             $imageWidth = $image->width();
             $imageHeight = $image->height();
@@ -204,12 +211,13 @@ class CharacterManager extends Service {
             }
         }
 
-        if (Config::get('lorekeeper.settings.masterlist_image_format') != 'png' && Config::get('lorekeeper.settings.masterlist_image_format') != null && Config::get('lorekeeper.settings.masterlist_image_background') != null) {
-            $canvas = Image::canvas($image->width(), $image->height(), Config::get('lorekeeper.settings.masterlist_image_background'));
+        // Add background fill if destination format is not transparent
+        if (!in_array(config('lorekeeper.settings.masterlist_image_format'), ['png', 'webp']) && config('lorekeeper.settings.masterlist_image_format') != null && config('lorekeeper.settings.masterlist_image_background') != null) {
+            $canvas = Image::canvas($image->width(), $image->height(), config('lorekeeper.settings.masterlist_image_background'));
             $image = $canvas->insert($image, 'center');
         }
 
-        if (Config::get('lorekeeper.settings.store_masterlist_fullsizes') == 1) {
+        if (config('lorekeeper.settings.store_masterlist_fullsizes') == 1) {
             // Generate fullsize hash if not already generated,
             // then save the full-sized image
             if (!$characterImage->fullsize_hash) {
@@ -217,19 +225,19 @@ class CharacterManager extends Service {
                 $characterImage->save();
             }
 
-            if (Config::get('lorekeeper.settings.masterlist_fullsizes_cap') != 0) {
+            if (config('lorekeeper.settings.masterlist_fullsizes_cap') != 0) {
                 $imageWidth = $image->width();
                 $imageHeight = $image->height();
 
                 if ($imageWidth > $imageHeight) {
                     // Landscape
-                    $image->resize(Config::get('lorekeeper.settings.masterlist_fullsizes_cap'), null, function ($constraint) {
+                    $image->resize(config('lorekeeper.settings.masterlist_fullsizes_cap'), null, function ($constraint) {
                         $constraint->aspectRatio();
                         $constraint->upsize();
                     });
                 } else {
                     // Portrait
-                    $image->resize(null, Config::get('lorekeeper.settings.masterlist_fullsizes_cap'), function ($constraint) {
+                    $image->resize(null, config('lorekeeper.settings.masterlist_fullsizes_cap'), function ($constraint) {
                         $constraint->aspectRatio();
                         $constraint->upsize();
                     });
@@ -237,7 +245,7 @@ class CharacterManager extends Service {
             }
 
             // Save the processed image
-            $image->save($characterImage->imagePath.'/'.$characterImage->fullsizeFileName, 100, Config::get('lorekeeper.settings.masterlist_image_format'));
+            $image->save($characterImage->imagePath.'/'.$characterImage->fullsizeFileName, 100, config('lorekeeper.settings.masterlist_fullsizes_format'));
         } else {
             // Delete fullsize if it was previously created.
             if (isset($characterImage->fullsize_hash) ? file_exists(public_path($characterImage->imageDirectory.'/'.$characterImage->fullsizeFileName)) : false) {
@@ -246,36 +254,47 @@ class CharacterManager extends Service {
         }
 
         // Resize image if desired
-        if (Config::get('lorekeeper.settings.masterlist_image_dimension') != 0) {
-            $imageWidth = $image->width();
-            $imageHeight = $image->height();
-
-            if ($imageWidth > $imageHeight) {
+        if (config('lorekeeper.settings.masterlist_image_dimension') != 0) {
+            if ($image->width() > $image->height()) {
                 // Landscape
-                $image->resize(null, Config::get('lorekeeper.settings.masterlist_image_dimension'), function ($constraint) {
-                    $constraint->aspectRatio();
-                    $constraint->upsize();
-                });
+                if (config('lorekeeper.settings.masterlist_image_dimension_target') == 'short') {
+                    $image->resize(null, config('lorekeeper.settings.masterlist_image_dimension'), function ($constraint) {
+                        $constraint->aspectRatio();
+                        $constraint->upsize();
+                    });
+                } else {
+                    $image->resize(config('lorekeeper.settings.masterlist_image_dimension'), null, function ($constraint) {
+                        $constraint->aspectRatio();
+                        $constraint->upsize();
+                    });
+                }
             } else {
                 // Portrait
-                $image->resize(Config::get('lorekeeper.settings.masterlist_image_dimension'), null, function ($constraint) {
-                    $constraint->aspectRatio();
-                    $constraint->upsize();
-                });
+                if (config('lorekeeper.settings.masterlist_image_dimension_target') == 'short') {
+                    $image->resize(config('lorekeeper.settings.masterlist_image_dimension'), null, function ($constraint) {
+                        $constraint->aspectRatio();
+                        $constraint->upsize();
+                    });
+                } else {
+                    $image->resize(null, config('lorekeeper.settings.masterlist_image_dimension'), function ($constraint) {
+                        $constraint->aspectRatio();
+                        $constraint->upsize();
+                    });
+                }
             }
         }
         // Watermark the image if desired
-        if (Config::get('lorekeeper.settings.watermark_masterlist_images') == 1) {
+        if (config('lorekeeper.settings.watermark_masterlist_images') == 1) {
             $watermark = Image::make('images/watermark.png');
 
-            if (Config::get('lorekeeper.settings.watermark_resizing') == 1) {
+            if (config('lorekeeper.settings.watermark_resizing') == 1) {
                 $imageWidth = $image->width();
                 $imageHeight = $image->height();
 
                 $wmWidth = $watermark->width();
                 $wmHeight = $watermark->height();
 
-                $wmScale = Config::get('lorekeeper.settings.watermark_percent');
+                $wmScale = config('lorekeeper.settings.watermark_percent');
 
                 //Assume Landscape by Default
                 $maxSize = $imageWidth * $wmScale;
@@ -304,7 +323,7 @@ class CharacterManager extends Service {
         }
 
         // Save the processed image
-        $image->save($characterImage->imagePath.'/'.$characterImage->imageFileName, 100, Config::get('lorekeeper.settings.masterlist_image_format'));
+        $image->save($characterImage->imagePath.'/'.$characterImage->imageFileName, 100, config('lorekeeper.settings.masterlist_image_format'));
     }
 
     /**
@@ -1902,7 +1921,8 @@ class CharacterManager extends Service {
             $imageData['sort'] = 0;
             $imageData['is_valid'] = isset($data['is_valid']);
             $imageData['is_visible'] = isset($data['is_visible']);
-            $imageData['extension'] = (Config::get('lorekeeper.settings.masterlist_image_format') ? Config::get('lorekeeper.settings.masterlist_image_format') : ($data['extension'] ?? $data['image']->getClientOriginalExtension()));
+            $imageData['extension'] = (Config::get('lorekeeper.settings.masterlist_image_format') ?? ($data['extension'] ?? $data['image']->getClientOriginalExtension()));
+            $imageData['fullsize_extension'] = (Config::get('lorekeeper.settings.masterlist_fullsizes_format') ?? ($data['fullsize_extension'] ?? $data['image']->getClientOriginalExtension()));
             $imageData['character_id'] = $character->id;
 
             $image = CharacterImage::create($imageData);

--- a/app/Services/GalleryManager.php
+++ b/app/Services/GalleryManager.php
@@ -2,6 +2,8 @@
 
 namespace App\Services;
 
+use App\Facades\Notifications;
+use App\Facades\Settings;
 use App\Models\Character\Character;
 use App\Models\Currency\Currency;
 use App\Models\Gallery\Gallery;
@@ -14,8 +16,6 @@ use App\Models\User\User;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 use Intervention\Image\Facades\Image;
-use App\Facades\Notifications;
-use App\Facades\Settings;
 
 class GalleryManager extends Service {
     /*
@@ -818,11 +818,11 @@ class GalleryManager extends Service {
             Config::set('image.driver', 'imagick');
         }
 
-        if(config('lorekeeper.settings.gallery_images_cap') || config('lorekeeper.settings.gallery_images_format')) {
+        if (config('lorekeeper.settings.gallery_images_cap') || config('lorekeeper.settings.gallery_images_format')) {
             $image = Image::make($submission->imagePath.'/'.$submission->imageFileName);
 
             // Scale the image if desired/necessary
-            if(config('lorekeeper.settings.gallery_images_cap') && ($imageProperties[0] > config('lorekeeper.settings.gallery_images_cap') || $imageProperties[1] > config('lorekeeper.settings.gallery_images_cap'))) {
+            if (config('lorekeeper.settings.gallery_images_cap') && ($imageProperties[0] > config('lorekeeper.settings.gallery_images_cap') || $imageProperties[1] > config('lorekeeper.settings.gallery_images_cap'))) {
                 if ($image->width() > $image->height()) {
                     // Landscape
                     $image->resize(config('lorekeeper.settings.gallery_images_cap'), null, function ($constraint) {

--- a/app/Services/GalleryManager.php
+++ b/app/Services/GalleryManager.php
@@ -11,11 +11,11 @@ use App\Models\Gallery\GalleryFavorite;
 use App\Models\Gallery\GallerySubmission;
 use App\Models\Prompt\Prompt;
 use App\Models\User\User;
-use Config;
-use DB;
-use Image;
-use Notifications;
-use Settings;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Intervention\Image\Facades\Image;
+use App\Facades\Notifications;
+use App\Facades\Settings;
 
 class GalleryManager extends Service {
     /*
@@ -806,21 +806,49 @@ class GalleryManager extends Service {
             unlink($submission->imagePath.'/'.$submission->thumbnailFileName);
         }
         $submission->hash = randomString(10);
-        $submission->extension = $data['image']->getClientOriginalExtension();
+        $submission->extension = config('lorekeeper.settings.gallery_images_format') ?? $data['image']->getClientOriginalExtension();
 
         // Save image itself
-        $this->handleImage($data['image'], $submission->imageDirectory, $submission->imageFileName);
+        $this->handleImage($data['image'], $submission->imagePath, $submission->imageFileName);
+
+        $imageProperties = getimagesize($submission->imagePath.'/'.$submission->imageFileName);
+        if ($imageProperties[0] > 2000 || $imageProperties[1] > 2000) {
+            // For large images (in terms of dimensions),
+            // use imagick instead, as it's better at handling them
+            Config::set('image.driver', 'imagick');
+        }
+
+        if(config('lorekeeper.settings.gallery_images_cap') || config('lorekeeper.settings.gallery_images_format')) {
+            $image = Image::make($submission->imagePath.'/'.$submission->imageFileName);
+
+            // Scale the image if desired/necessary
+            if(config('lorekeeper.settings.gallery_images_cap') && ($imageProperties[0] > config('lorekeeper.settings.gallery_images_cap') || $imageProperties[1] > config('lorekeeper.settings.gallery_images_cap'))) {
+                if ($image->width() > $image->height()) {
+                    // Landscape
+                    $image->resize(config('lorekeeper.settings.gallery_images_cap'), null, function ($constraint) {
+                        $constraint->aspectRatio();
+                        $constraint->upsize();
+                    });
+                } else {
+                    // Portrait
+                    $image->resize(null, config('lorekeeper.settings.gallery_images_cap'), function ($constraint) {
+                        $constraint->aspectRatio();
+                        $constraint->upsize();
+                    });
+                }
+            }
+
+            // Save the processed image
+            $image->save($submission->imagePath.'/'.$submission->imageFileName, 100, config('lorekeeper.settings.gallery_images_format'));
+        }
 
         // Process thumbnail
-        $thumbnail = Image::make($submission->imagePath.'/'.$submission->imageFileName);
-        // Resize
-        $thumbnail->resize(null, Config::get('lorekeeper.settings.masterlist_thumbnails.height'), function ($constraint) {
-            $constraint->aspectRatio();
-            $constraint->upsize();
-        });
-
-        // Save thumbnail
-        $thumbnail->save($submission->thumbnailPath.'/'.$submission->thumbnailFileName);
+        Image::make($submission->imagePath.'/'.$submission->imageFileName)
+            ->resize(null, Config::get('lorekeeper.settings.masterlist_thumbnails.height'), function ($constraint) {
+                $constraint->aspectRatio();
+                $constraint->upsize();
+            })
+            ->save($submission->thumbnailPath.'/'.$submission->thumbnailFileName);
 
         return $submission;
     }

--- a/config/image.php
+++ b/config/image.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Image Driver
+    |--------------------------------------------------------------------------
+    |
+    | Intervention Image supports "GD Library" and "Imagick" to process images
+    | internally. You may choose one of them according to your PHP
+    | configuration. By default PHP's "GD Library" implementation is used.
+    |
+    | Supported: "gd", "imagick"
+    |
+    */
+
+    'driver' => 'gd',
+
+];

--- a/config/lorekeeper/settings.php
+++ b/config/lorekeeper/settings.php
@@ -265,6 +265,25 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Gallery Image Settings
+    |--------------------------------------------------------------------------
+    |
+    | This affects images submitted to on-site galleries.
+    |
+    | Size, in pixels, to cap gallery images at.
+    | Images above this cap in either dimension will be resized to suit. Enter "0" to disable resizing.
+    |
+    | File format to encode gallery image uploads to.
+    | Set to null to leave images in their original formats.
+    | Example:
+    | 'gallery_images_format' => null,
+    |
+    */
+    'gallery_images_cap'    => 0,
+    'gallery_images_format' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | Trade Asset Limit
     |--------------------------------------------------------------------------
     |

--- a/config/lorekeeper/settings.php
+++ b/config/lorekeeper/settings.php
@@ -137,23 +137,28 @@ return [
     |
     | 0: Do not watermark. 1: Automatically watermark masterlist images.
     |
-    | Dimension, in pixels, to scale the shorter dimension (between width/height)
-    | of submitted masterlist images to. Enter "0" to disable resizing.
+    | Dimension, in pixels, to scale submitted masterlist images to. Enter "0" to disable resizing.
+    |
+    | Which dimension to scale submitted masterlist images on. Options are 'shorter' and 'longer'.
+    | Only takes effect if masterlist_image_dimension is set. Defaults to 'shorter'.
     |
     | File format to encode masterlist image uploads to.
     | Set to null to leave images in their original formats.
     | Example:
     | 'masterlist_image_format' => null,
     |
-    | Color to fill non-png images in when masterlist_image_format is set.
+    | Color to fill non-transparent images in when masterlist_image_format is set.
     | This is in an endeavor to make images with a transparent background
     | compress better. Set to null to disable.
     | Example:
-    | 'masterlist_image_background' => 'png',
+    | 'masterlist_image_background' => '#ffffff',
     |
     */
     'watermark_masterlist_images'                       => 0,
+
     'masterlist_image_dimension'                        => 0,
+    'masterlist_image_dimension_target'                 => 'shorter',
+
     'masterlist_image_format'                           => null,
     'masterlist_image_background'                       => '#ffffff',
 
@@ -168,9 +173,15 @@ return [
     | Size, in pixels, to cap full-sized masterlist images at (if storing full-sized images is enabled).
     | Images above this cap in either dimension will be resized to suit. Enter "0" to disable resizing.
     |
+    | File format to encode full-sized masterlist image uploads to.
+    | Set to null to leave images in their original formats.
+    | Example:
+    | 'masterlist_fullsizes_format' => null,
+    |
     */
     'store_masterlist_fullsizes'                        => 0,
     'masterlist_fullsizes_cap'                          => 0,
+    'masterlist_fullsizes_format'                       => null,
 
     /*
     |--------------------------------------------------------------------------

--- a/database/migrations/2023_12_07_163202_add_fullsize_format_to_character_images.php
+++ b/database/migrations/2023_12_07_163202_add_fullsize_format_to_character_images.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up() {
+        Schema::table('character_images', function (Blueprint $table) {
+            //
+            $table->string('fullsize_extension')->nullable()->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down() {
+        Schema::table('character_images', function (Blueprint $table) {
+            //
+            $table->dropColumn('fullsize_extension');
+        });
+    }
+};

--- a/resources/views/galleries/create_edit_submission.blade.php
+++ b/resources/views/galleries/create_edit_submission.blade.php
@@ -53,7 +53,7 @@
             </div>
             <div class="card p-2">
                 {!! Form::file('image', ['id' => 'mainImage']) !!}
-                <small>Images may be PNG, GIF, or JPG and up to 3MB in size.</small>
+                <small>Images may be PNG, GIF, JPG, or WebP and up to 3MB in size.</small>
             </div>
         </div>
 


### PR DESCRIPTION
Improves/makes explicit the WebP support already present, as well as adding several additional image processing and storage improvements and options:
- Add config setting for which dimension (shorter/longer) to target when resizing masterlist images
- Add config settings for masterlist fullsize and gallery submission image format
    - Store masterlist fullsize extension separately
    - Add a command to backfill extension for existing fullsizes
- Add config setting to cap gallery submission image dimensions
- Add WebP to supported mimes for character images, gallery submission images
- Use Imagick for processing large (2k+ px in any dimension) images. This helps address GD's difficulty with these (which can lead to unnecessary memory usage spikes and failing to process them), but ***does* require installing imagick if not already present**! It's usually available as both its own package (`imagemagick`) and associated php extension (`php8.1-imagick`, for instance).
- Fix background color being applied to WebP images (as they also support transparency).

Requires installing imagemagick/php extension, `php artisan migrate`, `php artisan app:fill-character-fullsize-extensions` if there are already fullsize images stored.