### PR TITLE
fix(claims): userGallerySubmissions 500'd claims

### DIFF
--- a/app/Http/Controllers/Users/SubmissionController.php
+++ b/app/Http/Controllers/Users/SubmissionController.php
@@ -406,6 +406,7 @@ class SubmissionController extends Controller {
             'raffles'             => Raffle::where('rolled_at', null)->where('is_active', 1)->orderBy('name')->pluck('name', 'id'),
             'page'                => 'submission',
             'expanded_rewards'    => config('lorekeeper.extensions.character_reward_expansion.expanded'),
+            'userGallerySubmissions' => [],
         ]));
     }
 
@@ -440,6 +441,7 @@ class SubmissionController extends Controller {
             'page'                  => 'submission',
             'expanded_rewards'      => config('lorekeeper.extensions.character_reward_expansion.expanded'),
             'selectedInventory'     => isset($submission->data['user']) ? parseAssetData($submission->data['user']) : null,
+            'userGallerySubmissions' => [],
         ]));
     }
 


### PR DESCRIPTION
It checks for `$userGallerySubmissions` on both editing and creating submissions and claims.

The SubmissionController handles this perfectly for submissions- for claims, not as much.

Figured this would be the easiest solution.