### PR TITLE
fix(admin):consistency fix

### DIFF
--- a/resources/views/admin/items/items.blade.php
+++ b/resources/views/admin/items/items.blade.php
@@ -38,6 +38,18 @@
         <div class="form-inline justify-content-end">
             <div class="form-group ml-3 mb-3">
                 {!! Form::select(
+                    'visibility',
+                    [
+                        'none' => 'Any Visibility',
+                        'visibleOnly' => 'Released Only',
+                        'hiddenOnly' => 'Hidden Only',
+                    ],
+                    Request::get('visibility') ?: 'none',
+                    ['class' => 'form-control'],
+                ) !!}
+            </div>
+            <div class="form-group ml-3 mb-3">
+                {!! Form::select(
                     'sort',
                     [
                         'alpha' => 'Sort Alphabetically (A-Z)',
@@ -47,18 +59,6 @@
                         'oldest' => 'Oldest First',
                     ],
                     Request::get('sort') ?: 'oldest',
-                    ['class' => 'form-control'],
-                ) !!}
-            </div>
-            <div class="form-group ml-3 mb-3">
-                {!! Form::select(
-                    'visibility',
-                    [
-                        'none' => 'Any Visibility',
-                        'visibleOnly' => 'Released Only',
-                        'hiddenOnly' => 'Hidden Only',
-                    ],
-                    Request::get('visibility') ?: 'none',
                     ['class' => 'form-control'],
                 ) !!}
             </div>


### PR DESCRIPTION
...Visibility was always meant to go in front of sort, as to not mess up the original order, and to be consistent otherwise.

Yet here I completely messed that up. My bad. Did not notice until JUST NOW.

(Worst part is that I did it right on the site I admin, but copied it wrong on my dev X_x;..)