### PR TITLE
fix(characters): wrong div class in extended mentions

### DIFF
--- a/resources/views/character/_image_info.blade.php
+++ b/resources/views/character/_image_info.blade.php
@@ -173,27 +173,25 @@
             @if (isset($showMention) && $showMention)
                 {{-- Mention This tab --}}
                 <div class="tab-pane fade" id="mention-{{ $image->id }}">
-                    <div class="imagenoteseditingparse">
-                        In the rich text editor:
-                        <div class="alert alert-secondary">
-                            [character={{ $character->slug }}]
-                        </div>
-                        In a comment:
-                        <div class="alert alert-secondary">
-                            [{{ $character->fullName }}]({{ $character->url }})
-                        </div>
+                    In the rich text editor:
+                    <div class="alert alert-secondary">
+                        [character={{ $character->slug }}]
+                    </div>
+                    In a comment:
+                    <div class="alert alert-secondary">
+                        [{{ $character->fullName }}]({{ $character->url }})
                     </div>
                     <hr>
-                    <div class="my-2"><strong>For Thumbnails:</strong></div>
-                    <div class="imagenoteseditingparse">
-                        In the rich text editor:
-                        <div class="alert alert-secondary">
-                            [charthumb={{ $character->slug }}]
-                        </div>
-                        In a comment:
-                        <div class="alert alert-secondary">
-                            [![Thumbnail of {{ $character->fullName }}]({{ $character->image->thumbnailUrl }})]({{ $character->url }})
-                        </div>
+                <div class="my-2">
+                    <strong>For Thumbnails:</strong>
+                </div>
+                    In the rich text editor:
+                    <div class="alert alert-secondary">
+                        [charthumb={{ $character->slug }}]
+                    </div>
+                    In a comment:
+                    <div class="alert alert-secondary">
+                        [![Thumbnail of {{ $character->fullName }}]({{ $character->image->thumbnailUrl }})]({{ $character->url }})
                     </div>
                 </div>
             @endif

--- a/resources/views/character/_image_info.blade.php
+++ b/resources/views/character/_image_info.blade.php
@@ -182,9 +182,9 @@
                         [{{ $character->fullName }}]({{ $character->url }})
                     </div>
                     <hr>
-                <div class="my-2">
-                    <strong>For Thumbnails:</strong>
-                </div>
+                    <div class="my-2">
+                        <strong>For Thumbnails:</strong>
+                    </div>
                     In the rich text editor:
                     <div class="alert alert-secondary">
                         [charthumb={{ $character->slug }}]


### PR DESCRIPTION
Yeah, I don't know why I did this when I originally added the Extended Mentions. I think I didn't think it through well enough.

These two divs are entirely unnecessary, and having the class on them triggers the wysiwyg editor on them once someone tries to edit Notes.

Big ol' whoopsie. An old whoopsie, too.