### PR TITLE
feat(comments): Add first time flag for page load

### DIFF
--- a/resources/views/comments/comments.blade.php
+++ b/resources/views/comments/comments.blade.php
@@ -92,6 +92,8 @@
                 target_list: false
             });
 
+            var firstTime = 1;
+
             function sortComments() {
                 $('#comments').fadeOut();
                 $.ajax({
@@ -110,8 +112,12 @@
                         $('#comments').html(data);
                         // update current url to reflect sort change
                         var url = new URL(window.location.href);
-                        url.searchParams.set('sort', $('#sort').val());
-                        url.searchParams.set('perPage', $('#perPage').val());
+                        if (firstTime != 1) {
+                            url.searchParams.set('sort', $('#sort').val());
+                            url.searchParams.set('perPage', $('#perPage').val());
+                        } else {
+                            firstTime = 0;
+                        }
 
                         window.history.pushState({}, '', url);
                         $('#comments').fadeIn();

--- a/resources/views/comments/comments.blade.php
+++ b/resources/views/comments/comments.blade.php
@@ -115,11 +115,12 @@
                         if (firstTime != 1) {
                             url.searchParams.set('sort', $('#sort').val());
                             url.searchParams.set('perPage', $('#perPage').val());
+                            
+                            window.history.pushState({}, '', url);
                         } else {
                             firstTime = 0;
                         }
 
-                        window.history.pushState({}, '', url);
                         $('#comments').fadeIn();
                     }
                 });

--- a/resources/views/comments/comments.blade.php
+++ b/resources/views/comments/comments.blade.php
@@ -115,7 +115,7 @@
                         if (firstTime != 1) {
                             url.searchParams.set('sort', $('#sort').val());
                             url.searchParams.set('perPage', $('#perPage').val());
-                            
+
                             window.history.pushState({}, '', url);
                         } else {
                             firstTime = 0;


### PR DESCRIPTION
Some users on a site I administrate, as well as admittedly I myself, found it a bit annoying that every single page with comments had the url change instantly. It made a clean link one riddled with sort parameters, when the sorting wasn't even altered.

So I figured I'd make a simple first time flag. :)