### PR TITLE
Remove duplicate edit-credits in js

### DIFF
--- a/resources/views/character/_image_js.blade.php
+++ b/resources/views/character/_image_js.blade.php
@@ -32,10 +32,6 @@
             e.preventDefault();
             loadModal("{{ url('admin/character/image') }}/" + $(this).data('id') + "/credits", 'Edit Image Credits');
         });
-        $('.edit-credits').on('click', function(e) {
-            e.preventDefault();
-            loadModal("{{ url('admin/character/image') }}/" + $(this).data('id') + "/credits", 'Edit Image Credits');
-        });
         $('.reupload-image').on('click', function(e) {
             e.preventDefault();
             loadModal("{{ url('admin/character/image') }}/" + $(this).data('id') + "/reupload", 'Reupload Image');


### PR DESCRIPTION
I noticed on my host when editing the credits of a character, the selectize would sometimes act freaky and appear empty/non functional. After digging for a while, I realized that the edit credits modal request gets sent twice. I think the reason is the event listener being duplicated. After removing it, the issue was resolved on my host - no more empty select and double requests.

(I checked the wiki on how to get small fixes in, so I hope I did it right! Sorry if not orz)