### PR TITLE
Allow Masterlist staff to see each others comments

### DIFF
--- a/resources/views/character/design/_header.blade.php
+++ b/resources/views/character/design/_header.blade.php
@@ -4,7 +4,7 @@
 </h1>
 
 @if (isset($request->staff_id))
-    @if ($request->staff_comments && ($request->user_id == Auth::user()->id || Auth::user()->hasPower('manage_submissions')))
+    @if ($request->staff_comments && ($request->user_id == Auth::user()->id || Auth::user()->hasPower('manage_characters')))
         <h5 class="text-danger">Staff Comments ({!! $request->staff->displayName !!})</h5>
         <div class="card border-danger mb-3">
             <div class="card-body">{!! nl2br(htmlentities($request->staff_comments)) !!}</div>


### PR DESCRIPTION
For some reason staff comments on masterlist submissions were set to be viewable by... the prompt submission power? So if you had staff that only did masterlist submissions they probably couldn't see it. This should fix that.