### PR TITLE
Bug(Comments): Permalinks pull all comments into memory

### DIFF
--- a/app/Http/Controllers/PermalinkController.php
+++ b/app/Http/Controllers/PermalinkController.php
@@ -16,7 +16,7 @@ class PermalinkController extends Controller {
      * @return \Illuminate\Contracts\Support\Renderable
      */
     public function getComment($id) {
-        $comments = Comment::withTrashed()->get();
+        $comments = Comment::withTrashed();
         //$comments = $comments->sortByDesc('created_at');
         $comment = $comments->find($id);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "lorekeeper",
+    "name": "lorekeeper-extensions",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {


### PR DESCRIPTION
Permalinked comments were pulling all comments into memory before finding the comment actually linked to, which will eventually crash the page with enough comments.