### PR TITLE
feat: Add ability for users to cancel their own design requests

### DIFF
--- a/app/Http/Controllers/Characters/DesignController.php
+++ b/app/Http/Controllers/Characters/DesignController.php
@@ -52,8 +52,8 @@ class DesignController extends Controller {
         }
 
         return view('character.design.request', [
-            'request' => $r,
-            'canCancel' => config('lorekeeper.extensions.design_return_to_draft')
+            'request'   => $r,
+            'canCancel' => config('lorekeeper.extensions.design_return_to_draft'),
         ]);
     }
 

--- a/app/Http/Controllers/Characters/DesignController.php
+++ b/app/Http/Controllers/Characters/DesignController.php
@@ -53,7 +53,7 @@ class DesignController extends Controller {
 
         return view('character.design.request', [
             'request'   => $r,
-            'canCancel' => config('lorekeeper.extensions.design_return_to_draft'),
+            'canCancel' => config('lorekeeper.extensions.design_return_to_draft') ?? 0,
         ]);
     }
 

--- a/app/Http/Controllers/Characters/DesignController.php
+++ b/app/Http/Controllers/Characters/DesignController.php
@@ -53,6 +53,7 @@ class DesignController extends Controller {
 
         return view('character.design.request', [
             'request' => $r,
+            'canCancel' => config('lorekeeper.extensions.design_return_to_draft')
         ]);
     }
 
@@ -362,5 +363,51 @@ class DesignController extends Controller {
         }
 
         return redirect()->to('designs');
+    }
+
+    /**
+     * Shows the design update request cancellation confirmation modal for a user.
+     *
+     * @param int $id
+     *
+     * @return \Illuminate\Contracts\Support\Renderable
+     */
+    public function getCancel($id) {
+        $r = CharacterDesignUpdate::find($id);
+        if (!$r || ($r->user_id != Auth::user()->id && !Auth::user()->hasPower('manage_characters'))) {
+            abort(404);
+        }
+
+        return view('character.design._cancel_modal', [
+            'request' => $r,
+        ]);
+    }
+
+    /**
+     * Cancels a design update request and returns it to drafts.
+     *
+     * @param App\Services\DesignUpdateManager $service
+     * @param int                              $id
+     *
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function postCancel(DesignUpdateManager $service, $id) {
+        $r = CharacterDesignUpdate::find($id);
+        if (!$r) {
+            abort(404);
+        }
+        if ($r->user_id != Auth::user()->id) {
+            abort(404);
+        }
+
+        if ($service->cancelRequest(null, $r, Auth::user(), true)) {
+            flash('Request canceled successfully.')->success();
+        } else {
+            foreach ($service->errors()->getMessages()['error'] as $error) {
+                flash($error)->error();
+            }
+        }
+
+        return redirect()->back();
     }
 }

--- a/app/Services/DesignUpdateManager.php
+++ b/app/Services/DesignUpdateManager.php
@@ -799,7 +799,7 @@ class DesignUpdateManager extends Service {
      * @param array                 $data
      * @param CharacterDesignUpdate $request
      * @param User                  $user
-     * @param boolean               $self
+     * @param bool                  $self
      *
      * @return bool
      */

