### PR TITLE
feat(admin/features): Sorting traits in admin

### DIFF
--- a/app/Http/Controllers/Admin/Data/FeatureController.php
+++ b/app/Http/Controllers/Admin/Data/FeatureController.php
@@ -164,7 +164,7 @@ class FeatureController extends Controller {
      */
     public function getFeatureIndex(Request $request) {
         $query = Feature::query();
-        $data = $request->only(['rarity_id', 'feature_category_id', 'species_id', 'subtype_id', 'name']);
+        $data = $request->only(['rarity_id', 'feature_category_id', 'species_id', 'subtype_id', 'name', 'sort']);
         if (isset($data['rarity_id']) && $data['rarity_id'] != 'none') {
             $query->where('rarity_id', $data['rarity_id']);
         }
@@ -179,6 +179,40 @@ class FeatureController extends Controller {
         }
         if (isset($data['name'])) {
             $query->where('name', 'LIKE', '%'.$data['name'].'%');
+        }
+
+        if (isset($data['sort'])) {
+            switch ($data['sort']) {
+                case 'alpha':
+                    $query->sortAlphabetical();
+                    break;
+                case 'alpha-reverse':
+                    $query->sortAlphabetical(true);
+                    break;
+                case 'category':
+                    $query->sortCategory();
+                    break;
+                case 'rarity':
+                    $query->sortRarity();
+                    break;
+                case 'rarity-reverse':
+                    $query->sortRarity(true);
+                    break;
+                case 'species':
+                    $query->sortSpecies();
+                    break;
+                case 'subtypes':
+                    $query->sortSubtype();
+                    break;
+                case 'newest':
+                    $query->sortNewest();
+                    break;
+                case 'oldest':
+                    $query->sortOldest();
+                    break;
+            }
+        } else {
+            $query->sortOldest();
         }
 
         return view('admin.features.features', [

--- a/resources/views/admin/features/features.blade.php
+++ b/resources/views/admin/features/features.blade.php
@@ -17,24 +17,46 @@
     </div>
 
     <div>
-        {!! Form::open(['method' => 'GET', 'class' => 'form-inline justify-content-end']) !!}
-        <div class="form-group mr-3 mb-3">
-            {!! Form::text('name', Request::get('name'), ['class' => 'form-control', 'placeholder' => 'Name']) !!}
+        {!! Form::open(['method' => 'GET', 'class' => '']) !!}
+        <div class="form-inline justify-content-end">
+            <div class="form-group ml-3 mb-3">
+                {!! Form::text('name', Request::get('name'), ['class' => 'form-control', 'placeholder' => 'Name']) !!}
+            </div>
+            <div class="form-group ml-3 mb-3">
+                {!! Form::select('species_id', $specieses, Request::get('species_id'), ['class' => 'form-control']) !!}
+            </div>
+            <div class="form-group ml-3 mb-3">
+                {!! Form::select('subtype_id', $subtypes, Request::get('subtype_id'), ['class' => 'form-control']) !!}
+            </div>
+            <div class="form-group ml-3 mb-3">
+                {!! Form::select('rarity_id', $rarities, Request::get('rarity_id'), ['class' => 'form-control']) !!}
+            </div>
+            <div class="form-group ml-3 mb-3">
+                {!! Form::select('feature_category_id', $categories, Request::get('feature_category_id'), ['class' => 'form-control']) !!}
+            </div>
         </div>
-        <div class="form-group mr-3 mb-3">
-            {!! Form::select('species_id', $specieses, Request::get('species_id'), ['class' => 'form-control']) !!}
-        </div>
-        <div class="form-group mr-3 mb-3">
-            {!! Form::select('subtype_id', $subtypes, Request::get('subtype_id'), ['class' => 'form-control']) !!}
-        </div>
-        <div class="form-group mr-3 mb-3">
-            {!! Form::select('rarity_id', $rarities, Request::get('rarity_id'), ['class' => 'form-control']) !!}
-        </div>
-        <div class="form-group mr-3 mb-3">
-            {!! Form::select('feature_category_id', $categories, Request::get('feature_category_id'), ['class' => 'form-control']) !!}
-        </div>
-        <div class="form-group mb-3">
-            {!! Form::submit('Search', ['class' => 'btn btn-primary']) !!}
+        <div class="form-inline justify-content-end">
+            <div class="form-group ml-3 mb-3">
+                {!! Form::select(
+                    'sort',
+                    [
+                        'alpha' => 'Sort Alphabetically (A-Z)',
+                        'alpha-reverse' => 'Sort Alphabetically (Z-A)',
+                        'category' => 'Sort by Category',
+                        'rarity-reverse' => 'Sort by Rarity (Common to Rare)',
+                        'rarity' => 'Sort by Rarity (Rare to Common)',
+                        'species' => 'Sort by Species',
+                        'subtypes' => 'Sort by Subtype',
+                        'newest' => 'Newest First',
+                        'oldest' => 'Oldest First',
+                    ],
+                    Request::get('sort') ?: 'oldest',
+                    ['class' => 'form-control'],
+                ) !!}
+            </div>
+            <div class="form-group ml-3 mb-3">
+                {!! Form::submit('Search', ['class' => 'btn btn-primary']) !!}
+            </div>
         </div>
         {!! Form::close() !!}
     </div>


### PR DESCRIPTION
Adds a sorting function to the traits section in the Admin panel.
Fixes #347.

Minor layout edit to be consistent with the Encyclopedia version, as they're quite literally the same thing.

Sort's Oldest First by default, as per standards.