### PR TITLE
Fix(admin): Admin Area Bootstrap tables (non-sortables)

### DIFF
--- a/resources/views/admin/files/index.blade.php
+++ b/resources/views/admin/files/index.blade.php
@@ -36,10 +36,10 @@
     <div class="mb-4 logs-table">
         <div class="logs-table-header">
             <div class="row">
-                <div class="col-6 col-md-3">
+                <div class="col-6 col-md-7">
                     <div class="logs-table-cell">Files</div>
                 </div>
-                <div class="col-6 col-md-3">
+                <div class="col-6 col-md-5">
                     <div class="logs-table-cell"></div>
                 </div>
             </div>
@@ -48,10 +48,10 @@
             @foreach ($files as $file)
                 <div class="logs-table-row">
                     <div class="row flex-wrap">
-                        <div class="col-6 col-md-3">
+                        <div class="col-6 col-md-7">
                             <div class="logs-table-cell"><a href="{{ asset('files/' . ($folder ? $folder . '/' : '') . $file) }}">{{ $file }}</a></div>
                         </div>
-                        <div class="col-6 col-md-3">
+                        <div class="col-6 col-md-5">
                             <div class="logs-table-cell text-right">
                                 <a href="#" class="btn btn-outline-primary btn-sm move-file" data-name="{{ $file }}" data-folder="{{ $folder }}">Move</a>
                                 <a href="#" class="btn btn-outline-primary btn-sm rename-file" data-name="{{ $file }}" data-folder="{{ $folder }}">Rename</a>

--- a/resources/views/admin/files/index.blade.php
+++ b/resources/views/admin/files/index.blade.php
@@ -33,28 +33,36 @@
     @endif
 
     <div class="text-right mb-3"><a href="#" class="btn btn-outline-primary" id="uploadButton"><i class="fas fa-plus"></i> Upload File</a></div>
-    <table class="table table-sm">
-        <thead>
-            <tr>
-                <th>Files</th>
-                <th></th>
-            </tr>
-        </thead>
-        <tbody>
+    <div class="mb-4 logs-table">
+        <div class="logs-table-header">
+            <div class="row">
+                <div class="col-6 col-md-3">
+                    <div class="logs-table-cell">Files</div>
+                </div>
+                <div class="col-6 col-md-3">
+                    <div class="logs-table-cell"></div>
+                </div>
+            </div>
+        </div>
+        <div class="logs-table-body">
             @foreach ($files as $file)
-                <tr>
-                    <td>
-                        <a href="{{ asset('files/' . ($folder ? $folder . '/' : '') . $file) }}">{{ $file }}</a>
-                    </td>
-                    <td class="text-right">
-                        <a href="#" class="btn btn-outline-primary btn-sm move-file" data-name="{{ $file }}" data-folder="{{ $folder }}">Move</a>
-                        <a href="#" class="btn btn-outline-primary btn-sm rename-file" data-name="{{ $file }}" data-folder="{{ $folder }}">Rename</a>
-                        <a href="#" class="btn btn-outline-danger btn-sm delete-file" data-name="{{ $file }}" data-folder="{{ $folder }}">Delete</a>
-                    </td>
-                </tr>
+                <div class="logs-table-row">
+                    <div class="row flex-wrap">
+                        <div class="col-6 col-md-3">
+                            <div class="logs-table-cell"><a href="{{ asset('files/' . ($folder ? $folder . '/' : '') . $file) }}">{{ $file }}</a></div>
+                        </div>
+                        <div class="col-6 col-md-3">
+                            <div class="logs-table-cell text-right">
+                                <a href="#" class="btn btn-outline-primary btn-sm move-file" data-name="{{ $file }}" data-folder="{{ $folder }}">Move</a>
+                                <a href="#" class="btn btn-outline-primary btn-sm rename-file" data-name="{{ $file }}" data-folder="{{ $folder }}">Rename</a>
+                                <a href="#" class="btn btn-outline-danger btn-sm delete-file" data-name="{{ $file }}" data-folder="{{ $folder }}">Delete</a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             @endforeach
-        </tbody>
-    </table>
+        </div>
+    </div>
 
     @if ($folder && !count($files))
         <div class="modal fade" id="editFolderModal" tabindex="-1" role="dialog">

--- a/resources/views/admin/logs.blade.php
+++ b/resources/views/admin/logs.blade.php
@@ -24,23 +24,43 @@
     </div>
 
     {!! $logs->render() !!}
-    <table class="table table-sm">
-        <thead>
-            <th>Staff</th>
-            <th>Action</th>
-            <th>Action Details</th>
-            <th>Date</th>
-        </thead>
-        <tbody>
+    <div class="mb-4 logs-table">
+        <div class="logs-table-header">
+            <div class="row">
+                <div class="col-6 col-md-3">
+                    <div class="logs-table-cell">Staff</div>
+                </div>
+                <div class="col-6 col-md-3">
+                    <div class="logs-table-cell">Action</div>
+                </div>
+                <div class="col-6 col-md-3">
+                    <div class="logs-table-cell">Action Details</div>
+                </div>
+                <div class="col-6 col-md-3">
+                    <div class="logs-table-cell">Date</div>
+                </div>
+            </div>
+        </div>
+        <div class="logs-table-body">
             @foreach ($logs as $log)
