### PR TITLE
fix(world): Reverse trait index showSubtype check removal

### DIFF
--- a/resources/views/world/_features_index.blade.php
+++ b/resources/views/world/_features_index.blade.php
@@ -22,7 +22,7 @@
                                         <i class="fas fa-eye-slash mr-1"></i>
                                     @endif
                                     {!! $feature->first()->displayName !!}
-                                    @if ($feature->first()->subtype)
+                                    @if ($showSubtype && $feature->first()->subtype)
                                         <br />({!! $feature->first()->subtype->displayName !!} Subtype)
                                     @endif
                                 </p>


### PR DESCRIPTION
This variable has been added when I merged the index code, because the Species index shows subtypes- but the other indexes do not.

I can only assume this check was accidentally removed as other code pertaining this variable are still there.