### PR TITLE
Suggestion: species visual index fix

### DIFF
--- a/resources/views/world/species_features.blade.php
+++ b/resources/views/world/species_features.blade.php
@@ -23,7 +23,7 @@
                                 <div class="col-sm-3 col-6 text-center align-self-center inventory-item">
                                     @if ($feature->first()->has_image)
                                         <a class="badge" style="border-radius:.5em; {{ $feature->first()->rarity->color ? 'background-color:#' . $feature->first()->rarity->color : '' }}" href="{{ $feature->first()->url }}">
-                                            <img class="my-1 modal-image" style="max-height:100%; height:150px; border-radius:.5em;" src="{{ $feature->first()->imageUrl }}" alt="{{ $feature->first()->name }}"  data-id="{{ $feature->first()->id }}" />
+                                            <img class="my-1 modal-image" style="max-height:100%; height:150px; border-radius:.5em;" src="{{ $feature->first()->imageUrl }}" alt="{{ $feature->first()->name }}" data-id="{{ $feature->first()->id }}" />
                                         </a>
                                     @endif
                                     <p>

--- a/resources/views/world/species_features.blade.php
+++ b/resources/views/world/species_features.blade.php
@@ -20,10 +20,10 @@
                     @foreach ($categoryFeatures->chunk(4) as $chunk)
                         <div class="row mb-3">
                             @foreach ($chunk as $featureId => $feature)
-                                <div class="col-sm-3 col-6 text-center align-self-center inventory-item" data-id="{{ $feature->first()->id }}">
+                                <div class="col-sm-3 col-6 text-center align-self-center inventory-item">
                                     @if ($feature->first()->has_image)
                                         <a class="badge" style="border-radius:.5em; {{ $feature->first()->rarity->color ? 'background-color:#' . $feature->first()->rarity->color : '' }}" href="{{ $feature->first()->url }}">
-                                            <img class="my-1" style="max-height:100%; height:150px; border-radius:.5em;" src="{{ $feature->first()->imageUrl }}" alt="{{ $feature->first()->name }}" />
+                                            <img class="my-1 modal-image" style="max-height:100%; height:150px; border-radius:.5em;" src="{{ $feature->first()->imageUrl }}" alt="{{ $feature->first()->name }}"  data-id="{{ $feature->first()->id }}" />
                                         </a>
                                     @endif
                                     <p>
@@ -46,7 +46,7 @@
     @if (config('lorekeeper.extensions.species_trait_index.trait_modals'))
         <script>
             $(document).ready(function() {
-                $('.inventory-item').on('click', function(e) {
+                $('.modal-image').on('click', function(e) {
                     e.preventDefault();
 
                     loadModal("{{ url('world/species/' . $species->id . '/trait') }}/" + $(this).data('id'), 'Trait Detail');


### PR DESCRIPTION
Clicking either the image, name or rarity returns the modal.. highly annoying!

Even if you just want to copy paste the name, or want to get the rarity specifically, or maybe you want the link to the trait itself- any of these would make the modal pop up!

..Not anymore. This fixes it so only the IMAGE returns the modal, and the name and rarity work like the links they always were.