### PR TITLE
Allow for removal of last power on a rank

### DIFF
--- a/app/Services/RankService.php
+++ b/app/Services/RankService.php
@@ -111,8 +111,8 @@ class RankService extends Service {
             $data['icon'] ??= 'fas fa-user';
 
             $rank->update($data);
+            $rank->powers()->delete();
             if ($powers) {
-                $rank->powers()->delete();
                 foreach ($powers as $power) {
                     DB::table('rank_powers')->insert(['rank_id' => $rank->id, 'power' => $power]);
                 }


### PR DESCRIPTION
Discovered today that if you add a power to a rank, and it's the only power, and you try to remove it, it doesn't remove, because the code that deletes the old powers was only happening if at least one other power was being specified.