### PR TITLE
Fix error on invalid submission

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "lorekeeper",
+    "name": "lorekeeper-extensions",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/resources/views/widgets/_inventory_select.blade.php
+++ b/resources/views/widgets/_inventory_select.blade.php
@@ -1,5 +1,5 @@
 @php
-    if (old('stack_id')) {
+    if (old('stack_id') && old('stack_quantity')) {
         $old_selection = array_combine(old('stack_id'), old('stack_quantity'));
     }
 @endphp


### PR DESCRIPTION
If you submit a claim and check and item where the items quantity is being held in another submission (therefore creating an invalid quantity), you'd hit the error on the quantity and then `return redirect()->back()->withInput();`, and with Input would include an empty quantity value causing this line to 500 error instead of appropriately redirecting with the error banner.