### PR TITLE
fixing gallery queue url in notif

### DIFF
--- a/config/lorekeeper/notifications.php
+++ b/config/lorekeeper/notifications.php
@@ -386,7 +386,7 @@ return [
     508 => [
         'name'    => 'Gallery Submission Rejected',
         'message' => 'Your submission <strong>{submission_title}</strong> (#{submission_id}) was rejected. (<a href="{url}">View Submission</a>)',
-        'url'     => 'submissions/queue/{submission_id}',
+        'url'     => 'gallery/queue/{submission_id}',
     ],
 
     // GALLERY_SUBMISSION_VALUED


### PR DESCRIPTION
'Gallery Submission Rejected' notification was using the wrong url, causing a 404 error when clicked