### PR TITLE
fix(world): Unhide hidden categories for appropriate staff on Universal Visual Index

### DIFF
--- a/resources/views/world/universal_features.blade.php
+++ b/resources/views/world/universal_features.blade.php
@@ -11,9 +11,12 @@
     <p>This is a visual index of all universal traits. Click a trait to view more info on it!</p>
 
     @foreach ($features as $categoryId => $categoryFeatures)
-        @if (!isset($categories[$categoryId]) || $categories[$categoryId]->is_visible)
+        @if (!isset($categories[$categoryId]) || (Auth::check() && Auth::user()->hasPower('edit_data')) || $categories[$categoryId]->is_visible)
             <div class="card mb-3 inventory-category">
                 <h5 class="card-header inventory-header">
+                    @if (isset($categories[$categoryId]) && !$categories[$categoryId]->is_visible)
+                        <i class="fas fa-eye-slash mr-1"></i>
+                    @endif
                     {!! isset($categories[$categoryId]) ? '<a href="' . $categories[$categoryId]->searchUrl . '">' . $categories[$categoryId]->name . '</a>' : 'Miscellaneous' !!}
                 </h5>
                 <div class="card-body inventory-body">


### PR DESCRIPTION
This fixes a minor issue where hidden categories would not show up on the Species Visual Index for staff that do have the permission.. of course with appropriate fa-eye-slash marker. :)

I'd have liked to do this differently, like taking the permission from the model, but this seems to be the only way possible.

Though I distinctly count as a bug fix, as this should've been available from the get-go, the Universal Visual Index is a feature that's only on develop, and so this PR goes to develop.