### PR TITLE
bug fix: updating character slug

### DIFF
--- a/app/Services/CharacterManager.php
+++ b/app/Services/CharacterManager.php
@@ -1126,7 +1126,7 @@ class CharacterManager extends Service {
                     $old['number'] = $character->number;
                     $new['number'] = $characterData['number'];
                 }
-                if ($characterData['slug'] != $character->number) {
+                if ($characterData['slug'] != $character->slug) {
                     $result[] = 'character code';
                     $old['slug'] = $character->slug;
                     $new['slug'] = $characterData['slug'];


### PR DESCRIPTION
the slug submitted via edit_stats_modal was being compared to the character's number rather than its slug, thus logging a slug update when saved even when slug was not edited. just a quick fix :)