-                <tr>
-                    <td>{!! $log->user->displayName !!}</td>
-                    <td>{!! $log->action !!}</td>
-                    <td>{!! $log->action_details !!}</td>
-                    <td>{!! format_date($log->created_at) !!} ({!! pretty_date($log->created_at) !!})</td>
-                </tr>
+                <div class="logs-table-row">
+                    <div class="row flex-wrap">
+                        <div class="col-6 col-md-3">
+                            <div class="logs-table-cell">{!! $log->user->displayName !!}</div>
+                        </div>
+                        <div class="col-6 col-md-3">
+                            <div class="logs-table-cell">{!! $log->action !!}</div>
+                        </div>
+                        <div class="col-6 col-md-3">
+                            <div class="logs-table-cell">{!! $log->action_details !!}</div>
+                        </div>
+                        <div class="col-6 col-md-3">
+                            <div class="logs-table-cell">{!! format_date($log->created_at) !!} ({!! pretty_date($log->created_at) !!})</div>
+                        </div>
+                    </div>
+                </div>
             @endforeach
-        </tbody>
-    </table>
+        </div>
+    </div>
     {!! $logs->render() !!}
 @endsection

--- a/resources/views/admin/loot_tables/_roll_loot_table.blade.php
+++ b/resources/views/admin/loot_tables/_roll_loot_table.blade.php
@@ -1,25 +1,41 @@
 <p>You rolled {{ $quantity }} time{{ $quantity != 1 ? 's' : '' }} for the following:</p>
-<table class="table table-sm table-striped">
-    <thead>
-        <th>#</th>
-        <th>Reward</th>
-        <th>Quantity</th>
-    </thead>
-    <tbody>
+<div class="mb-4 logs-table table-striped">
+    <div class="logs-table-header">
+        <div class="row">
+            <div class="col-xs-1" style="width:100px;">
+                <div class="logs-table-cell text-center">#</div>
+            </div>
+            <div class="col-6 col-md-3">
+                <div class="logs-table-cell">Reward</div>
+            </div>
+            <div class="col-5 col-md-3">
+                <div class="logs-table-cell">Quantity</div>
+            </div>
+        </div>
+    </div>
+    <div class="logs-table-body">
         <?php $count = 1; ?>
         @foreach ($results as $result)
             @foreach ($result as $type)
                 @if (count($type))
                     @foreach ($type as $t)
-                        <tr>
-                            <td>{{ $count++ }}</td>
-                            <td>{!! $t['asset']->displayName !!}</td>
-                            <td>{{ $t['quantity'] }}</td>
-                        </tr>
+                        <div class="logs-table-row">
+                            <div class="row flex-wrap">
+                                <div class="col-xs-1" style="width:100px;">
+                                    <div class="logs-table-cell text-center">{{ $count++ }}</div>
+                                </div>
+                                <div class="col-6 col-md-3">
+                                    <div class="logs-table-cell">{!! $t['asset']->displayName !!}</div>
+                                </div>
+                                <div class="col-6 col-md-3">
+                                    <div class="logs-table-cell">{{ $t['quantity'] }}</div>
+                                </div>
+                            </div>
+                        </div>
                     @endforeach
                 @endif
             @endforeach
         @endforeach
-    </tbody>
-</table>
+    </div>
+</div>
 <p>Note: "None" results are not shown in this table.</p>

--- a/resources/views/admin/loot_tables/_roll_loot_table.blade.php
+++ b/resources/views/admin/loot_tables/_roll_loot_table.blade.php
@@ -2,7 +2,7 @@
 <div class="mb-4 logs-table table-striped">
     <div class="logs-table-header">
         <div class="row">
-            <div class="col-xs-1" style="width:100px;">
+            <div class="col-1">
                 <div class="logs-table-cell text-center">#</div>
             </div>
             <div class="col-6 col-md-3">
@@ -21,13 +21,13 @@
                     @foreach ($type as $t)
                         <div class="logs-table-row">
                             <div class="row flex-wrap">
-                                <div class="col-xs-1" style="width:100px;">
+                                <div class="col-1">
                                     <div class="logs-table-cell text-center">{{ $count++ }}</div>
                                 </div>
                                 <div class="col-6 col-md-3">
                                     <div class="logs-table-cell">{!! $t['asset']->displayName !!}</div>
                                 </div>
-                                <div class="col-6 col-md-3">
+                                <div class="col-5 col-md-3">
                                     <div class="logs-table-cell">{{ $t['quantity'] }}</div>
                                 </div>
                             </div>

