### PR TITLE
fix(galleries): Shows subgalleries of parent while in subgallery (and siblings and avunculi!)

### DIFF
--- a/app/Models/Gallery/Gallery.php
+++ b/app/Models/Gallery/Gallery.php
@@ -78,6 +78,26 @@ class Gallery extends Model
     }
 
     /**
+     * Get the sibling galleries of this gallery.
+     */
+    public function siblings() {
+		if($this->parent) {
+			return $this->parent->hasMany(self::class, 'parent_id')->sort();
+		}
+		return null;
+    }
+	
+    /**
+     * Get the avunculi galleries of this gallery.
+     */
+    public function avunculi() {
+		if ($this->parent && $this->parent->siblings()) {
+			return $this->parent->siblings()->sort();
+		}
+		return null;
+    }
+
+    /**
      * Get the submissions made to this gallery.
      */
     public function submissions()

--- a/resources/views/galleries/_sidebar.blade.php
+++ b/resources/views/galleries/_sidebar.blade.php
@@ -19,6 +19,15 @@
         </li>
     @endif
 
+    @if ($galleryPage && $sideGallery->parent && $sideGallery->parent->children->count())
+        <li class="sidebar-section">
+            <div class="sidebar-section-header">{{ $sideGallery->parent->name }}: Sub-Galleries</div>
+            @foreach ($sideGallery->parent->children()->visible()->get() as $child)
+                <div class="sidebar-item"><a href="{{ url('gallery/' . $child->id) }}" class="{{ set_active('gallery/' . $child->id) }}">{{ $child->name }}</a></div>
+            @endforeach
+        </li>
+    @endif
+
     <li class="sidebar-section">
         <div class="sidebar-section-header">Galleries</div>
         @foreach($sidebarGalleries as $gallery)

--- a/resources/views/galleries/_sidebar.blade.php
+++ b/resources/views/galleries/_sidebar.blade.php
@@ -19,11 +19,20 @@
         </li>
     @endif
 
-    @if ($galleryPage && $sideGallery->parent && $sideGallery->parent->children->count())
+    @if ($galleryPage && $sideGallery->siblings() && $sideGallery->siblings->count())
         <li class="sidebar-section">
             <div class="sidebar-section-header">{{ $sideGallery->parent->name }}: Sub-Galleries</div>
-            @foreach ($sideGallery->parent->children()->visible()->get() as $child)
-                <div class="sidebar-item"><a href="{{ url('gallery/' . $child->id) }}" class="{{ set_active('gallery/' . $child->id) }}">{{ $child->name }}</a></div>
+            @foreach ($sideGallery->siblings()->visible()->get() as $sibling)
+                <div class="sidebar-item"><a href="{{ url('gallery/' . $sibling->id) }}" class="{{ set_active('gallery/' . $sibling->id) }}">{{ $sibling->name }}</a></div>
+            @endforeach
+        </li>
+    @endif
+	
+    @if ($galleryPage && $sideGallery->avunculi() && $sideGallery->avunculi->count())
+        <li class="sidebar-section">
+            <div class="sidebar-section-header">{{ $sideGallery->parent->parent->name }}: Sub-Galleries</div>
+            @foreach ($sideGallery->avunculi()->visible()->get() as $avunculus)
+                <div class="sidebar-item"><a href="{{ url('gallery/' . $avunculus->id) }}" class="{{ set_active('gallery/' . $avunculus->id) }}">{{ $avunculus->name }}</a></div>
             @endforeach
         </li>
     @endif


### PR DESCRIPTION
While in a subgallery, the sidebar stopped showing the other subgalleries of it's parent.

This fixes it, and even works for sub-subgalleries.. Though only one level in.

~~This may require more finetuning in the model later, but I figured this is a fine start.~~

I actually added some fixes that makes it instead check for siblings and avunculi. (Aunts and uncles - aka the parent's siblings.)

You can now have up to Three levels in- which marks a vast improvement in my opinion.