### PR TITLE
Make back-hashing images optional

### DIFF
--- a/app/Console/Commands/UpdateLorekeeperV3.php
+++ b/app/Console/Commands/UpdateLorekeeperV3.php
@@ -62,9 +62,6 @@ class UpdateLorekeeperV3 extends Command {
 
             $this->line("\n".'Updating comments...');
             $this->call('update-comment-types');
-
-            $this->line("\n".'Updating data images...');
-            $this->call('add-image-hashes');
         } else {
             $this->line('Aborting! Please run composer update and then run this command again.');
         }

--- a/app/Console/Commands/UpdateLorekeeperV3.php
+++ b/app/Console/Commands/UpdateLorekeeperV3.php
@@ -64,11 +64,11 @@ class UpdateLorekeeperV3 extends Command {
             $this->call('update-comment-types');
 
             if ($this->confirm(
-                "\n" . 'Adding image hashes to old images will protect existing unreleased content'
-                . "\n" . 'but may break references to these urls in places like news, sales or pages.'
-                . "\n" . 'Do you wish to add hashes to your existing images?'
+                "\n".'Adding image hashes to old images will protect existing unreleased content'
+                ."\n".'but may break references to these urls in places like news, sales or pages.'
+                ."\n".'Do you wish to add hashes to your existing images?'
             )) {
-                $this->line("\n" . 'Updating data images...');
+                $this->line("\n".'Updating data images...');
                 $this->call('add-image-hashes');
             }
         } else {

--- a/app/Console/Commands/UpdateLorekeeperV3.php
+++ b/app/Console/Commands/UpdateLorekeeperV3.php
@@ -62,6 +62,15 @@ class UpdateLorekeeperV3 extends Command {
 
             $this->line("\n".'Updating comments...');
             $this->call('update-comment-types');
+
+            if ($this->confirm(
+                "\n" . 'Adding image hashes to old images will protect existing unreleased content'
+                . "\n" . 'but may break references to these urls in places like news, sales or pages.'
+                . "\n" . 'Do you wish to add hashes to your existing images?'
+            )) {
+                $this->line("\n" . 'Updating data images...');
+                $this->call('add-image-hashes');
+            }
         } else {
             $this->line('Aborting! Please run composer update and then run this command again.');
         }


### PR DESCRIPTION
While I agreed with providing this command for those that wish to back-hash their image urls, I don't think it's a good idea to assume everyone updating to V3 will inherently want to do this - I certainly wouldn't.

Most existing images likely won't be unreleased content, _and_ it's not uncommon to use the static link to an image in other places of the site, via pages, news, sales, etc. Back-hashing will kill all of those links, which very much may not be expected or remotely wanted by those updating to V3.

So this opts to add that information as a part of the V3 update command and give the option to skip back-hashing images