### PR TITLE
feature/password reset fix

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -6,6 +6,12 @@
 
 @section('content')
     @if ($userCount)
+        @if (session('status'))
+            <div class="alert alert-success mb-4">
+                {{ session('status') }}
+            </div>
+        @endif
+
         <div class="row">
             <div class="col-md-6 offset-md-4">
                 <h1>Log In</h1>

--- a/resources/views/auth/passwords/forgot.blade.php
+++ b/resources/views/auth/passwords/forgot.blade.php
@@ -5,6 +5,12 @@
 @endsection
 
 @section('content')
+    @if(isset($status) || isset($errors))
+        <div class="alert alert-success mb-4">
+            Form submitted successfully. If this email address is registered to an account, you will receive a password reset email.
+        </div>
+    @endif
+
     <h1>Forgot Password</h1>
 
     <p>Please enter the email address associated with your account. An email will be sent to this address to reset your password.</p>

--- a/resources/views/auth/passwords/forgot.blade.php
+++ b/resources/views/auth/passwords/forgot.blade.php
@@ -5,7 +5,7 @@
 @endsection
 
 @section('content')
-    @if(isset($status) || isset($errors))
+    @if (isset($status) || isset($errors))
         <div class="alert alert-success mb-4">
             Form submitted successfully. If this email address is registered to an account, you will receive a password reset email.
         </div>

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -19,7 +19,7 @@
             <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('E-Mail Address') }}</label>
 
             <div class="col-md-6">
-                <input id="email" type="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" name="email" value="{{ $email ?? old('email') }}" required autofocus>
+                <input id="email" type="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" name="email" value="{{ request()->email ?? old('email') }}" required autofocus>
 
                 @if ($errors->has('email'))
                     <span class="invalid-feedback" role="alert">

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -13,7 +13,7 @@
     <form method="POST" action="{{ route('password.update') }}">
         @csrf
 
-        <input type="hidden" name="token" value="{{ $token }}">
+        <input type="hidden" name="token" value="{{ request()->route('token') }}">
 
         <div class="form-group row">
             <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('E-Mail Address') }}</label>


### PR DESCRIPTION
As on the tin. Fixes an error getting the password reset token from the route and adds flash messages back to the password reset flow. Note that the one for _requesting_ a password reset is very deliberately obtuse for security reasons/so as not to directly confirm/deny whether or not a given email address exists in the system (and since tanking UX a little for this sake is an acceptable sacrifice; it's not liable to be a high-traffic area).