### PR TITLE
Fix: Remove old fa-close line from character selection

### DIFF
--- a/resources/views/admin/sales/_character_select.blade.php
+++ b/resources/views/admin/sales/_character_select.blade.php
@@ -19,7 +19,6 @@
                     </div>
                 </div>
                 <div class="col-md-10">
-                    <a href="#" class="float-right fas fa-close"></a>
                     <div class="form-group">
                         {!! Form::label('slug', 'Character Code') !!}
                         {!! Form::select('slug[]', $characters, null, ['class' => 'form-control character-code', 'placeholder' => 'Select Character', 'placeholder' => 'Select Character']) !!}

--- a/resources/views/admin/sales/_character_select_entry.blade.php
+++ b/resources/views/admin/sales/_character_select_entry.blade.php
@@ -21,7 +21,6 @@
                 </div>
             </div>
             <div class="col-md-10">
-                <a href="#" class="float-right fas fa-close"></a>
                 <div class="form-group">
                     {!! Form::label('slug[]', 'Character Code') !!}
                     {!! Form::select('slug[]', $characters, $character->character->slug, ['class' => 'form-control character-code', 'placeholder' => 'Select Character']) !!}

--- a/resources/views/admin/submissions/submission.blade.php
+++ b/resources/views/admin/submissions/submission.blade.php
@@ -170,7 +170,6 @@
                             </div>
                         </div>
                         <div class="col-md-10">
-                            <a href="#" class="float-right fas fa-close"></a>
                             <div class="form-group">
                                 {!! Form::label('slug', 'Character Code') !!}
                                 {!! Form::select('slug[]', $characters, null, ['class' => 'form-control character-code', 'placeholder' => 'Select Character']) !!}

--- a/resources/views/galleries/_character_select.blade.php
+++ b/resources/views/galleries/_character_select.blade.php
@@ -17,7 +17,6 @@
                 </div>
             </div>
             <div class="col-md-7">
-                <a href="#" class="float-right fas fa-close"></a>
                 <div class="form-group">
                     {!! Form::select('slug[]', $characters, null, ['class' => 'form-control character-code', 'placeholder' => 'Character Code (EX-001, for example)']) !!}
                 </div>

--- a/resources/views/galleries/_character_select_entry.blade.php
+++ b/resources/views/galleries/_character_select_entry.blade.php
@@ -18,7 +18,6 @@
             </div>
         </div>
         <div class="col-md-7">
-            <a href="#" class="float-right fas fa-close"></a>
             <div class="form-group">
                 {!! Form::select('slug[]', $characters, $character->character ? $character->character->slug : $character->slug, ['class' => 'form-control character-code', 'placeholder' => 'Select Character']) !!}
             </div>

--- a/resources/views/widgets/_character_select.blade.php
+++ b/resources/views/widgets/_character_select.blade.php
@@ -20,7 +20,6 @@
                     </div>
                 </div>
                 <div class="col-md-10">
-                    <a href="#" class="float-right fas fa-close"></a>
                     <div class="form-group">
                         {!! Form::label('slug[]', 'Character Code') !!}
                         {!! Form::select('slug[]', $characters, null, ['class' => 'form-control character-code', 'placeholder' => 'Select Character']) !!}

--- a/resources/views/widgets/_character_select_entry.blade.php
+++ b/resources/views/widgets/_character_select_entry.blade.php
@@ -21,7 +21,6 @@
                 </div>
             </div>
             <div class="col-md-10">
-                <a href="#" class="float-right fas fa-close"></a>
                 <div class="form-group">
                     {!! Form::label('slug[]', 'Character Code') !!}
                     {!! Form::select('slug[]', $characters, $character->character ? $character->character->slug : $character->slug, ['class' => 'form-control character-code', 'placeholder' => 'Select Character']) !!}


### PR DESCRIPTION
My first PR, I hope I'm doing everything right!

Noticed that there was still old unused lines of code in the character selection menus concerning submissions, sales, galleries and where you'd have select_entry and select.blade I believe. Didn't do anything nor was linked to any JS and wasn't visible on v3.0.0 unless you had an extension that made it visible because of custom `<a>` classes like Theme Manager.

`remove-character` is the correct class given it's in the JS and the copy file to delete the selected entry when on-click.