### PR TITLE
fix(titles): A lot of layout title fixes

### DIFF
--- a/resources/views/admin/characters/create_edit_character_category.blade.php
+++ b/resources/views/admin/characters/create_edit_character_category.blade.php
@@ -1,7 +1,7 @@
 @extends('admin.layout')
 
 @section('admin-title')
-    Character Categories
+    {{ $category->id ? 'Edit' : 'Create' }} Character Category
 @endsection
 
 @section('admin-content')
@@ -11,7 +11,7 @@
         ($category->id ? 'Edit' : 'Create') . ' Category' => $category->id ? 'admin/data/character-categories/edit/' . $category->id : 'admin/data/character-categories/create',
     ]) !!}
 
-    <h1>{{ $category->id ? 'Edit' : 'Create' }} Category
+    <h1>{{ $category->id ? 'Edit' : 'Create' }} Character Category
         @if ($category->id)
             <a href="#" class="btn btn-danger float-right delete-category-button">Delete Category</a>
         @endif

--- a/resources/views/admin/currencies/create_edit_currency.blade.php
+++ b/resources/views/admin/currencies/create_edit_currency.blade.php
@@ -1,7 +1,7 @@
 @extends('admin.layout')
 
 @section('admin-title')
-    Currencies
+    {{ $currency->id ? 'Edit' : 'Create' }} Currency
 @endsection
 
 @section('admin-content')

--- a/resources/views/admin/features/create_edit_feature.blade.php
+++ b/resources/views/admin/features/create_edit_feature.blade.php
@@ -1,7 +1,7 @@
 @extends('admin.layout')
 
 @section('admin-title')
-    Traits
+    {{ $feature->id ? 'Edit' : 'Create' }} Trait
 @endsection
 
 @section('admin-content')

--- a/resources/views/admin/features/create_edit_feature_category.blade.php
+++ b/resources/views/admin/features/create_edit_feature_category.blade.php
@@ -1,7 +1,7 @@
 @extends('admin.layout')
 
 @section('admin-title')
-    Trait Categories
+    {{ $category->id ? 'Edit' : 'Create' }} Trait Category
 @endsection
 
 @section('admin-content')
@@ -11,7 +11,7 @@
         ($category->id ? 'Edit' : 'Create') . ' Category' => $category->id ? 'admin/data/trait-categories/edit/' . $category->id : 'admin/data/trait-categories/create',
     ]) !!}
 
-    <h1>{{ $category->id ? 'Edit' : 'Create' }} Category
+    <h1>{{ $category->id ? 'Edit' : 'Create' }} Trait Category
         @if ($category->id)
             <a href="#" class="btn btn-danger float-right delete-category-button">Delete Category</a>
         @endif

--- a/resources/views/admin/galleries/create_edit_gallery.blade.php
+++ b/resources/views/admin/galleries/create_edit_gallery.blade.php
@@ -1,7 +1,7 @@
 @extends('admin.layout')
 
 @section('admin-title')
-    Galleries
+    {{ $gallery->id ? 'Edit' : 'Create' }} Gallery
 @endsection
 
 @section('admin-content')

--- a/resources/views/admin/items/create_edit_item.blade.php
+++ b/resources/views/admin/items/create_edit_item.blade.php
@@ -1,7 +1,7 @@
 @extends('admin.layout')
 
 @section('admin-title')
-    Items
+    {{ $item->id ? 'Edit' : 'Create' }} Item
 @endsection
 
 @section('admin-content')

--- a/resources/views/admin/items/create_edit_item_category.blade.php
+++ b/resources/views/admin/items/create_edit_item_category.blade.php
@@ -1,7 +1,7 @@
 @extends('admin.layout')
 
 @section('admin-title')
-    Item Categories
+    {{ $category->id ? 'Edit' : 'Create' }} Item Category
 @endsection
 
 @section('admin-content')
@@ -11,7 +11,7 @@
         ($category->id ? 'Edit' : 'Create') . ' Category' => $category->id ? 'admin/data/item-categories/edit/' . $category->id : 'admin/data/item-categories/create',
     ]) !!}
 
-    <h1>{{ $category->id ? 'Edit' : 'Create' }} Category
+    <h1>{{ $category->id ? 'Edit' : 'Create' }} Item Category
         @if ($category->id)
             <a href="#" class="btn btn-danger float-right delete-category-button">Delete Category</a>
         @endif

