### PR TITLE
fix(sales/news): Removed redundant anchor, fixed links and consistency

### DIFF
--- a/resources/views/news/_news.blade.php
+++ b/resources/views/news/_news.blade.php
@@ -16,11 +16,11 @@
         ->count(); ?>
     @if (!$page)
         <div class="text-right mb-2 mr-2">
-            <a class="btn" href="{{ $news->url }}"><i class="fas fa-comment"></i> {{ $commentCount }} Comment{{ $commentCount != 1 ? 's' : '' }}</a>
+            <a class="btn" href="{{ $news->url }}#comments"><i class="fas fa-comment"></i> {{ $commentCount }} Comment{{ $commentCount != 1 ? 's' : '' }}</a>
         </div>
     @else
         <div class="text-right mb-2 mr-2">
-            <span class="btn"><i class="fas fa-comment"></i> {{ $commentCount }} Comment{{ $commentCount != 1 ? 's' : '' }}</span>
+            <a class="btn" href="#comments"><i class="fas fa-comment"></i> {{ $commentCount }} Comment{{ $commentCount != 1 ? 's' : '' }}</a>
         </div>
     @endif
 </div>

--- a/resources/views/news/_news.blade.php
+++ b/resources/views/news/_news.blade.php
@@ -16,11 +16,11 @@
         ->count(); ?>
     @if (!$page)
         <div class="text-right mb-2 mr-2">
-            <a class="btn" href="{{ $news->url }}#comments"><i class="fas fa-comment"></i> {{ $commentCount }} Comment{{ $commentCount != 1 ? 's' : '' }}</a>
+            <a class="btn" href="{{ $news->url }}#comment-comments"><i class="fas fa-comment"></i> {{ $commentCount }} Comment{{ $commentCount != 1 ? 's' : '' }}</a>
         </div>
     @else
         <div class="text-right mb-2 mr-2">
-            <a class="btn" href="#comments"><i class="fas fa-comment"></i> {{ $commentCount }} Comment{{ $commentCount != 1 ? 's' : '' }}</a>
+            <a class="btn" href="#comment-comments"><i class="fas fa-comment"></i> {{ $commentCount }} Comment{{ $commentCount != 1 ? 's' : '' }}</a>
         </div>
     @endif
 </div>

--- a/resources/views/news/news.blade.php
+++ b/resources/views/news/news.blade.php
@@ -7,7 +7,7 @@
 @section('news-content')
     {!! breadcrumbs(['Site News' => 'news', $news->title => $news->url]) !!}
     @include('news._news', ['news' => $news, 'page' => true])
-    <hr class="mb-5" />
 
+    <hr class="mb-5" />
     @comments(['model' => $news, 'perPage' => 5])
 @endsection

--- a/resources/views/sales/_sales.blade.php
+++ b/resources/views/sales/_sales.blade.php
@@ -45,11 +45,11 @@
             ->count(); ?>
         @if (!$page)
             <div class="text-right mb-2 mr-2">
-                <a class="btn" href="{{ $sales->url }}#comments"><i class="fas fa-comment"></i> {{ $commentCount }} Comment{{ $commentCount != 1 ? 's' : '' }}</a>
+                <a class="btn" href="{{ $sales->url }}#comment-comments"><i class="fas fa-comment"></i> {{ $commentCount }} Comment{{ $commentCount != 1 ? 's' : '' }}</a>
             </div>
         @else
             <div class="text-right mb-2 mr-2">
-                <a class="btn" href="#comments"><i class="fas fa-comment"></i> {{ $commentCount }} Comment{{ $commentCount != 1 ? 's' : '' }}</a>
+                <a class="btn" href="#comment-comments"><i class="fas fa-comment"></i> {{ $commentCount }} Comment{{ $commentCount != 1 ? 's' : '' }}</a>
             </div>
         @endif
     @endif

--- a/resources/views/sales/_sales.blade.php
+++ b/resources/views/sales/_sales.blade.php
@@ -45,11 +45,11 @@
             ->count(); ?>
         @if (!$page)
             <div class="text-right mb-2 mr-2">
-                <a class="btn" href="{{ $sales->url }}#commentsSection"><i class="fas fa-comment"></i> {{ $commentCount }} Comment{{ $commentCount != 1 ? 's' : '' }}</a>
+                <a class="btn" href="{{ $sales->url }}#comments"><i class="fas fa-comment"></i> {{ $commentCount }} Comment{{ $commentCount != 1 ? 's' : '' }}</a>
             </div>
         @else
             <div class="text-right mb-2 mr-2">
-                <a class="btn" href="#commentsSection"><i class="fas fa-comment"></i> {{ $commentCount }} Comment{{ $commentCount != 1 ? 's' : '' }}</a>
+                <a class="btn" href="#comments"><i class="fas fa-comment"></i> {{ $commentCount }} Comment{{ $commentCount != 1 ? 's' : '' }}</a>
             </div>
         @endif
     @endif

--- a/resources/views/sales/sales.blade.php
+++ b/resources/views/sales/sales.blade.php
@@ -8,7 +8,7 @@
     {!! breadcrumbs(['Site Sales' => 'sales', $sales->title => $sales->url]) !!}
     @include('sales._sales', ['sales' => $sales, 'page' => true])
 
-    <hr class="mb-5" id="commentsSection" />
+    <hr class="mb-5" />
     @if ((isset($sales->comments_open_at) && $sales->comments_open_at < Carbon\Carbon::now()) || (Auth::check() && (Auth::user()->hasPower('manage_sales') || Auth::user()->hasPower('comment_on_sales'))) || !isset($sales->comments_open_at))
         @comments(['model' => $sales, 'perPage' => 5])
     @else


### PR DESCRIPTION
Each comments block has the id of 'comments', so a specific commentsSection anchor id is no longer necessary.

Then figured I'd update the news side as well, to be more consistent with sales.