### PR TITLE
fix(commands): Extension Tracker not working on live due to backslash vs forwardslash

### DIFF
--- a/app/Console/Commands/UpdateExtensionTracker.php
+++ b/app/Console/Commands/UpdateExtensionTracker.php
@@ -38,7 +38,7 @@ class UpdateExtensionTracker extends Command {
         $this->info('****************************');
 
         $extendos = [];
-        foreach (glob('config\lorekeeper\ext-tracker\*.php') as $extension) {
+        foreach (glob('config/lorekeeper/ext-tracker/*.php') as $extension) {
             $extendos[basename($extension, '.php')] = include $extension;
         }
 


### PR DESCRIPTION
Linux servers do __not__ like back slashes. (**Boo to `\`!!**)

Linux servers **do** like forward slashes. (**Yay to `/`!!**)

TL;DR No matter how nice it looks locally, it won't run live unless forwardslash.