--- a/resources/views/admin/loot_tables/create_edit_loot_table.blade.php
+++ b/resources/views/admin/loot_tables/create_edit_loot_table.blade.php
@@ -1,7 +1,7 @@
 @extends('admin.layout')
 
 @section('admin-title')
-    Loot Tables
+    {{ $table->id ? 'Edit' : 'Create' }} Loot Table
 @endsection
 
 @section('admin-content')

--- a/resources/views/admin/news/create_edit_news.blade.php
+++ b/resources/views/admin/news/create_edit_news.blade.php
@@ -1,13 +1,13 @@
 @extends('admin.layout')
 
 @section('admin-title')
-    News
+    {{ $news->id ? 'Edit' : 'Create' }} News Post
 @endsection
 
 @section('admin-content')
     {!! breadcrumbs(['Admin Panel' => 'admin', 'News' => 'admin/news', ($news->id ? 'Edit' : 'Create') . ' Post' => $news->id ? 'admin/news/edit/' . $news->id : 'admin/news/create']) !!}
 
-    <h1>{{ $news->id ? 'Edit' : 'Create' }} Post
+    <h1>{{ $news->id ? 'Edit' : 'Create' }} News Post
         @if ($news->id)
             <a href="#" class="btn btn-danger float-right delete-news-button">Delete Post</a>
         @endif

--- a/resources/views/admin/pages/create_edit_page.blade.php
+++ b/resources/views/admin/pages/create_edit_page.blade.php
@@ -1,7 +1,7 @@
 @extends('admin.layout')
 
 @section('admin-title')
-    Pages
+    {{ $page->id ? 'Edit' : 'Create' }} Page
 @endsection
 
 @section('admin-content')

--- a/resources/views/admin/prompts/create_edit_prompt.blade.php
+++ b/resources/views/admin/prompts/create_edit_prompt.blade.php
@@ -1,7 +1,7 @@
 @extends('admin.layout')
 
 @section('admin-title')
-    Prompts
+    {{ $prompt->id ? 'Edit' : 'Create' }} Prompts
 @endsection
 
 @section('admin-content')

--- a/resources/views/admin/prompts/create_edit_prompt_category.blade.php
+++ b/resources/views/admin/prompts/create_edit_prompt_category.blade.php
@@ -1,7 +1,7 @@
 @extends('admin.layout')
 
 @section('admin-title')
-    Prompt Categories
+    {{ $category->id ? 'Edit' : 'Create' }} Prompt Category
 @endsection
 
 @section('admin-content')
@@ -11,7 +11,7 @@
         ($category->id ? 'Edit' : 'Create') . ' Category' => $category->id ? 'admin/data/prompt-categories/edit/' . $category->id : 'admin/data/prompt-categories/create',
     ]) !!}
 
-    <h1>{{ $category->id ? 'Edit' : 'Create' }} Category
+    <h1>{{ $category->id ? 'Edit' : 'Create' }} Prompt Category
         @if ($category->id)
             <a href="#" class="btn btn-danger float-right delete-category-button">Delete Category</a>
         @endif

--- a/resources/views/admin/rarities/create_edit_rarity.blade.php
+++ b/resources/views/admin/rarities/create_edit_rarity.blade.php
@@ -1,7 +1,7 @@
 @extends('admin.layout')
 
 @section('admin-title')
-    Rarities
+    {{ $rarity->id ? 'Edit' : 'Create' }} Rarity
 @endsection
 
 @section('admin-content')

--- a/resources/views/admin/sales/create_edit_sales.blade.php
+++ b/resources/views/admin/sales/create_edit_sales.blade.php
@@ -1,13 +1,13 @@
 @extends('admin.layout')
 
 @section('admin-title')
-    Sales
+    {{ $sales->id ? 'Edit' : 'Create' }} Sales Post
 @endsection
 
 @section('admin-content')
     {!! breadcrumbs(['Admin Panel' => 'admin', 'Sales' => 'admin/sales', ($sales->id ? 'Edit' : 'Create') . ' Post' => $sales->id ? 'admin/sales/edit/' . $sales->id : 'admin/sales/create']) !!}
 
