### PR TITLE
fix(user): Forced lowercase on name check

### DIFF
--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -11,7 +11,7 @@
 @section('profile-content')
     {!! breadcrumbs(['Users' => 'users', $user->name => $user->url]) !!}
 
-    @if (strtolower($user->name) != strtolower($name))
+    @if (mb_strtolower($user->name) != mb_strtolower($name))
         <div class="alert alert-info">This user has changed their name to <strong>{{ $user->name }}</strong>.</div>
     @endif
 

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -11,7 +11,7 @@
 @section('profile-content')
     {!! breadcrumbs(['Users' => 'users', $user->name => $user->url]) !!}
 
-    @if ($user->name != $name)
+    @if (strtolower($user->name) != strtolower($name))
         <div class="alert alert-info">This user has changed their name to <strong>{{ $user->name }}</strong>.</div>
     @endif
 


### PR DESCRIPTION
Imagine: you know a username, and you visit their profile by just typing their name.

But you forgot to capitalize their name. Now a box appears that their username was changed to "Username", just cause you missed the capitalization.

..Very minor bug, yes, but by forcing the check to be entirely lowercase, it eliminates the messagebox from popping up on missing caps.