### PR TITLE
Bug(Reports): User's couldn't see comments of assigned tickets

### DIFF
--- a/resources/views/home/_report_content.blade.php
+++ b/resources/views/home/_report_content.blade.php
@@ -43,7 +43,7 @@
 <div class="card mb-3">
     <div class="card-body">{!! nl2br(htmlentities($report->comments)) !!}</div>
 </div>
-@if ((Auth::check() && $report->status == 'Assigned' && $report->user == Auth::user()) || Auth::user()->hasPower('manage_reports'))
+@if ((Auth::check() && $report->status == 'Assigned' && $report->user_id == Auth::user()->id) || Auth::user()->hasPower('manage_reports'))
     <div class="alert alert-danger">Admins will be alerted by new comments, however to keep the conversation organised we ask that you please reply to the admin comment.</div>
     @comments(['model' => $report, 'perPage' => 5])
 @elseif($report->status == 'Closed')


### PR DESCRIPTION
An incorrect comparison means that if a report ticket was assigned, a user couldn't see comments made by staff on the ticket - you can see even just a few lines down from the change where the same comparison was being done correctly.