### PR TITLE
change Admin Logs from 'logs' to 'admin-logs'

### DIFF
--- a/config/lorekeeper/admin_sidebar.php
+++ b/config/lorekeeper/admin_sidebar.php
@@ -23,7 +23,7 @@ return [
             ],
             [
                 'name' => 'Admin Logs',
-                'url'  => 'admin/logs',
+                'url'  => 'admin/admin-logs',
             ],
             [
                 'name' => 'Staff Reward Settings',

--- a/routes/lorekeeper/admin.php
+++ b/routes/lorekeeper/admin.php
@@ -11,7 +11,7 @@
 
 Route::get('/', 'HomeController@getIndex');
 
-Route::get('logs', 'HomeController@getLogs');
+Route::get('admin-logs', 'HomeController@getLogs');
 Route::group(['middleware' => 'admin'], function () {
     Route::get('staff-reward-settings', 'HomeController@getStaffRewardSettings');
     Route::post('staff-reward-settings/{key}', 'HomeController@postEditStaffRewardSetting');


### PR DESCRIPTION
with the recent addition of the Log Viewer, Admin Logs became inaccessible due to duplication (both 'logs')
changed Admin Logs to 'admin-logs' to resolve this conflict