### PR TITLE
Fix Gallery Performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "lorekeeper",
+    "name": "lorekeeper-extensions",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/resources/views/galleries/index.blade.php
+++ b/resources/views/galleries/index.blade.php
@@ -51,20 +51,18 @@
                     @endif
                 </div>
                 <div class="card-body">
-                    @if ($gallery->submissions->where('status', 'Accepted')->count())
+                    @if ($gallery->submissions()->where('status', 'Accepted')->count())
                         <div class="row">
-                            @foreach ($gallery->submissions->where('is_visible', 1)->where('status', 'Accepted')->take(4) as $submission)
+                            @foreach ($gallery->submissions()->where('is_visible', 1)->where('status', 'Accepted')->take(4)->get() as $submission)
                                 <div class="col-md-3 text-center align-self-center">
                                     @include('galleries._thumb', ['submission' => $submission, 'gallery' => true])
                                 </div>
                             @endforeach
                         </div>
-                        @if ($gallery->submissions->where('status', 'Accepted')->count() > 4)
+                        @if ($gallery->submissions()->where('status', 'Accepted')->count() > 4)
                             <div class="text-right"><a href="{{ url('gallery/' . $gallery->id) }}">See More...</a></div>
                         @endif
-                    @elseif(
-                        $gallery->children->count() &&
-                            App\Models\Gallery\GallerySubmission::whereIn('gallery_id', $gallery->children->pluck('id')->toArray())->where('is_visible', 1)->where('status', 'Accepted')->count())
+                    @elseif($gallery->children->count() && App\Models\Gallery\GallerySubmission::whereIn('gallery_id', $gallery->children->pluck('id')->toArray())->where('is_visible', 1)->where('status', 'Accepted')->count())
                         <div class="row">
                             @foreach (App\Models\Gallery\GallerySubmission::whereIn('gallery_id', $gallery->children->pluck('id')->toArray())->where('is_visible', 1)->where('status', 'Accepted')->orderBy('created_at', 'DESC')->get()->take(4) as $submission)
                                 <div class="col-md-3 text-center align-self-center">

--- a/resources/views/galleries/index.blade.php
+++ b/resources/views/galleries/index.blade.php
@@ -62,7 +62,9 @@
                         @if ($gallery->submissions()->where('status', 'Accepted')->count() > 4)
                             <div class="text-right"><a href="{{ url('gallery/' . $gallery->id) }}">See More...</a></div>
                         @endif
-                    @elseif($gallery->children->count() && App\Models\Gallery\GallerySubmission::whereIn('gallery_id', $gallery->children->pluck('id')->toArray())->where('is_visible', 1)->where('status', 'Accepted')->count())
+                    @elseif(
+                        $gallery->children->count() &&
+                            App\Models\Gallery\GallerySubmission::whereIn('gallery_id', $gallery->children->pluck('id')->toArray())->where('is_visible', 1)->where('status', 'Accepted')->count())
                         <div class="row">
                             @foreach (App\Models\Gallery\GallerySubmission::whereIn('gallery_id', $gallery->children->pluck('id')->toArray())->where('is_visible', 1)->where('status', 'Accepted')->orderBy('created_at', 'DESC')->get()->take(4) as $submission)
                                 <div class="col-md-3 text-center align-self-center">


### PR DESCRIPTION
The Gallery Index was pulling in all submissions for a gallery before counting them / only taking the top 4 which over time can cause performance issues as the number of submissions in each gallery grows.

This seemed like more of a bug than a feature so I put it on release? But feel free to let me know if I should redirect to develop.