### PR TITLE
fix(comments): add back comment type field

### DIFF
--- a/resources/views/comments/_form.blade.php
+++ b/resources/views/comments/_form.blade.php
@@ -1,6 +1,7 @@
 <div class="card mt-3">
     <div class="card-body">
         {!! Form::open(['url' => 'comments/make/' . base64_encode(urlencode(get_class($model))) . '/' . $model->getKey()]) !!}
+        <input type="hidden" name="type" value="{{ isset($type) ? $type : null }}" />
         <div class="form-group">
             {!! Form::label('message', 'Enter your message here:') !!}
             {!! Form::textarea('message', null, ['class' => 'form-control ' . (config('lorekeeper.settings.wysiwyg_comments') ? 'comment-wysiwyg' : ''), 'rows' => 5, config('lorekeeper.settings.wysiwyg_comments') ? '' : 'required']) !!}


### PR DESCRIPTION
As on the tin-- the field just got eaten in the big round of comment updates a while back. There's probably room for a more sophisticated implementation of this, but I figured it would probably be better to have it working at _all_ short-term.