--- a/app/Services/DesignUpdateManager.php
+++ b/app/Services/DesignUpdateManager.php
@@ -799,11 +799,11 @@ class DesignUpdateManager extends Service {
      * @param array                 $data
      * @param CharacterDesignUpdate $request
      * @param User                  $user
-     * @param mixed|null            $self
+     * @param boolean               $self
      *
      * @return bool
      */
-    public function cancelRequest($data, $request, $user, $self = null) {
+    public function cancelRequest($data, $request, $user, $self = 0) {
         DB::beginTransaction();
 
         try {
@@ -820,7 +820,7 @@ class DesignUpdateManager extends Service {
             // to add a comment to it. Status is returned to Draft status.
             // Use when rejecting a request that just requires minor modifications to approve.
 
-            if ($self == null) {
+            if (!$self) {
                 // Set staff comment if this is not a self-cancel
                 $request->staff_id = $user->id;
                 $request->staff_comments = $data['staff_comments'] ?? null;
@@ -835,7 +835,7 @@ class DesignUpdateManager extends Service {
             $request->status = 'Draft';
             $request->save();
 
-            if ($self == null) {
+            if (!$self) {
                 // Notify the user if it is not being canceled by the user themself.
                 // Note that an admin canceling their own will also not result in a notification
                 Notifications::create('DESIGN_CANCELED', $request->user, [

--- a/app/Services/DesignUpdateManager.php
+++ b/app/Services/DesignUpdateManager.php
@@ -799,6 +799,7 @@ class DesignUpdateManager extends Service {
      * @param array                 $data
      * @param CharacterDesignUpdate $request
      * @param User                  $user
+     * @param mixed|null            $self
      *
      * @return bool
      */
@@ -819,20 +820,22 @@ class DesignUpdateManager extends Service {
             // to add a comment to it. Status is returned to Draft status.
             // Use when rejecting a request that just requires minor modifications to approve.
 
-            if($self == null){
+            if ($self == null) {
                 // Set staff comment if this is not a self-cancel
                 $request->staff_id = $user->id;
                 $request->staff_comments = $data['staff_comments'] ?? null;
                 if (!isset($data['preserve_queue'])) {
                     $request->submitted_at = null;
                 }
-            } else $request->submitted_at = null;
+            } else {
+                $request->submitted_at = null;
+            }
 
             // Set status
             $request->status = 'Draft';
             $request->save();
 
-            if($self == null){
+            if ($self == null) {
                 // Notify the user if it is not being canceled by the user themself.
                 // Note that an admin canceling their own will also not result in a notification
                 Notifications::create('DESIGN_CANCELED', $request->user, [

--- a/app/Services/DesignUpdateManager.php
+++ b/app/Services/DesignUpdateManager.php
@@ -802,7 +802,7 @@ class DesignUpdateManager extends Service {
      *
      * @return bool
      */
-    public function cancelRequest($data, $request, $user) {
+    public function cancelRequest($data, $request, $user, $self = null) {
         DB::beginTransaction();
 
         try {
@@ -819,21 +819,28 @@ class DesignUpdateManager extends Service {
             // to add a comment to it. Status is returned to Draft status.
             // Use when rejecting a request that just requires minor modifications to approve.
 
-            // Set staff comment and status
-            $request->staff_id = $user->id;
-            $request->staff_comments = $data['staff_comments'] ?? null;
+            if($self == null){
+                // Set staff comment if this is not a self-cancel
+                $request->staff_id = $user->id;
+                $request->staff_comments = $data['staff_comments'] ?? null;
+                if (!isset($data['preserve_queue'])) {
+                    $request->submitted_at = null;
+                }
+            } else $request->submitted_at = null;
+
+            // Set status
             $request->status = 'Draft';
-            if (!isset($data['preserve_queue'])) {
-                $request->submitted_at = null;
-            }
             $request->save();
 
-            // Notify the user
-            Notifications::create('DESIGN_CANCELED', $request->user, [
-                'design_url'    => $request->url,
-                'character_url' => $request->character->url,
-                'name'          => $request->character->fullName,
-            ]);
+            if($self == null){
+                // Notify the user if it is not being canceled by the user themself.
+                // Note that an admin canceling their own will also not result in a notification
+                Notifications::create('DESIGN_CANCELED', $request->user, [
+                    'design_url'    => $request->url,
+                    'character_url' => $request->character->url,
+                    'name'          => $request->character->fullName,
+                ]);
+            }
 
             return $this->commitReturn(true);
         } catch (\Exception $e) {

--- a/config/lorekeeper/extensions.php
+++ b/config/lorekeeper/extensions.php
@@ -116,4 +116,7 @@ return [
     // Show Small Badges on the User's Characters/MYO Slots Page
     // Indicating Trading Status (and Gift Art & Gift Writing Status)
     'badges_on_user_character_page' => 0,
+
+    // Allow users to return a pending design update to drafts, for instance if they make a mistake. - Uri
+    'design_return_to_draft' => 1,
 ];

--- a/resources/views/character/design/_cancel_modal.blade.php
+++ b/resources/views/character/design/_cancel_modal.blade.php
@@ -1,6 +1,9 @@
 @if ($request->user_id == Auth::user()->id)
     <p>This will cancel the pending design approval request and will send it back to your drafts. <br>
         You will need to resubmit in order for it to be in the queue again.</p>
+    <p>
+        Note that you will lose your place in the queue if you do this.
+    </p>
     <p>Are you sure you want to cancel this request?</p>
     {!! Form::open(['url' => 'designs/' . $request->id . '/cancel', 'class' => 'text-right']) !!}
     {!! Form::submit('Cancel Request', ['class' => 'btn btn-primary']) !!}

--- a/resources/views/character/design/_cancel_modal.blade.php
+++ b/resources/views/character/design/_cancel_modal.blade.php
@@ -1,0 +1,9 @@
+@if ($request->user_id == Auth::user()->id)
+    <p>This will cancel the pending design approval request and will send it back to your drafts. <br>
+        You will need to resubmit in order for it to be in the queue again.</p>
+    <p>Are you sure you want to cancel this request?</p>
+    {!! Form::open(['url' => 'designs/' . $request->id . '/cancel', 'class' => 'text-right']) !!}
+    {!! Form::submit('Cancel Request', ['class' => 'btn btn-primary']) !!}
+@else
+    <div>You cannot cancel this request.</div>
+@endif

--- a/resources/views/character/design/request.blade.php
+++ b/resources/views/character/design/request.blade.php
@@ -37,7 +37,7 @@
             This request is in the approval queue.
             @if (!Auth::user()->hasPower('manage_characters'))
                 Please wait for it to be processed{{ isset($canCancel) && $canCancel ? ' or cancel it below.' : '.' }}
-                @if(isset($canCancel) && $canCancel)
+                @if (isset($canCancel) && $canCancel)
                     <div class="card mb-3">
                         <div class="card-body">
                             <a href="#" class="btn btn-outline-secondary cancel-button btn-sm float-right" data-action="cancel">Cancel</a>

--- a/resources/views/character/design/request.blade.php
+++ b/resources/views/character/design/request.blade.php
@@ -36,7 +36,15 @@
         <p>
             This request is in the approval queue.
             @if (!Auth::user()->hasPower('manage_characters'))
-                Please wait for it to be processed.
+                Please wait for it to be processed{{ isset($canCancel) && $canCancel ? ' or cancel it below.' : '.' }}
+                @if(isset($canCancel) && $canCancel)
+                    <div class="card mb-3">
+                        <div class="card-body">
+                            <a href="#" class="btn btn-outline-secondary cancel-button btn-sm float-right" data-action="cancel">Cancel</a>
+                            <strong class="text-secondary">Cancelling</strong> the request returns it to its draft status, allowing you to make further edits.
+                        </div>
+                    </div>
+                @endif
             @else
                 As a staff member with the ability to edit the masterlist, you can view the details of the request, but can only edit certain parts of it.
             @endif
@@ -78,6 +86,13 @@
                 $('.delete-button').on('click', function(e) {
                     e.preventDefault();
                     loadModal("{{ url('designs/' . $request->id . '/delete/') }}", 'Delete Submission');
+                });
+            @endif
+
+            @if ($request->user_id == Auth::user()->id && $request->status == 'Pending' && isset($canCancel) && $canCancel)
+                $('.cancel-button').on('click', function(e) {
+                    e.preventDefault();
+                    loadModal("{{ url('designs/' . $request->id . '/cancel/') }}", 'Cancel Submission');
                 });
             @endif
 

--- a/resources/views/character/design/request.blade.php
+++ b/resources/views/character/design/request.blade.php
@@ -36,8 +36,8 @@
         <p>
             This request is in the approval queue.
             @if (!Auth::user()->hasPower('manage_characters'))
-                Please wait for it to be processed{{ isset($canCancel) && $canCancel ? ' or cancel it below.' : '.' }}
-                @if (isset($canCancel) && $canCancel)
+                Please wait for it to be processed{{ $canCancel ? ' or cancel it below.' : '.' }}
+                @if ($canCancel)
                     <div class="card mb-3">
                         <div class="card-body">
                             <a href="#" class="btn btn-outline-secondary cancel-button btn-sm float-right" data-action="cancel">Cancel</a>
@@ -89,7 +89,7 @@
                 });
             @endif
 
-            @if ($request->user_id == Auth::user()->id && $request->status == 'Pending' && isset($canCancel) && $canCancel)
+            @if ($request->user_id == Auth::user()->id && $request->status == 'Pending' && $canCancel)
                 $('.cancel-button').on('click', function(e) {
                     e.preventDefault();
                     loadModal("{{ url('designs/' . $request->id . '/cancel/') }}", 'Cancel Submission');

--- a/routes/lorekeeper/members.php
+++ b/routes/lorekeeper/members.php
@@ -205,6 +205,9 @@ Route::group(['prefix' => 'designs', 'namespace' => 'Characters'], function () {
 
     Route::get('{id}/delete', 'DesignController@getDelete');
     Route::post('{id}/delete', 'DesignController@postDelete');
+
+    Route::get('{id}/cancel', 'DesignController@getCancel');
+    Route::post('{id}/cancel', 'DesignController@postCancel');
 });
 
 /**************************************************************************************************


### PR DESCRIPTION
Adds the ability for users to cancel their own design requests. Optional by way of config. By default it is set to ON.