### PR TITLE
fix(characters): update design update feature ordering

### DIFF
--- a/app/Models/Character/CharacterDesignUpdate.php
+++ b/app/Models/Character/CharacterDesignUpdate.php
@@ -113,11 +113,13 @@ class CharacterDesignUpdate extends Model {
      * Get the features (traits) attached to the design update, ordered by display order.
      */
     public function features() {
-        $ids = FeatureCategory::orderBy('sort', 'DESC')->pluck('id')->toArray();
+        $query = $this
+            ->hasMany(CharacterFeature::class, 'character_image_id')->where('character_features.character_type', 'Update')
+            ->join('features', 'features.id', '=', 'character_features.feature_id')
+            ->leftJoin('feature_categories', 'feature_categories.id', '=', 'features.feature_category_id')
+            ->select(['character_features.*', 'features.*', 'character_features.id AS character_feature_id', 'feature_categories.sort']);
 
-        $query = $this->hasMany('App\Models\Character\CharacterFeature', 'character_image_id')->where('character_features.character_type', 'Update')->join('features', 'features.id', '=', 'character_features.feature_id')->select(['character_features.*', 'features.*', 'character_features.id AS character_feature_id']);
-
-        return count($ids) ? $query->orderByRaw(DB::raw('FIELD(features.feature_category_id, '.implode(',', $ids).')')) : $query;
+        return $query->orderByDesc('sort');
     }
 
     /**


### PR DESCRIPTION
Realized while doing some other cleanup that design updates also has a copy of the offending `orderByRaw()` from #746 ...