### PR TITLE
prevent throttling on different links

### DIFF
--- a/app/Http/Middleware/PostRequestThrottleMiddleware.php
+++ b/app/Http/Middleware/PostRequestThrottleMiddleware.php
@@ -16,11 +16,15 @@ class PostRequestThrottleMiddleware {
      * @param \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response) $next
      */
     public function handle(Request $request, Closure $next): Response {
-        if ($request->isMethod('get')) {
+        $allowedRoutes = [
+            'admin/*',
+        ];
+        if ($request->isMethod('get') || $request->is(...$allowedRoutes)) {
             return $next($request);
         }
 
         $key = $request->user()?->id ?: $request->ip();
+        $key .= $request->fullUrl(); // add current url to key to prevent rate limiting on different pages
         $maxAttempts = 1;
         $decaySeconds = 10;
 


### PR DESCRIPTION
adds a url to the throttle key so users arent limited from preforming different actions
also adds an exemption to admin routes

**why?**
- this feature is intended to stop spamming, a blanket limit (especially at 10 seconds) can be inhibiting on a click / request heaving application like lorekeeper
- admin routes have similar reasoning to the above, and are at lower risk of spamming being an issue