--- a/resources/views/admin/raffle/ticket_index.blade.php
+++ b/resources/views/admin/raffle/ticket_index.blade.php
@@ -38,10 +38,10 @@
                 <div class="mb-4 logs-table mb-0">
                     <div class="logs-table-header">
                         <div class="row">
-                            <div class="col-xs-1" style="max-width:100px;">
+                            <div class="col-1">
                                 <div class="logs-table-cell text-center">#</div>
                             </div>
-                            <div class="col-6 col-md-3">
+                            <div class="col-11">
                                 <div class="logs-table-cell text-left">User</div>
                             </div>
                         </div>
@@ -50,10 +50,10 @@
                         @foreach ($raffle->tickets()->winners()->get() as $winner)
                             <div class="logs-table-row">
                                 <div class="row flex-wrap">
-                                    <div class="col-xs-1" style="max-width:100px;">
+                                    <div class="col-1">
                                         <div class="logs-table-cell text-center">{{ $winner->position }}</div>
                                     </div>
-                                    <div class="col-6 col-md-3">
+                                    <div class="col-11">
                                         <div class="logs-table-cell text-left">{!! $winner->displayHolderName !!}</div>
                                     </div>
                                 </div>
@@ -72,15 +72,15 @@
         <div class="mb-4 logs-table">
             <div class="logs-table-header">
                 <div class="row">
-                    <div class="col-xs-1 text-center" style="width:100px;">
-                        <div class="logs-table-cell">#</div>
+                    <div class="col-1">
+                        <div class="logs-table-cell text-center">#</div>
                     </div>
-                    <div class="col-6 col-md-3">
-                        <div class="logs-table-cell">User</div>
+                    <div class="col-8 col-md-3">
+                        <div class="logs-table-cell text-left">User</div>
                     </div>
                     @if ($raffle->is_active < 2)
-                        <div class="col-6 col-md-3">
-                            <div class="logs-table-cell">User</div>
+                        <div class="col-3">
+                            <div class="logs-table-cell"></div>
                         </div>
                     @endif
                 </div>
@@ -88,18 +88,19 @@
                     @foreach ($tickets as $count => $ticket)
                         <div class="logs-table-row">
                             <div class="row flex-wrap">
-                                <div class="col-6 col-md-3">
+                                <div class="col-1">
                                     <div class="logs-table-cell text-center">{{ $page * 200 + $count + 1 }}</div>
-                                    <div class="col-6 col-md-3">
-                                        <div class="logs-table-cell">{!! $ticket->displayHolderName !!}</div>
-                                    </div>
-                                    @if ($raffle->is_active < 2)
-                                        <div class="col-6 col-md-3">
-                                            <div class="logs-table-cell text-right">{!! Form::open(['url' => 'admin/raffles/view/ticket/delete/' . $ticket->id]) !!}{!! Form::submit('Delete', ['class' => 'btn btn-danger btn-sm']) !!}{!! Form::close() !!}</div>
-                                        </div>
-                                    @endif
                                 </div>
+                                <div class="col-8 col-md-3">
+                                    <div class="logs-table-cell text-left">{!! $ticket->displayHolderName !!}</div>
+                                </div>
+                                @if ($raffle->is_active < 2)
+                                    <div class="col-3">
+                                        <div class="logs-table-cell text-right">{!! Form::open(['url' => 'admin/raffles/view/ticket/delete/' . $ticket->id]) !!}{!! Form::submit('Delete', ['class' => 'btn btn-danger btn-sm']) !!}{!! Form::close() !!}</div>
+                                    </div>
+                                @endif
                             </div>
+                        </div>
                     @endforeach
                 </div>
             </div>

--- a/resources/views/admin/raffle/ticket_index.blade.php
+++ b/resources/views/admin/raffle/ticket_index.blade.php
@@ -78,95 +78,95 @@
                     <div class="col-6 col-md-3">
                         <div class="logs-table-cell">User</div>
                     </div>
-                @if ($raffle->is_active < 2)
-                    <div class="col-6 col-md-3">
-                        <div class="logs-table-cell">User</div>
-                    </div>
-                @endif
-            </div>
-            <div class="logs-table-body">
-                @foreach ($tickets as $count => $ticket)
-                    <div class="logs-table-row">
-                        <div class="row flex-wrap">
-                            <div class="col-6 col-md-3">
-                                <div class="logs-table-cell text-center">{{ $page * 200 + $count + 1 }}</div>
-                            <div class="col-6 col-md-3">
-                                <div class="logs-table-cell">{!! $ticket->displayHolderName !!}</div>
-                            </div>
-                            @if ($raffle->is_active < 2)
+                    @if ($raffle->is_active < 2)
+                        <div class="col-6 col-md-3">
+                            <div class="logs-table-cell">User</div>
+                        </div>
+                    @endif
+                </div>
+                <div class="logs-table-body">
+                    @foreach ($tickets as $count => $ticket)
+                        <div class="logs-table-row">
+                            <div class="row flex-wrap">
                                 <div class="col-6 col-md-3">
