### PR TITLE
Fix multiple comment display & loading, multiple subtypes command

### DIFF
--- a/app/Console/Commands/ConvertCharacterSubtype.php
+++ b/app/Console/Commands/ConvertCharacterSubtype.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use App\Models\Character\CharacterImage;
 use App\Models\Character\CharacterImageSubtype;
+use App\Models\Character\CharacterDesignUpdate;
 use Illuminate\Console\Command;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
@@ -46,11 +47,11 @@ class ConvertCharacterSubtype extends Command {
             }
 
             // DESIGN UPDATES
-            $updates = DB::table('design_updates')->where('subtype_id', '!=', null)->get();
+            $updates = CharacterDesignUpdate::where('subtype_id', '!=', null)->get();
             // make the string into an array
             foreach ($updates as $update) {
                 $update->update([
-                    'subtype_ids' => json_encode([$update->subtype_ids]),
+                    'subtype_ids' => $update->subtype_id,
                 ]);
             }
             Schema::table('design_updates', function (Blueprint $table) {

--- a/app/Console/Commands/ConvertCharacterSubtype.php
+++ b/app/Console/Commands/ConvertCharacterSubtype.php
@@ -2,12 +2,11 @@
 
 namespace App\Console\Commands;
 
+use App\Models\Character\CharacterDesignUpdate;
 use App\Models\Character\CharacterImage;
 use App\Models\Character\CharacterImageSubtype;
-use App\Models\Character\CharacterDesignUpdate;
 use Illuminate\Console\Command;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 class ConvertCharacterSubtype extends Command {

--- a/resources/views/comments/_comments.blade.php
+++ b/resources/views/comments/_comments.blade.php
@@ -1,4 +1,4 @@
-<div id="comments">
+<div>
     <div class="d-flex mw-100 row mx-0" style="overflow:hidden;">
         @php
             $comments = isset($sort) && $sort == 'oldest' ? $comments->sortBy('created_at') : $comments->sortByDesc('created_at');

--- a/resources/views/comments/comments.blade.php
+++ b/resources/views/comments/comments.blade.php
@@ -33,7 +33,7 @@
                             'newest' => 'Newest First',
                             'oldest' => 'Oldest First',
                         ],
-                        Request::get('sort') ?: 'newest',
+                        Request::get($commentType . '-sort') ?: 'newest',
                         ['class' => 'form-control', 'id' => $commentType.'-sort'],
                     ) !!}
                 </div>
@@ -47,7 +47,7 @@
                             50 => '50 Per Page',
                             100 => '100 Per Page',
                         ],
-                        Request::get('perPage') ?: 5,
+                        Request::get($commentType . '-perPage') ?: 5,
                         ['class' => 'form-control', 'id' => $commentType.'-perPage'],
                     ) !!}
                 </div>
@@ -113,7 +113,10 @@
                     success: function(data) {
                         $('#{{ $commentType }}-comments').html(data);
                         // update current url to reflect sort change
-                        if ($('#{{ $commentType }}-sort').val() != 'newest' && $('#{{ $commentType }}-perPage').val() != 5) { // don't add to url if default
+                        if (
+                            ($('#{{ $commentType }}-sort').val() != 'newest' && $('#{{ $commentType }}-perPage').val() != 5) ||
+                            (window.location.href.indexOf('{{ $commentType }}-sort') != -1 || window.location.href.indexOf('{{ $commentType }}-perPage') != -1)
+                        ) { // don't add to url if default
                             var url = new URL(window.location.href);
                             url.searchParams.set('{{ $commentType }}-sort', $('#{{ $commentType }}-sort').val());
                             url.searchParams.set('{{ $commentType }}-perPage', $('#{{ $commentType }}-perPage').val());

--- a/resources/views/comments/comments.blade.php
+++ b/resources/views/comments/comments.blade.php
@@ -12,6 +12,10 @@
             $comments = $model->commentz->where('type', 'User-User');
         }
     }
+
+    if (!isset($commentType)) {
+        $commentType = 'comment';
+    }
 @endphp
 
 @if (!isset($type) || $type == 'User-User')
@@ -30,7 +34,7 @@
                             'oldest' => 'Oldest First',
                         ],
                         Request::get('sort') ?: 'newest',
-                        ['class' => 'form-control', 'id' => 'sort'],
+                        ['class' => 'form-control', 'id' => $commentType.'-sort'],
                     ) !!}
                 </div>
                 <div class="form-group ml-3 mb-3">
