### PR TITLE
Bug(Images): Old Fullsize images no longer detected

### DIFF
--- a/app/Models/Character/CharacterImage.php
+++ b/app/Models/Character/CharacterImage.php
@@ -209,7 +209,8 @@ class CharacterImage extends Model {
      * @return string
      */
     public function getFullsizeFileNameAttribute() {
-        return $this->id.'_'.$this->hash.'_'.$this->fullsize_hash.'_full.'.$this->fullsize_extension;
+        // Backwards compatibility pre v3
+        return $this->id . '_' . $this->hash . '_' . $this->fullsize_hash . '_full.' . ($this->fullsize_extension ?? $this->extension);
     }
 
     /**

--- a/app/Models/Character/CharacterImage.php
+++ b/app/Models/Character/CharacterImage.php
@@ -210,7 +210,7 @@ class CharacterImage extends Model {
      */
     public function getFullsizeFileNameAttribute() {
         // Backwards compatibility pre v3
-        return $this->id . '_' . $this->hash . '_' . $this->fullsize_hash . '_full.' . ($this->fullsize_extension ?? $this->extension);
+        return $this->id.'_'.$this->hash.'_'.$this->fullsize_hash.'_full.'.($this->fullsize_extension ?? $this->extension);
     }
 
     /**


### PR DESCRIPTION
Context: https://discord.com/channels/678909186683437056/1208583607506042992

Anyone on v2 with fullsize images who migrates to v3, wouldn't have the correct extensions in `fullsize_extension` but in `extension` so this makes it backwards compatible.