-                                    <div class="logs-table-cell text-right">{!! Form::open(['url' => 'admin/raffles/view/ticket/delete/' . $ticket->id]) !!}{!! Form::submit('Delete', ['class' => 'btn btn-danger btn-sm']) !!}{!! Form::close() !!}</div>
+                                    <div class="logs-table-cell text-center">{{ $page * 200 + $count + 1 }}</div>
+                                    <div class="col-6 col-md-3">
+                                        <div class="logs-table-cell">{!! $ticket->displayHolderName !!}</div>
+                                    </div>
+                                    @if ($raffle->is_active < 2)
+                                        <div class="col-6 col-md-3">
+                                            <div class="logs-table-cell text-right">{!! Form::open(['url' => 'admin/raffles/view/ticket/delete/' . $ticket->id]) !!}{!! Form::submit('Delete', ['class' => 'btn btn-danger btn-sm']) !!}{!! Form::close() !!}</div>
+                                        </div>
+                                    @endif
                                 </div>
-                            @endif
+                            </div>
+                    @endforeach
+                </div>
+            </div>
+        </div>
+        <div class="text-right">{!! $tickets->render() !!}</div>
+
+        <div class="modal fade" id="raffle-modal" tabindex="-1" role="dialog">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <span class="modal-title h5 mb-0">Add Tickets</span>
+                        <button type="button" class="close" data-dismiss="modal">&times;</button>
+                    </div>
+                    <div class="modal-body">
+                        <p>Select an on-site user or enter an off-site username, as well as the number of tickets to create for them. Any created tickets are in addition to any pre-existing tickets for the user(s).</p>
+                        {!! Form::open(['url' => 'admin/raffles/view/ticket/' . $raffle->id]) !!}
+                        <div id="ticketList">
+                        </div>
+                        <div><a href="#" class="btn btn-primary" id="add-ticket">Add Ticket</a></div>
+                        <div class="text-right">
+                            {!! Form::submit('Add', ['class' => 'btn btn-primary']) !!}
+                        </div>
+                        {!! Form::close() !!}
+                        <div class="ticket-row hide mb-2">
+                            {!! Form::select('user_id[]', $users, null, ['class' => 'form-control mr-2 user-select', 'placeholder' => 'Select User']) !!}
+                            {!! Form::text('alias[]', null, ['class' => 'form-control mr-2', 'placeholder' => 'OR Enter Alias']) !!}
+                            {!! Form::number('ticket_count[]', null, ['class' => 'form-control mr-2', 'placeholder' => 'Ticket Count']) !!}
+                            <a href="#" class="remove-ticket btn btn-danger mb-2">×</a>
                         </div>
                     </div>
-                @endforeach
-            </div>
-        </div>
-    </div>
-    <div class="text-right">{!! $tickets->render() !!}</div>
-
-    <div class="modal fade" id="raffle-modal" tabindex="-1" role="dialog">
-        <div class="modal-dialog" role="document">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <span class="modal-title h5 mb-0">Add Tickets</span>
-                    <button type="button" class="close" data-dismiss="modal">&times;</button>
-                </div>
-                <div class="modal-body">
-                    <p>Select an on-site user or enter an off-site username, as well as the number of tickets to create for them. Any created tickets are in addition to any pre-existing tickets for the user(s).</p>
-                    {!! Form::open(['url' => 'admin/raffles/view/ticket/' . $raffle->id]) !!}
-                    <div id="ticketList">
-                    </div>
-                    <div><a href="#" class="btn btn-primary" id="add-ticket">Add Ticket</a></div>
-                    <div class="text-right">
-                        {!! Form::submit('Add', ['class' => 'btn btn-primary']) !!}
-                    </div>
-                    {!! Form::close() !!}
-                    <div class="ticket-row hide mb-2">
-                        {!! Form::select('user_id[]', $users, null, ['class' => 'form-control mr-2 user-select', 'placeholder' => 'Select User']) !!}
-                        {!! Form::text('alias[]', null, ['class' => 'form-control mr-2', 'placeholder' => 'OR Enter Alias']) !!}
-                        {!! Form::number('ticket_count[]', null, ['class' => 'form-control mr-2', 'placeholder' => 'Ticket Count']) !!}
-                        <a href="#" class="remove-ticket btn btn-danger mb-2">×</a>
-                    </div>
                 </div>
             </div>
         </div>