@@ -44,14 +48,14 @@
                             100 => '100 Per Page',
                         ],
                         Request::get('perPage') ?: 5,
-                        ['class' => 'form-control', 'id' => 'perPage'],
+                        ['class' => 'form-control', 'id' => $commentType.'-perPage'],
                     ) !!}
                 </div>
             </div>
         </div>
     </div>
 @endif
-<div id="comments">
+<div id="{{ $commentType }}-comments">
     <div class="justify-content-center text-center mb-2">
         <i class="fas fa-spinner fa-spin fa-2x"></i>
     </div>
@@ -93,7 +97,7 @@
             });
 
             function sortComments() {
-                $('#comments').fadeOut();
+                $('#{{ $commentType }}-comments').fadeOut();
                 $.ajax({
                     url: "{{ url('sort-comments/' . base64_encode(urlencode(get_class($model))) . '/' . $model->getKey()) }}",
                     type: 'GET',
@@ -102,28 +106,30 @@
                         allow_dislikes: '{{ isset($allow_dislikes) ? $allow_dislikes : false }}',
                         approved: '{{ isset($approved) ? $approved : false }}',
                         type: '{{ isset($type) ? $type : null }}',
-                        sort: $('#sort').val(),
-                        perPage: $('#perPage').val(),
+                        sort: $('#{{ $commentType }}-sort').val(),
+                        perPage: $('#{{ $commentType }}-perPage').val(),
                         page: '{{ request()->query('page') }}',
                     },
                     success: function(data) {
-                        $('#comments').html(data);
+                        $('#{{ $commentType }}-comments').html(data);
                         // update current url to reflect sort change
-                        var url = new URL(window.location.href);
-                        url.searchParams.set('sort', $('#sort').val());
-                        url.searchParams.set('perPage', $('#perPage').val());
+                        if ($('#{{ $commentType }}-sort').val() != 'newest' && $('#{{ $commentType }}-perPage').val() != 5) { // don't add to url if default
+                            var url = new URL(window.location.href);
+                            url.searchParams.set('{{ $commentType }}-sort', $('#{{ $commentType }}-sort').val());
+                            url.searchParams.set('{{ $commentType }}-perPage', $('#{{ $commentType }}-perPage').val());
 
-                        window.history.pushState({}, '', url);
-                        $('#comments').fadeIn();
+                            window.history.pushState({}, '', url);
+                        }
+                        $('#{{ $commentType }}-comments').fadeIn();
                     }
                 });
             }
 
-            $('#sort').change(function() {
+            $('#{{ $commentType }}-sort').change(function() {
                 sortComments();
             });
 
-            $('#perPage').change(function() {
+            $('#{{ $commentType }}-perPage').change(function() {
                 sortComments();
             });
 

--- a/resources/views/comments/comments.blade.php
+++ b/resources/views/comments/comments.blade.php
@@ -34,7 +34,7 @@
                             'oldest' => 'Oldest First',
                         ],
                         Request::get($commentType . '-sort') ?: 'newest',
-                        ['class' => 'form-control', 'id' => $commentType.'-sort'],
+                        ['class' => 'form-control', 'id' => $commentType . '-sort'],
                     ) !!}
                 </div>
                 <div class="form-group ml-3 mb-3">
@@ -48,7 +48,7 @@
                             100 => '100 Per Page',
                         ],
                         Request::get($commentType . '-perPage') ?: 5,
-                        ['class' => 'form-control', 'id' => $commentType.'-perPage'],
+                        ['class' => 'form-control', 'id' => $commentType . '-perPage'],
                     ) !!}
                 </div>
             </div>

--- a/resources/views/galleries/submission_log.blade.php
+++ b/resources/views/galleries/submission_log.blade.php
@@ -207,7 +207,7 @@
                     <div class="card-body">
                         <!-- Staff-User Comments -->
                         <div class="container">
-                            @comments(['model' => $submission, 'type' => 'Staff-Staff', 'perPage' => 5])
+                            @comments(['model' => $submission, 'type' => 'Staff-Staff', 'perPage' => 5, 'commentType' => 'staff'])
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
updates subtypes command to use the orm so `update` can be used
makes it so initial load on comments doesn't modify URL, since that's the default URL state anyway
allows multiple comment instances to exist on one page (gallery approval for example)

thanks to @SpeedyD for pointing these out to me!