### PR TITLE
Bug(Visual Trait Index): Hidden Traits were still showing when they shouldn't

### DIFF
--- a/app/Models/Feature/Feature.php
+++ b/app/Models/Feature/Feature.php
@@ -187,7 +187,7 @@ class Feature extends Model {
      * Scope a query to show only visible features.
      *
      * @param \Illuminate\Database\Eloquent\Builder $query
-     * @param bool                                  $withHidden
+     * @param mixed|null                            $user
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */

--- a/app/Models/Feature/Feature.php
+++ b/app/Models/Feature/Feature.php
@@ -191,8 +191,8 @@ class Feature extends Model {
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function scopeVisible($query, $withHidden = 0) {
-        if ($withHidden) {
+    public function scopeVisible($query, $user = null) {
+        if ($user && $user->hasPower('edit_data')) {
             return $query;
         }
 
@@ -297,14 +297,15 @@ class Feature extends Model {
     **********************************************************************************************/
 
     public static function getDropdownItems($withHidden = 0) {
+        $visibleOnly = 1;
+        if ($withHidden) {
+            $visibleOnly = 0;
+        }
+
         if (config('lorekeeper.extensions.organised_traits_dropdown')) {
-            $visibleOnly = 1;
-            if ($withHidden) {
-                $visibleOnly = 0;
-            }
             $sorted_feature_categories = collect(FeatureCategory::all()->where('is_visible', '>=', $visibleOnly)->sortBy('sort')->pluck('name')->toArray());
 
-            $grouped = self::visible($withHidden)->select('name', 'id', 'feature_category_id')->with('category')->orderBy('name')->get()->keyBy('id')->groupBy('category.name', $preserveKeys = true)->toArray();
+            $grouped = self::where('is_visible', '>=', $visibleOnly)->select('name', 'id', 'feature_category_id')->with('category')->orderBy('name')->get()->keyBy('id')->groupBy('category.name', $preserveKeys = true)->toArray();
             if (isset($grouped[''])) {
                 if (!$sorted_feature_categories->contains('Miscellaneous')) {
                     $sorted_feature_categories->push('Miscellaneous');
@@ -327,7 +328,7 @@ class Feature extends Model {
 
             return $features_by_category;
         } else {
-            return self::visible($withHidden)->orderBy('name')->pluck('name', 'id')->toArray();
+            return self::where('is_visible', '>=', $visibleOnly)->orderBy('name')->pluck('name', 'id')->toArray();
         }
     }
 }


### PR DESCRIPTION
Turns out Feature's scopeVisible function was a special snowflake compared to the others so having the same check sent through wasn't working right. This updates it to be the same, and also updates the `getDropdownItems` function since it was originally dependent on the different format.