### PR TITLE
Bug(Admin): New Powers didn't give sidebar access

### DIFF
--- a/config/lorekeeper/admin_sidebar.php
+++ b/config/lorekeeper/admin_sidebar.php
@@ -40,17 +40,27 @@ return [
             ],
         ],
     ],
-    'Site'       => [
-        'power' => 'edit_pages',
+    'News' => [
+        'power' => 'manage_news',
         'links' => [
             [
                 'name' => 'News',
-                'url'  => 'admin/news',
+                'url' => 'admin/news'
             ],
+        ]
+    ],
+    'Sales' => [
+        'power' => 'manage_sales',
+        'links' => [
             [
                 'name' => 'Sales',
-                'url'  => 'admin/sales',
+                'url' => 'admin/sales'
             ],
+        ]
+    ],
+    'Pages'       => [
+        'power' => 'edit_pages',
+        'links' => [
             [
                 'name' => 'Pages',
                 'url'  => 'admin/pages',


### PR DESCRIPTION
Was looking at this feature and realized that the admin sidebar links hadn't been exposed for the relevant powers. 