### PR TITLE
Prevent Horizontal Stretch on <main>

### DIFF
--- a/public/css/lorekeeper.css
+++ b/public/css/lorekeeper.css
@@ -84,6 +84,7 @@ body {
 main {
     flex-grow: 1;
     display: flex;
+    flex-direction: column;
 }
 
 main > .row {

--- a/public/css/lorekeeper.css
+++ b/public/css/lorekeeper.css
@@ -85,6 +85,7 @@ main {
     flex-grow: 1;
     display: flex;
     flex-direction: column;
+    word-wrap: break-word;
 }
 
 main > .row {


### PR DESCRIPTION
The flex direction limit will prevent blocks from stretching the main container since it's set to flex. This is only on #app right now but it should be on main as well.

As for break-word, I think Lorekeeper ships with name length limits, but this prevents cases where users add header blocks to their comments / descriptions / other stuff it'd be odd to impose a limit on. I understand removing that property but definitely recommend keeping flex-direction.