-    <h1>{{ $sales->id ? 'Edit' : 'Create' }} Post
+    <h1>{{ $sales->id ? 'Edit' : 'Create' }} Sales Post
         @if ($sales->id)
             <a href="#" class="btn btn-danger float-right delete-sales-button">Delete Post</a>
         @endif

--- a/resources/views/admin/shops/create_edit_shop.blade.php
+++ b/resources/views/admin/shops/create_edit_shop.blade.php
@@ -1,7 +1,7 @@
 @extends('admin.layout')
 
 @section('admin-title')
-    Shops
+    {{ $shop->id ? 'Edit' : 'Create' }} Shop
 @endsection
 
 @section('admin-content')

--- a/resources/views/admin/specieses/create_edit_species.blade.php
+++ b/resources/views/admin/specieses/create_edit_species.blade.php
@@ -1,7 +1,7 @@
 @extends('admin.layout')
 
 @section('admin-title')
-    Species
+    {{ $species->id ? 'Edit' : 'Create' }} Species
 @endsection
 
 @section('admin-content')

--- a/resources/views/admin/specieses/create_edit_subtype.blade.php
+++ b/resources/views/admin/specieses/create_edit_subtype.blade.php
@@ -1,7 +1,7 @@
 @extends('admin.layout')
 
 @section('admin-title')
-    Species
+    {{ $subtype->id ? 'Edit' : 'Create' }} Subtype
 @endsection
 
 @section('admin-content')

--- a/resources/views/admin/specieses/subtypes.blade.php
+++ b/resources/views/admin/specieses/subtypes.blade.php
@@ -1,7 +1,7 @@
 @extends('admin.layout')
 
 @section('admin-title')
-    Species
+    Subtypes
 @endsection
 
 @section('admin-content')

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -1,6 +1,8 @@
 @extends('admin.layout')
 
-@section('admin-title') User Index @stop
+@section('admin-title')
+    User Index
+@endsection
 
 @section('admin-content')
     {!! breadcrumbs(['Admin Panel' => 'admin', 'User Index' => 'admin/users']) !!}

--- a/resources/views/admin/users/user.blade.php
+++ b/resources/views/admin/users/user.blade.php
@@ -1,6 +1,8 @@
 @extends('admin.layout')
 
-@section('admin-title') User Index @stop
+@section('admin-title')
+    User Index
+@endsection
 
 @section('admin-content')
     {!! breadcrumbs(['Admin Panel' => 'admin', 'User Index' => 'admin/users', $user->name => 'admin/users/' . $user->name . '/edit']) !!}

--- a/resources/views/admin/users/user_ban.blade.php
+++ b/resources/views/admin/users/user_ban.blade.php
@@ -1,6 +1,8 @@
 @extends('admin.layout')
 
-@section('admin-title') User: {{ $user->name }} @stop
+@section('admin-title')
+    User: {{ $user->name }}
+@endsection
 
 @section('admin-content')
     {!! breadcrumbs(['Admin Panel' => 'admin', 'User Index' => 'admin/users', $user->name => 'admin/users/' . $user->name . '/edit', 'Account Updates' => 'admin/users/' . $user->name . '/updates']) !!}

--- a/resources/views/admin/users/user_deactivate.blade.php
+++ b/resources/views/admin/users/user_deactivate.blade.php
@@ -1,6 +1,8 @@
 @extends('admin.layout')
 
-@section('admin-title') User: {{ $user->name }} @stop
+@section('admin-title')
+    User: {{ $user->name }}
+@endsection
 
 @section('admin-content')
     {!! breadcrumbs(['Admin Panel' => 'admin', 'User Index' => 'admin/users', $user->name => 'admin/users/' . $user->name . '/edit', 'Account Updates' => 'admin/users/' . $user->name . '/updates']) !!}

--- a/resources/views/admin/users/user_update_log.blade.php
+++ b/resources/views/admin/users/user_update_log.blade.php
@@ -1,6 +1,8 @@
 @extends('admin.layout')
 
-@section('admin-title') User: {{ $user->name }} @stop
+@section('admin-title')
+    User: {{ $user->name }}
+@endsection
 
 @section('admin-content')
     {!! breadcrumbs(['Admin Panel' => 'admin', 'User Index' => 'admin/users', $user->name => 'admin/users/' . $user->name . '/edit', 'Account Updates' => 'admin/users/' . $user->name . '/updates']) !!}

