### PR TITLE
fix(user): FTO badge unreasonably small

### DIFF
--- a/resources/views/user/_profile_content.blade.php
+++ b/resources/views/user/_profile_content.blade.php
@@ -21,7 +21,9 @@
 
             @if ($user->settings->is_fto)
                 <div class="col-md-1 text-center">
-                    <span class="badge badge-success float-md-right" data-toggle="tooltip" title="This user has not owned any characters from this world before.">FTO</span>
+                    <h2>
+                        <span class="badge badge-success float-md-right" data-toggle="tooltip" title="This user has not owned any characters from this world before.">FTO</span>
+                    </h2>
                 </div>
             @endif
         </div>

--- a/resources/views/user/_profile_content.blade.php
+++ b/resources/views/user/_profile_content.blade.php
@@ -21,9 +21,7 @@
 
             @if ($user->settings->is_fto)
                 <div class="col-md-1 text-center">
-                    <h2>
-                        <span class="badge badge-success float-md-right" data-toggle="tooltip" title="This user has not owned any characters from this world before.">FTO</span>
-                    </h2>
+                    <span class="btn badge-success float-md-right" data-toggle="tooltip" title="This user has not owned any characters from this world before.">FTO</span>
                 </div>
             @endif
         </div>


### PR DESCRIPTION
Before you ask, 'why not add the h2 class'? It's cause badges do not support it, they require the html heading.

[See bootstrap documentation on badges](https://getbootstrap.com/docs/4.1/components/badge/#headings) - and [even the newer version](https://getbootstrap.com/docs/5.3/components/badge/#headings) is missing it..

...Of course, then I decided- hang on a sec, I should just make it consistent to character status badges, and I did.