### PR TITLE
Fix: Missing closing tag

### DIFF
--- a/app/Services/TradeManager.php
+++ b/app/Services/TradeManager.php
@@ -691,7 +691,7 @@ class TradeManager extends Service {
                         if (!$currency) {
                             throw new \Exception('Cannot credit an invalid currency. ('.$currencyId.')');
                         }
-                        if (!$currencyManager->creditCurrency($trade->{$type}, $trade->{$recipientType}, 'Trade', 'Received in trade [<a href="'.$trade->url.'">#'.$trade->id.']', $currency, $quantity)) {
+                        if (!$currencyManager->creditCurrency($trade->{$type}, $trade->{$recipientType}, 'Trade', 'Received in trade [<a href="'.$trade->url.'">#'.$trade->id.'</a>]', $currency, $quantity)) {
                             throw new \Exception('Could not credit currency. ('.$currencyId.')');
                         }
                     }


### PR DESCRIPTION
Said in title, a missing `</a>` was messing with currency logs, unsure if it can be applied retroactively but it behaves correctly now.