### PR TITLE
Bug(Registration): Alias registration page needs updated birthday input

### DIFF
--- a/resources/views/auth/register_with_driver.blade.php
+++ b/resources/views/auth/register_with_driver.blade.php
@@ -48,12 +48,7 @@
             <div class="form-group row">
                 {{ Form::label('dob', 'Date of Birth', ['class' => 'col-md-4 col-form-label text-md-right']) }}
                 <div class="col-md-6">
-                    <div class="col-md row">
-                        {{ Form::selectRange('dob[day]', 1, 31, null, ['class' => 'form-control col-2 mr-1']) }}
-                        {{ Form::selectMonth('dob[month]', null, ['class' => 'form-control col-2 mr-1']) }}
-                        {{ Form::selectYear('dob[year]', date('Y'), date('Y') - 70, null, ['class' => 'form-control col-2']) }}
-                    </div>
-
+                    {!! Form::date('dob', null, ['class' => 'form-control']) !!}
                 </div>
                 @if ($errors->has('dob'))
                     <span class="invalid-feedback" role="alert">


### PR DESCRIPTION
Alias registration on release was breaking because the registration page had updated to a different date input for the birthday and the driver registration page needed the same update.