### PR TITLE
Fix: Character Image Size Validation

### DIFF
--- a/app/Http/Controllers/Admin/Characters/CharacterImageController.php
+++ b/app/Http/Controllers/Admin/Characters/CharacterImageController.php
@@ -249,6 +249,7 @@ class CharacterImageController extends Controller {
      * @return \Illuminate\Http\RedirectResponse
      */
     public function postImageReupload(Request $request, CharacterManager $service, $id) {
+        $request->validate(['image' => CharacterImage::$createRules['image'], 'thumbnail' => CharacterImage::$createRules['thumbnail']]);
         $data = $request->only(['image', 'thumbnail', 'x0', 'x1', 'y0', 'y1', 'use_cropper']);
         $image = CharacterImage::find($id);
         if (!$image) {

--- a/app/Models/Character/Character.php
+++ b/app/Models/Character/Character.php
@@ -78,8 +78,8 @@ class Character extends Model {
         'slug'                  => 'required|alpha_dash',
         'description'           => 'nullable',
         'sale_value'            => 'nullable',
-        'image'                 => 'required|mimes:jpeg,jpg,gif,png|max:20000',
-        'thumbnail'             => 'nullable|mimes:jpeg,jpg,gif,png|max:20000',
+        'image'                 => 'required|mimes:jpeg,jpg,gif,png|max:2048',
+        'thumbnail'             => 'nullable|mimes:jpeg,jpg,gif,png|max:2048',
         'owner_url'             => 'url|nullable',
     ];
 
@@ -109,8 +109,8 @@ class Character extends Model {
         'description' => 'nullable',
         'sale_value'  => 'nullable',
         'name'        => 'required',
-        'image'       => 'nullable|mimes:jpeg,gif,png|max:20000',
-        'thumbnail'   => 'nullable|mimes:jpeg,gif,png|max:20000',
+        'image'       => 'nullable|mimes:jpeg,gif,png|max:2048',
+        'thumbnail'   => 'nullable|mimes:jpeg,gif,png|max:2048',
     ];
 
     /**********************************************************************************************

--- a/app/Models/Character/Character.php
+++ b/app/Models/Character/Character.php
@@ -111,8 +111,8 @@ class Character extends Model {
         'description' => 'nullable',
         'sale_value'  => 'nullable',
         'name'        => 'required',
-        'image'       => 'nullable|mimes:jpeg,gif,png|max:2048',
-        'thumbnail'   => 'nullable|mimes:jpeg,gif,png|max:2048',
+        'image'       => 'nullable|mimes:jpeg,gif,png|max:2mb',
+        'thumbnail'   => 'nullable|mimes:jpeg,gif,png|max:2mb',
     ];
 
     /**********************************************************************************************

--- a/app/Models/Character/Character.php
+++ b/app/Models/Character/Character.php
@@ -78,8 +78,8 @@ class Character extends Model {
         'slug'                  => 'required|alpha_dash',
         'description'           => 'nullable',
         'sale_value'            => 'nullable',
-        'image'                 => 'required|mimes:jpeg,jpg,gif,png|max:2048',
-        'thumbnail'             => 'nullable|mimes:jpeg,jpg,gif,png|max:2048',
+        'image'                 => 'required|mimes:jpeg,jpg,gif,png|max:2mb',
+        'thumbnail'             => 'nullable|mimes:jpeg,jpg,gif,png|max:2mb',
         'owner_url'             => 'url|nullable',
     ];
 
@@ -94,6 +94,8 @@ class Character extends Model {
         'slug'                  => 'required',
         'description'           => 'nullable',
         'sale_value'            => 'nullable',
+        'image'                 => 'nullable|mimes:jpeg,jpg,gif,png|max:2mb',
+        'thumbnail'             => 'nullable|mimes:jpeg,jpg,gif,png|max:2mb',
     ];
 
     /**

--- a/app/Models/Character/CharacterImage.php
+++ b/app/Models/Character/CharacterImage.php
@@ -47,8 +47,8 @@ class CharacterImage extends Model {
     public static $createRules = [
         'species_id' => 'required',
         'rarity_id'  => 'required',
-        'image'      => 'required|mimes:jpeg,jpg,gif,png,webp|max:2048',
-        'thumbnail'  => 'nullable|mimes:jpeg,jpg,gif,png,webp|max:2048',
+        'image'      => 'required|mimes:jpeg,jpg,gif,png,webp|max:2mb',
+        'thumbnail'  => 'nullable|mimes:jpeg,jpg,gif,png,webp|max:2mb',
     ];
 
     /**
@@ -62,6 +62,8 @@ class CharacterImage extends Model {
         'species_id'   => 'required',
         'rarity_id'    => 'required',
         'description'  => 'nullable',
+        'image'        => 'mimes:jpeg,jpg,gif,png,webp|max:2mb',
+        'thumbnail'    => 'nullable|mimes:jpeg,jpg,gif,png,webp|max:2mb',
     ];
 
     /**********************************************************************************************

--- a/app/Models/Character/CharacterImage.php
+++ b/app/Models/Character/CharacterImage.php
@@ -47,8 +47,8 @@ class CharacterImage extends Model {
     public static $createRules = [
         'species_id' => 'required',
         'rarity_id'  => 'required',
-        'image'      => 'required|mimes:jpeg,jpg,gif,png,webp|max:20000',
-        'thumbnail'  => 'nullable|mimes:jpeg,jpg,gif,png,webp|max:20000',
+        'image'      => 'required|mimes:jpeg,jpg,gif,png,webp|max:2048',
+        'thumbnail'  => 'nullable|mimes:jpeg,jpg,gif,png,webp|max:2048',
     ];
 
     /**
@@ -225,7 +225,7 @@ class CharacterImage extends Model {
     /**
      * Gets the file name of the model's fullsize image.
      *
-     * @param  user
+     * @param  User
      * @param mixed|null $user
      *
      * @return string


### PR DESCRIPTION
[currently the size validation is incorrectly set to 20mb ish instead of 2mb](https://laravel.com/docs/11.x/validation#validating-files:~:text=(1024)-,%2D%3Emax(12%20*%201024)%2C,-%5D%2C)
also added validation on admin reuploads
the necessity of the validation can be debated, my thought process is if an admin tries to reupload a large image and brings down their PHP process, it can cause a lot of delays unless there is an active coder around to reboot etc