### PR TITLE
hotfix(security|requests): add middleware that parses post fields

### DIFF
--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -101,7 +101,6 @@ function parse($text, &$pings = null) {
     $config->set('Attr.EnableID', true);
     $config->set('HTML.DefinitionID', 'include');
     $config->set('HTML.DefinitionRev', 2);
-	$config->set('Cache.DefinitionImpl', null); // TODO: remove this later!
     if ($def = $config->maybeGetRawHTMLDefinition()) {
         $def->addElement('include', 'Block', 'Empty', 'Common', array('file*' => 'URI', 'height' => 'Text', 'width' => 'Text'));
 		$def->addAttribute('a', 'data-toggle', 'Enum#collapse,tab');

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -19,6 +19,7 @@ class Kernel extends HttpKernel
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         \App\Http\Middleware\TrustProxies::class,
+        \App\Http\Middleware\ParsePostRequestFields::class,
     ];
 
     /**

--- a/app/Http/Middleware/ParsePostRequestFields.php
+++ b/app/Http/Middleware/ParsePostRequestFields.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class ParsePostRequestFields
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
+     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        if ($request->isMethod('post')) {
+            $excludedFields = ['_token', 'password', 'email', 'description', 'text'];
+            $strippedFields = ['name', 'title'];
+            
+            $parsedFields = [];
+            foreach ($request->except($excludedFields) as $key => $value) {
+                if (in_array($key, $strippedFields)) { // we strip these since parse() doesn't remove HTML tags
+                    $parsedFields[$key] = parse(strip_tags($value));
+                } else {
+                    $parsedFields[$key] = parse($value);
+                }
+                
+            }
+
+            $request->merge($parsedFields);
+        }
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
# Context
user reported a security concern verified locally (can utilise HTML in character names for example)

# Description
Applies a middleware to all requests that:
- parses all fields, minus `excludedFields`
- additionally strips those in `strippedFields` for extra security (since `parse()` doesn't remove HTML tags such a `<b>` etc)