### PR TITLE
Suggestion(sales): Comments anchor and consistency edit

### DIFF
--- a/resources/views/sales/_sales.blade.php
+++ b/resources/views/sales/_sales.blade.php
@@ -49,7 +49,7 @@
             </div>
         @else
             <div class="text-right mb-2 mr-2">
-            <a class="btn" href="#commentsSection"><i class="fas fa-comment"></i> {{ $commentCount }} Comment{{ $commentCount != 1 ? 's' : '' }}</a>
+                <a class="btn" href="#commentsSection"><i class="fas fa-comment"></i> {{ $commentCount }} Comment{{ $commentCount != 1 ? 's' : '' }}</a>
             </div>
         @endif
     @endif

--- a/resources/views/sales/_sales.blade.php
+++ b/resources/views/sales/_sales.blade.php
@@ -45,11 +45,11 @@
             ->count(); ?>
         @if (!$page)
             <div class="text-right mb-2 mr-2">
-                <a class="btn" href="{{ $sales->url }}"><i class="fas fa-comment"></i> {{ $commentCount }} Comment{{ $commentCount != 1 ? 's' : '' }}</a>
+                <a class="btn" href="{{ $sales->url }}#commentsSection"><i class="fas fa-comment"></i> {{ $commentCount }} Comment{{ $commentCount != 1 ? 's' : '' }}</a>
             </div>
         @else
             <div class="text-right mb-2 mr-2">
-                <span class="btn"><i class="fas fa-comment"></i> {{ $commentCount }} Comment{{ $commentCount != 1 ? 's' : '' }}</span>
+            <a class="btn" href="#commentsSection"><i class="fas fa-comment"></i> {{ $commentCount }} Comment{{ $commentCount != 1 ? 's' : '' }}</a>
             </div>
         @endif
     @endif

--- a/resources/views/sales/sales.blade.php
+++ b/resources/views/sales/sales.blade.php
@@ -8,7 +8,7 @@
     {!! breadcrumbs(['Site Sales' => 'sales', $sales->title => $sales->url]) !!}
     @include('sales._sales', ['sales' => $sales, 'page' => true])
 
-    <hr class="mb-5" id="commentsSection"/>
+    <hr class="mb-5" id="commentsSection" />
     @if ((isset($sales->comments_open_at) && $sales->comments_open_at < Carbon\Carbon::now()) || (Auth::check() && (Auth::user()->hasPower('manage_sales') || Auth::user()->hasPower('comment_on_sales'))) || !isset($sales->comments_open_at))
         @comments(['model' => $sales, 'perPage' => 5])
     @else

--- a/resources/views/sales/sales.blade.php
+++ b/resources/views/sales/sales.blade.php
@@ -8,8 +8,8 @@
     {!! breadcrumbs(['Site Sales' => 'sales', $sales->title => $sales->url]) !!}
     @include('sales._sales', ['sales' => $sales, 'page' => true])
 
+    <hr class="mb-5" id="commentsSection"/>
     @if ((isset($sales->comments_open_at) && $sales->comments_open_at < Carbon\Carbon::now()) || (Auth::check() && (Auth::user()->hasPower('manage_sales') || Auth::user()->hasPower('comment_on_sales'))) || !isset($sales->comments_open_at))
-        <hr class="mb-5" />
         @comments(['model' => $sales, 'perPage' => 5])
     @else
         <div class="alert alert-warning text-center">


### PR DESCRIPTION
Long story short:

Used the comments link and realized it just went to the sale. Figured a comments anchor would make more sense. Noted that on the page itself it's just a dead span, so I also made that go to the anchor (despite being right below.. consistency tho.)

Also; Didn't like how the "Comments are not open yet" block is right there leaning against the sales, felt it more consistent to give it the same hr treatment. Moved it out of the if and used it for the above link anchor. :)


I labelled this as suggestion because I kinda just went for it without talking about it- it's very minor and if it's not liked, well, there's a decline for a reason. :)
