### PR TITLE
Fix: Visual Trait Index image resizing on view

### DIFF
--- a/resources/views/world/species_features.blade.php
+++ b/resources/views/world/species_features.blade.php
@@ -23,10 +23,10 @@
                     @foreach ($categoryFeatures->chunk(4) as $chunk)
                         <div class="row mb-3">
                             @foreach ($chunk as $featureId => $feature)
-                                <div class="col-sm-3 col-6 text-center align-self-center inventory-item">
+                                <div class="col-md-3 col-6 text-center align-self-center inventory-item">
                                     @if ($feature->first()->has_image)
                                         <a class="badge" style="border-radius:.5em; {{ $feature->first()->rarity->color ? 'background-color:#' . $feature->first()->rarity->color : '' }}" href="{{ $feature->first()->url }}">
-                                            <img class="my-1 modal-image" style="max-height:100%; height:150px; border-radius:.5em;" src="{{ $feature->first()->imageUrl }}" alt="{{ $feature->first()->name }}" data-id="{{ $feature->first()->id }}" />
+                                            <img class="my-1 modal-image" style="max-height:150px; border-radius:.5em;" src="{{ $feature->first()->imageUrl }}" alt="{{ $feature->first()->name }}" data-id="{{ $feature->first()->id }}" />
                                         </a>
                                     @endif
                                     <p>


### PR DESCRIPTION
Noticed the visual trait index is a bit clunky when resizing the window from where you're viewing it, especially on mobile with long images that gets heavily squished (example at hand below on a clear v3 branch).
![image](https://github.com/user-attachments/assets/02789992-ee54-4c5e-8f18-a71e4f004a66)

This is just a small change that removes the set height and sets max-height as 150px (default), and replace the breakpoint of the column so it doesn't show as small on medium screens and resized windows.