### PR TITLE
fix(many): @comments overwriting scripts section

### DIFF
--- a/resources/views/comments/comments.blade.php
+++ b/resources/views/comments/comments.blade.php
@@ -80,6 +80,7 @@
 @endauth
 
 @section('scripts')
+    @parent
     <script>
         $(document).ready(function() {
             tinymce.init({


### PR DESCRIPTION
This is not a problem in main, but only in release (and dev) because of the updated comments function.

Without this `@parent`, many pages which have an `@comments` tag will find their scripts function completely non-functional, as the scripts section in the comments page just.. overrides any other.

(For example: The admin side of handling reports, the Assign button did NOTHING.)