### PR TITLE
Bug(Character): Hidden characters not showing for admin

### DIFF
--- a/app/Models/Character/Character.php
+++ b/app/Models/Character/Character.php
@@ -216,7 +216,11 @@ class Character extends Model {
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function scopeVisible($query) {
+    public function scopeVisible($query, $user = null) {
+        if ($user && $user->hasPower('manage_characters')) {
+            return $query;
+        }
+        
         return $query->where('is_visible', 1);
     }
 

--- a/app/Models/Character/Character.php
+++ b/app/Models/Character/Character.php
@@ -213,6 +213,7 @@ class Character extends Model {
      * Scope a query to only include visible characters.
      *
      * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param mixed|null                            $user
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */
@@ -220,7 +221,7 @@ class Character extends Model {
         if ($user && $user->hasPower('manage_characters')) {
             return $query;
         }
-        
+
         return $query->where('is_visible', 1);
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "lorekeeper",
+    "name": "lorekeeper-extensions",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {


### PR DESCRIPTION
Fixes case found in the discord where if you create a Sale you can't see hidden characters despite having the appropriate permissions as an admin.