### PR TITLE
Deprecate laravelcollective/html forms

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "socialiteproviders/tumblr": "^4.1",
         "socialiteproviders/twitch": "^5.3",
         "spatie/laravel-feed": "^4.1",
-        "spatie/laravel-honeypot": "^4.1"
+        "spatie/laravel-honeypot": "^4.1",
+        "spatie/laravel-html": "^3.5"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ac16e377cc2e367f3e2c2d2e9a64634a",
+    "content-hash": "600614d9a8d933ab7520bec6c1c22baa",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -4898,6 +4898,84 @@
                 }
             ],
             "time": "2023-12-01T10:30:39+00:00"
+        },
+        {
+            "name": "spatie/laravel-html",
+            "version": "3.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-html.git",
+                "reference": "ead179a8b6802647027486049f5209bd23b610a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-html/zipball/ead179a8b6802647027486049f5209bd23b610a9",
+                "reference": "ead179a8b6802647027486049f5209bd23b610a9",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/http": "^9.0|^8.0|^10.0",
+                "illuminate/support": "^9.0|^8.0|^10.0",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.3",
+                "orchestra/testbench": "^7.0|^6.23|^8.0",
+                "pestphp/pest": "^1.22"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\Html\\HtmlServiceProvider"
+                    ],
+                    "aliases": {
+                        "Html": "Spatie\\Html\\Facades\\Html"
+                    }
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Spatie\\Html\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian De Deyne",
+                    "email": "sebastian@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A fluent html builder",
+            "homepage": "https://github.com/spatie/laravel-html",
+            "keywords": [
+                "html",
+                "spatie"
+            ],
+            "support": {
+                "source": "https://github.com/spatie/laravel-html/tree/3.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                }
+            ],
+            "time": "2024-02-20T15:17:00+00:00"
         },
         {
             "name": "spatie/laravel-package-tools",


### PR DESCRIPTION
The package [is abandoned](https://packagist.org/packages/laravelcollective/html) in favor of [spatie/laravel-html](https://github.com/spatie/laravel-html), and will need to be replaced likely before we update to Laravel 11.

However, as it stands we rely *heavily* on the `Form` utility provided by the former-- and this same is true of extensions, which largely follow the core project. `spatie/laravel-html`, meanwhile, uses [a considerably different syntax](https://spatie.be/docs/laravel-html/v2/introduction) for its HTML generation utilities; however, having migrated a few of my own projects to get a sense for how it works, the amount of effort involved, etc. I don't think it's going to be a functionality issue as much as just a lot of work. 

Still, sooner or later all of those forms and form fields are going to need to migrated to the new syntax. Conveniently, the packages seem to be able to coexist without issue, which is good because that migration is not going to happen overnight for the core project, let alone for extensions.

Consequently, it makes sense to deprecate use of the existing `Form` utility in favor of adopting and gradually migrating existing forms/form fields over to the new `html()` utilities. This is in the interests of eventually removing `laravelcollective/html` entirely, likely in v4 at the earliest (as that alone will constitute a breaking change). Ideally the migration process can happen during v3.x, as it would be good to be able to update Laravel at next convenience.