--- a/resources/views/character/design/addons.blade.php
+++ b/resources/views/character/design/addons.blade.php
@@ -1,11 +1,11 @@
 @extends('character.design.layout')
 
 @section('design-title')
-    Design Approval Request (#{{ $request->id }}) :: Comments
+    Request (#{{ $request->id }}) :: Add-ons
 @endsection
 
 @section('design-content')
-    {!! breadcrumbs(['Design Approvals' => 'designs', 'Request (#' . $request->id . ')' => 'designs/' . $request->id, 'Comments' => 'designs/' . $request->id . '/comments']) !!}
+    {!! breadcrumbs(['Design Approvals' => 'designs', 'Request (#' . $request->id . ')' => 'designs/' . $request->id, 'Add-ons' => 'designs/' . $request->id . '/addons']) !!}
 
     @include('character.design._header', ['request' => $request])
 

--- a/resources/views/character/design/comments.blade.php
+++ b/resources/views/character/design/comments.blade.php
@@ -1,7 +1,7 @@
 @extends('character.design.layout')
 
 @section('design-title')
-    Design Approval Request (#{{ $request->id }}) :: Comments
+    Request (#{{ $request->id }}) :: Comments
 @endsection
 
 @section('design-content')

--- a/resources/views/character/design/features.blade.php
+++ b/resources/views/character/design/features.blade.php
@@ -1,7 +1,7 @@
 @extends('character.design.layout')
 
 @section('design-title')
-    Design Approval Request (#{{ $request->id }}) :: Comments
+    Request (#{{ $request->id }}) :: Comments
 @endsection
 
 @section('design-content')

--- a/resources/views/character/design/features.blade.php
+++ b/resources/views/character/design/features.blade.php
@@ -1,7 +1,7 @@
 @extends('character.design.layout')
 
 @section('design-title')
-    Request (#{{ $request->id }}) :: Comments
+    Request (#{{ $request->id }}) :: Traits
 @endsection
 
 @section('design-content')

--- a/resources/views/character/design/image.blade.php
+++ b/resources/views/character/design/image.blade.php
@@ -1,7 +1,7 @@
 @extends('character.design.layout')
 
 @section('design-title')
-    Design Approval Request (#{{ $request->id }}) :: Image
+    Request (#{{ $request->id }}) :: Image
 @endsection
 
 @section('design-content')

--- a/resources/views/character/design/index.blade.php
+++ b/resources/views/character/design/index.blade.php
@@ -1,7 +1,7 @@
 @extends('character.design.layout')
 
 @section('design-title')
-    Design Approvals
+    Index
 @endsection
 
 @section('design-content')

--- a/resources/views/character/design/layout.blade.php
+++ b/resources/views/character/design/layout.blade.php
@@ -1,6 +1,7 @@
 @extends('layouts.app')
 
 @section('title')
+    Design Approvals ::
     @yield('design-title')
 @endsection
 

--- a/resources/views/character/design/request.blade.php
+++ b/resources/views/character/design/request.blade.php
@@ -1,7 +1,7 @@
 @extends('character.design.layout')
 
 @section('design-title')
-    Design Approval Request (#{{ $request->id }})
+    Request (#{{ $request->id }})
 @endsection
 
 @section('design-content')

--- a/resources/views/character/layout.blade.php
+++ b/resources/views/character/layout.blade.php
@@ -1,7 +1,8 @@
 @extends('layouts.app')
 
 @section('title')
-    Character ::@yield('profile-title')
+    Character ::
+    @yield('profile-title')
 @endsection
 
 @section('sidebar')

--- a/resources/views/prompts/index.blade.php
+++ b/resources/views/prompts/index.blade.php
@@ -1,7 +1,7 @@
 @extends('prompts.layout')
 
-@section('title')
-    Prompts
+@section('prompts-title')
+    Home
 @endsection
 
 @section('content')

--- a/resources/views/prompts/prompt.blade.php
+++ b/resources/views/prompts/prompt.blade.php
@@ -1,7 +1,7 @@
 @extends('prompts.layout')
 
 @section('title')
-    Prompts:: {{ $prompt->name }}
+    {{ $prompt->name }}
 @endsection
 
 @section('content')

--- a/resources/views/prompts/prompt_categories.blade.php
+++ b/resources/views/prompts/prompt_categories.blade.php
@@ -1,6 +1,6 @@
 @extends('prompts.layout')
 
-@section('title')
+@section('prompts-title')
     Prompt Categories
 @endsection
 

--- a/resources/views/prompts/prompts.blade.php
+++ b/resources/views/prompts/prompts.blade.php
@@ -1,6 +1,6 @@
 @extends('prompts.layout')
 
-@section('title')
+@section('prompts-title')
     All Prompts
 @endsection
 

--- a/resources/views/world/character_categories.blade.php
+++ b/resources/views/world/character_categories.blade.php
@@ -1,6 +1,6 @@
 @extends('world.layout')
 
-@section('title')
+@section('world-title')
     Character Categories
 @endsection
 

--- a/resources/views/world/currencies.blade.php
+++ b/resources/views/world/currencies.blade.php
@@ -1,6 +1,6 @@
 @extends('world.layout')
 
-@section('title')
+@section('world-title')
     Currencies
 @endsection
 

--- a/resources/views/world/feature_categories.blade.php
+++ b/resources/views/world/feature_categories.blade.php
@@ -1,6 +1,6 @@
 @extends('world.layout')
 
-@section('title')
+@section('world-title')
     Trait Categories
 @endsection
 

--- a/resources/views/world/features.blade.php
+++ b/resources/views/world/features.blade.php
@@ -1,6 +1,6 @@
 @extends('world.layout')
 
-@section('title')
+@section('world-title')
     Traits
 @endsection
 

--- a/resources/views/world/index.blade.php
+++ b/resources/views/world/index.blade.php
@@ -1,6 +1,6 @@
 @extends('world.layout')
 
-@section('title')
+@section('world-title')
     Home
 @endsection
 

--- a/resources/views/world/item_categories.blade.php
+++ b/resources/views/world/item_categories.blade.php
@@ -1,6 +1,6 @@
 @extends('world.layout')
 
-@section('title')
+@section('world-title')
     Item Categories
 @endsection
 

--- a/resources/views/world/item_page.blade.php
+++ b/resources/views/world/item_page.blade.php
@@ -1,6 +1,6 @@
 @extends('world.layout')
 
-@section('title')
+@section('world-title')
     {{ $item->name }}
 @endsection
 

--- a/resources/views/world/items.blade.php
+++ b/resources/views/world/items.blade.php
@@ -1,6 +1,6 @@
 @extends('world.layout')
 
-@section('title')
+@section('world-title')
     Items
 @endsection
 

--- a/resources/views/world/rarities.blade.php
+++ b/resources/views/world/rarities.blade.php
@@ -1,6 +1,6 @@
 @extends('world.layout')
 
-@section('title')
+@section('world-title')
     Rarities
 @endsection
 

--- a/resources/views/world/species_features.blade.php
+++ b/resources/views/world/species_features.blade.php
@@ -1,6 +1,6 @@
 @extends('world.layout')
 
-@section('title')
+@section('world-title')
     {{ $species->name }} Traits
 @endsection
 

--- a/resources/views/world/specieses.blade.php
+++ b/resources/views/world/specieses.blade.php
@@ -1,6 +1,6 @@
 @extends('world.layout')
 
-@section('title')
+@section('world-title')
     Species
 @endsection
 

--- a/resources/views/world/subtypes.blade.php
+++ b/resources/views/world/subtypes.blade.php
@@ -1,6 +1,6 @@
 @extends('world.layout')
 
-@section('title')
+@section('world-title')
     Subtypes
 @endsection
 


### PR DESCRIPTION
I present to you: A TON of title fixes, consistency edits and replacement of old `@stop` Laravel code.

Exceptions include:
- account/banned.blade.php (I figured when banned, the title Banned is straight forward, should not need Account in front)
- account/deactivated.blade.php (I figured when deactivated, the title Deactviated is straight forward, should not need Account in front)

As well as the following:
- admin/submissions/submission.blade.php
- home/submissions.blade.php
- home/bug_report_index.blade.php
- home/report.blade.php

Of which all require quite a bit more edits than just this, and will be done in a seperate PR.