-    </div>
-@endsection
-@section('scripts')
-    @parent
-    <script>
-        $('.edit-tickets').on('click', function(e) {
-            e.preventDefault();
-            $('#raffle-modal').modal('show');
-        });
-
-        $(document).ready(function() {
-            $('#add-ticket').on('click', function(e) {
+    @endsection
+    @section('scripts')
+        @parent
+        <script>
+            $('.edit-tickets').on('click', function(e) {
                 e.preventDefault();
-                addTicketRow();
+                $('#raffle-modal').modal('show');
             });
-            $('.remove-ticket').on('click', function(e) {
-                e.preventDefault();
-                removeTicketRow($(this));
-            })
 
-            function addTicketRow() {
-                var $clone = $('.ticket-row').clone();
-                $('#ticketList').append($clone);
-                $clone.removeClass('hide ticket-row');
-                $clone.addClass('d-flex');
-                $clone.find('.remove-ticket').on('click', function(e) {
+            $(document).ready(function() {
+                $('#add-ticket').on('click', function(e) {
+                    e.preventDefault();
+                    addTicketRow();
+                });
+                $('.remove-ticket').on('click', function(e) {
                     e.preventDefault();
                     removeTicketRow($(this));
                 })
-                $clone.find('.user-select').selectize();
-            }
 
-            function removeTicketRow($trigger) {
-                $trigger.parent().remove();
-            }
-        });
-    </script>
-@endsection
+                function addTicketRow() {
+                    var $clone = $('.ticket-row').clone();
+                    $('#ticketList').append($clone);
+                    $clone.removeClass('hide ticket-row');
+                    $clone.addClass('d-flex');
+                    $clone.find('.remove-ticket').on('click', function(e) {
+                        e.preventDefault();
+                        removeTicketRow($(this));
+                    })
+                    $clone.find('.user-select').selectize();
+                }
+
+                function removeTicketRow($trigger) {
+                    $trigger.parent().remove();
+                }
+            });
+        </script>
+    @endsection

--- a/resources/views/admin/raffle/ticket_index.blade.php
+++ b/resources/views/admin/raffle/ticket_index.blade.php
@@ -35,20 +35,32 @@
         <div class="card mb-3">
             <div class="card-header h3">Winner(s)</div>
             <div class="table-responsive">
-                <table class="table table-sm mb-0">
-                    <thead>
-                        <th class="col-xs-1 text-center" style="width:100px;">#</th>
-                        <th>User</th>
-                    </thead>
-                    <tbody>
+                <div class="mb-4 logs-table mb-0">
+                    <div class="logs-table-header">
+                        <div class="row">
+                            <div class="col-xs-1" style="max-width:100px;">
+                                <div class="logs-table-cell text-center">#</div>
+                            </div>
+                            <div class="col-6 col-md-3">
+                                <div class="logs-table-cell text-left">User</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="logs-table-body">
                         @foreach ($raffle->tickets()->winners()->get() as $winner)
-                            <tr>
-                                <td class="text-center">{{ $winner->position }}</td>
-                                <td class="text-left">{!! $winner->displayHolderName !!}</td>
-                            </tr>
+                            <div class="logs-table-row">
+                                <div class="row flex-wrap">
+                                    <div class="col-xs-1" style="max-width:100px;">
+                                        <div class="logs-table-cell text-center">{{ $winner->position }}</div>
+                                    </div>
+                                    <div class="col-6 col-md-3">
+                                        <div class="logs-table-cell text-left">{!! $winner->displayHolderName !!}</div>
+                                    </div>
+                                </div>
+                            </div>
                         @endforeach
-                    </tbody>
-                </table>
+                    </div>
+                </div>
             </div>
         </div>
     @endif
@@ -57,26 +69,40 @@
 
     <div class="text-right">{!! $tickets->render() !!}</div>
     <div class="table-responsive">
-        <table class="table table-sm">
-            <thead>
-                <th class="col-xs-1 text-center" style="width:100px;">#</th>
-                <th>User</th>
+        <div class="mb-4 logs-table">
+            <div class="logs-table-header">
+                <div class="row">
+                    <div class="col-xs-1 text-center" style="width:100px;">
+                        <div class="logs-table-cell">#</div>
+                    </div>
+                    <div class="col-6 col-md-3">
+                        <div class="logs-table-cell">User</div>
+                    </div>
                 @if ($raffle->is_active < 2)
-                    <th></th>
+                    <div class="col-6 col-md-3">
+                        <div class="logs-table-cell">User</div>
+                    </div>
                 @endif
-            </thead>
-            <tbody>
+            </div>
+            <div class="logs-table-body">
                 @foreach ($tickets as $count => $ticket)
-                    <tr>
-                        <td class="text-center">{{ $page * 200 + $count + 1 }}</td>
-                        <td>{!! $ticket->displayHolderName !!}</td>
-                        @if ($raffle->is_active < 2)
-                            <td class="text-right">{!! Form::open(['url' => 'admin/raffles/view/ticket/delete/' . $ticket->id]) !!}{!! Form::submit('Delete', ['class' => 'btn btn-danger btn-sm']) !!}{!! Form::close() !!}</td>
-                        @endif
-                    </tr>
+                    <div class="logs-table-row">
+                        <div class="row flex-wrap">
+                            <div class="col-6 col-md-3">
+                                <div class="logs-table-cell text-center">{{ $page * 200 + $count + 1 }}</div>
+                            <div class="col-6 col-md-3">
+                                <div class="logs-table-cell">{!! $ticket->displayHolderName !!}</div>
+                            </div>
+                            @if ($raffle->is_active < 2)
+                                <div class="col-6 col-md-3">
+                                    <div class="logs-table-cell text-right">{!! Form::open(['url' => 'admin/raffles/view/ticket/delete/' . $ticket->id]) !!}{!! Form::submit('Delete', ['class' => 'btn btn-danger btn-sm']) !!}{!! Form::close() !!}</div>
+                                </div>
+                            @endif
+                        </div>
+                    </div>
                 @endforeach
-            </tbody>
-        </table>
+            </div>
+        </div>
     </div>
     <div class="text-right">{!! $tickets->render() !!}</div>
 

--- a/resources/views/admin/sales/sales.blade.php
+++ b/resources/views/admin/sales/sales.blade.php
@@ -16,39 +16,54 @@
         <p>No sales found.</p>
     @else
         {!! $saleses->render() !!}
-        <table class="table table-sm page-table">
-            <thead>
-                <tr>
-                    <th>Title</th>
-                    <th>Posted At</th>
-                    <th>Last Edited</th>
-                    <th></th>
-                </tr>
-            </thead>
-            <tbody>
+        <div class="mb-4 logs-table">
+            <div class="logs-table-header">
+                <div class="row">
+                    <div class="col-12 col-md-5">
+                        <div class="logs-table-cell">Title</div>
+                    </div>
+                    <div class="col-6 col-md-3">
+                        <div class="logs-table-cell">Posted At</div>
+                    </div>
+                    <div class="col-6 col-md-3">
+                        <div class="logs-table-cell">Last Edited</div>
+                    </div>
+                </div>
+            </div>
+            <div class="logs-table-body">
                 @foreach ($saleses as $sales)
-                    <tr>
-                        <td>
-                            @if (!$sales->is_visible)
-                                @if ($sales->post_at)
-                                    <i class="fas fa-clock" data-toggle="tooltip" title="This post is scheduled to be posted in the future."></i>
-                                @else
-                                    <i class="fas fa-eye-slash" data-toggle="tooltip" title="This post is hidden."></i>
-                                @endif
-                            @endif
-                            <a href="{{ $sales->url }}">{{ $sales->title }}</a>
-                        </td>
-                        <td>{!! format_date($sales->post_at ?: $sales->created_at) !!}</td>
-                        <td>{!! format_date($sales->updated_at) !!}</td>
-                        <td class="text-right">
-                            <a href="{{ url('admin/sales/edit/' . $sales->id) }}" class="btn btn-primary">Edit</a>
-                        </td>
-                    </tr>
+                    <div class="logs-table-row">
+                        <div class="row flex-wrap">
+                            <div class="col-12 col-md-5">
+                                <div class="logs-table-cell">
+                                    @if (!$sales->is_visible)
+                                        @if ($sales->post_at)
+                                            <i class="fas fa-clock mr-1" data-toggle="tooltip" title="This post is scheduled to be posted in the future."></i>
+                                        @else
+                                            <i class="fas fa-eye-slash mr-1" data-toggle="tooltip" title="This post is hidden."></i>
+                                        @endif
+                                    @endif
+                                    <a href="{{ $sales->url }}">{{ $sales->title }}</a>
+                                </div>
+                            </div>
+                            <div class="col-6 col-md-3">
+                                <div class="logs-table-cell">{!! pretty_date($sales->post_at ?: $sales->created_at) !!}</div>
+                            </div>
+                            <div class="col-6 col-md-3">
+                                <div class="logs-table-cell">{!! pretty_date($sales->updated_at) !!}</div>
+                            </div>
+                            <div class="col-12 col-md-1 text-right">
+                                <div class="logs-table-cell"><a href="{{ url('admin/sales/edit/' . $sales->id) }}" class="btn btn-primary py-0 px-2 w-100">Edit</a></div>
+                            </div>
+                        </div>
+                    </div>
                 @endforeach
-            </tbody>
-
-        </table>
+            </div>
+        </div>
         {!! $saleses->render() !!}
+
+        <div class="text-center mt-4 small text-muted">{{ $saleses->total() }} result{{ $saleses->total() == 1 ? '' : 's' }} found.</div>
+                                  
     @endif
 
 @endsection

--- a/resources/views/admin/sales/sales.blade.php
+++ b/resources/views/admin/sales/sales.blade.php
@@ -63,7 +63,6 @@
         {!! $saleses->render() !!}
 
         <div class="text-center mt-4 small text-muted">{{ $saleses->total() }} result{{ $saleses->total() == 1 ? '' : 's' }} found.</div>
-                                  
     @endif
 
 @endsection

--- a/resources/views/admin/settings/settings.blade.php
+++ b/resources/views/admin/settings/settings.blade.php
@@ -16,35 +16,48 @@
         <p>No settings found.</p>
     @else
         {!! $settings->render() !!}
-        <table class="table table-sm setting-table">
-            <thead>
-                <tr>
-                    <th>Key</th>
-                    <th>Description</th>
-                    <th>Value</th>
-                    <th></th>
-                </tr>
-            </thead>
-            <tbody>
+        <div class="mb-4 logs-table setting-table">
+            <div class="logs-table-header">
+                <div class="row">
+                    <div class="col-6 col-md-3">
+                        <div class="logs-table-cell">Key</div>
+                    </div>
+                    <div class="col-6 col-md-3">
+                        <div class="logs-table-cell">Description</div>
+                    </div>
+                    <div class="col-md-6">
+                        <div class="logs-table-cell">Value</div>
+                    </div>
+                </div>
+            </div>
+            <div class="logs-table-body">
                 @foreach ($settings as $setting)
-                    <tr>
-                        <td>{{ $setting->key }}</td>
-                        <td>{{ $setting->description }}</td>
-                        <td>
-                            {!! Form::open(['url' => 'admin/settings/' . $setting->key, 'class' => 'd-flex justify-content-end']) !!}
-                            <div class="form-group mr-3 mb-3">
-                                {!! Form::text('value', $setting->value, ['class' => 'form-control']) !!}
+                    <div class="logs-table-row">
+                        <div class="row flex-wrap">
+                            <div class="col-6 col-md-3">
+                                <div class="logs-table-cell">{{ $setting->key }}</div>
                             </div>
-                            <div class="form-group mb-3">
-                                {!! Form::submit('Edit', ['class' => 'btn btn-primary']) !!}
+                            <div class="col-6 col-md-3">
+                                <div class="logs-table-cell">{{ $setting->description }}</div>
                             </div>
-                            {!! Form::close() !!}
-                        </td>
-                    </tr>
+                            <div class="col-6 col-md-3">
+                                <div class="logs-table-cell">
+                                    {!! Form::open(['url' => 'admin/settings/' . $setting->key, 'class' => 'd-flex justify-content-end']) !!}
+                                    <div class="form-group mr-3 mb-3">
+                                        {!! Form::text('value', $setting->value, ['class' => 'form-control']) !!}
+                                    </div>
+                                    <div class="form-group mb-3">
+                                        {!! Form::submit('Edit', ['class' => 'btn btn-primary']) !!}
+                                    </div>
+                                    {!! Form::close() !!}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 @endforeach
-            </tbody>
+            </div>
 
-        </table>
+        </div>
         {!! $settings->render() !!}
     @endif
 

--- a/resources/views/admin/staff_reward_settings.blade.php
+++ b/resources/views/admin/staff_reward_settings.blade.php
@@ -22,35 +22,46 @@
         <p>No settings found.</p>
     @else
         {!! $settings->render() !!}
-        <table class="table table-sm setting-table">
-            <thead>
-                <tr>
-                    <th>Name</th>
-                    <th>Description</th>
-                    <th>Value</th>
-                    <th></th>
-                </tr>
-            </thead>
-            <tbody>
+        <div class="mb-4 logs-table setting-table">
+            <div class="logs-table-header">
+                <div class="row">
+                    <div class="col-6 col-md-3">
+                        <div class="logs-table-cell">Name</div>
+                    </div>
+                    <div class="col-6 col-md-3">
+                        <div class="logs-table-cell">Description</div>
+                    </div>
+                    <div class="col-md-6">
+                        <div class="logs-table-cell">Value</div>
+                    </div>
+                </div>
+            </div>
+            <div class="logs-table-body">
                 @foreach ($settings as $setting)
-                    <tr>
-                        <td>{{ $setting->name }}</td>
-                        <td>{{ $setting->description }}</td>
-                        <td>
-                            {!! Form::open(['url' => 'admin/staff-reward-settings/' . $setting->key, 'class' => 'd-flex justify-content-end']) !!}
-                            <div class="form-group mr-3 mb-3">
-                                {!! Form::text('value', $setting->value, ['class' => 'form-control']) !!}
+                    <div class="row">
+                        <div class="col-6 col-md-3">
+                            <div class="logs-table-cell">{{ $setting->name }}</div>
+                        </div>
+                        <div class="col-6 col-md-3">
+                            <div class="logs-table-cell">{{ $setting->description }}</div>
+                        </div>
+                        <div class="col-6 col-md-3">
+                            <div class="logs-table-cell">
+                                {!! Form::open(['url' => 'admin/staff-reward-settings/' . $setting->key, 'class' => 'd-flex justify-content-end']) !!}
+                                <div class="form-group mr-3 mb-3">
+                                    {!! Form::text('value', $setting->value, ['class' => 'form-control']) !!}
+                                </div>
+                                <div class="form-group mb-3">
+                                    {!! Form::submit('Edit', ['class' => 'btn btn-primary']) !!}
+                                </div>
+                                {!! Form::close() !!}
                             </div>
-                            <div class="form-group mb-3">
-                                {!! Form::submit('Edit', ['class' => 'btn btn-primary']) !!}
-                            </div>
-                            {!! Form::close() !!}
-                        </td>
-                    </tr>
+                        </div>
+                    </div>
                 @endforeach
-            </tbody>
+            </div>
 
-        </table>
+        </div>
         {!! $settings->render() !!}
     @endif
 

--- a/resources/views/admin/users/user_update_log.blade.php
+++ b/resources/views/admin/users/user_update_log.blade.php
@@ -27,33 +27,49 @@
     <p>This is a list of changes that have been made to this account's information, whether by the user or by a staff member.</p>
 
     {!! $logs->render() !!}
-    <table class="table table-sm">
-        <thead>
-            <tr>
-                <th>Staff Member</th>
-                <th>Type</th>
-                <th>Data</th>
-                <th>Date</th>
-            </tr>
-        </thead>
-        <tbody>
+    <div class="mb-4 logs-table">
+        <div class="logs-table-header">
+            <div class="row">
+                <div class="col-6 col-md-3">
+                    <div class="logs-table-cell">Staff Member</div>
+                </div>
+                <div class="col-6 col-md-3">
+                    <div class="logs-table-cell">Type</div>
+                </div>
+                <div class="col-6 col-md-3">
+                    <div class="logs-table-cell">Data</div>
+                </div>
+                <div class="col-6 col-md-3">
+                    <div class="logs-table-cell">Date</div>
+                </div>
+            </div>
+        </div>
+        <div class="logs-table-body">
             @foreach ($logs as $log)
-                <tr>
-                    <td>{!! $log->staff_id ? $log->staff->displayName : '---' !!}</td>
-                    <td>{{ $log->type }}</td>
-                    <td>
-                        @foreach ($log->data as $key => $value)
-                            <div>
-                                @if (is_string($value))
-                                    <strong>{{ ucfirst(str_replace('_', ' ', $key)) }}: </strong>{{ $value }}
-                                @endif
-                            </div>
-                        @endforeach
-                    </td>
-                    <td>{!! format_date($log->created_at) !!}</td>
-                </tr>
+                <div class="row">
+                    <div class="col-6 col-md-3">
+                        <div class="logs-table-cell">{!! $log->staff_id ? $log->staff->displayName : '---' !!}</div>
+                    </div>
+                    <div class="col-6 col-md-3">
+                        <div class="logs-table-cell">{{ $log->type }}</div>
+                    </div>
+                    <div class="col-6 col-md-3">
+                        <div class="logs-table-cell">
+                            @foreach ($log->data as $key => $value)
+                                <div>
+                                    @if (is_string($value))
+                                        <strong>{{ ucfirst(str_replace('_', ' ', $key)) }}: </strong>{{ $value }}
+                                    @endif
+                                </div>
+                            @endforeach
+                        </div>
+                    </div>
+                    <div class="col-6 col-md-3">
+                        <div class="logs-table-cell">{!! format_date($log->created_at) !!}</div>
+                    </div>
+                </div>
             @endforeach
-        </tbody>
-    </table>
+        </div>
+    </div>
     {!! $logs->render() !!}
 @endsection


### PR DESCRIPTION
Starting a minor project to get rid of all `<table>`s, to make them Bootstrap instead.

**Files affected by this PR:**
- \resources\views\admin\sales\sales.blade.php
- \resources\views\admin\users\user_update_log.blade.php
- \resources\views\admin\staff_reward_settings.blade.php
- \resources\views\admin\settings\settings.blade.php
- \resources\views\admin\raffle\ticket_index.blade.php
- \resources\views\admin\loot_tables\_roll_loot_table.blade.php
- \resources\views\admin\logs.blade.php
- \resources\views\admin\files\index.blade.php

This particular PR does not cover pages that have sort functions, namely the following:
- \resources\views\admin\submissions\submission.blade.php
- \resources\views\admin\items\create_edit_item.blade.php
- \resources\views\admin\users\ranks.blade.php
- \resources\views\admin\sublist\sublist.blade.php
- \resources\views\admin\specieses\subtypes.blade.php
- \resources\views\admin\specieses\specieses.blade.php
- \resources\views\admin\shops\shops.blade.php
- \resources\views\admin\rarities\rarities.blade.php
- \resources\views\admin\prompts\prompt_categories.blade.php
- \resources\views\admin\items\item_categories.blade.php
- \resources\views\admin\features\feature_categories.blade.php
- \resources\views\admin\currencies\sort.blade.php
- \resources\views\admin\characters\character_categories.blade.php

As well as `\resources\views\admin\loot_tables\create_edit_loot_table.blade.php` which is it's own little problem.

I intend to do another PR later for these.