### PR TITLE
Fix Permalinks sometimes 404'ing incorrectly

### DIFF
--- a/app/Http/Controllers/PermalinkController.php
+++ b/app/Http/Controllers/PermalinkController.php
@@ -61,6 +61,7 @@ class PermalinkController extends Controller {
                         }
                         break;
                 }
+                break;
             case 'Staff-Staff':
                 if (!Auth::check()) {
                     abort(404);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "lorekeeper",
+    "name": "lorekeeper-extensions",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {


### PR DESCRIPTION
If you had a report, and a staff member replied to your comment on a report, the comment permalink in the notification would 404 because it was a "Staff-User" comment and with no break, was also falling into the "Staff-Staff" comment section and 404'ing there because the user was not staff.