### PR TITLE
Feat: Default character rewards in prompts

### DIFF
--- a/app/Helpers/AssetHelpers.php
+++ b/app/Helpers/AssetHelpers.php
@@ -254,6 +254,7 @@ function getDataReadyAssets($array, $isCharacter = false) {
  * Use the data attribute after json_decode()ing it.
  *
  * @param array $array
+ * @param mixed $isCharacter
  *
  * @return array
  */

--- a/app/Helpers/AssetHelpers.php
+++ b/app/Helpers/AssetHelpers.php
@@ -171,11 +171,12 @@ function createAssetsArray($isCharacter = false) {
  *
  * @param array $first
  * @param array $second
+ * @param mixed $isCharacter
  *
  * @return array
  */
-function mergeAssetsArrays($first, $second) {
-    $keys = getAssetKeys();
+function mergeAssetsArrays($first, $second, $isCharacter = false) {
+    $keys = getAssetKeys($isCharacter);
     foreach ($keys as $key) {
         foreach ($second[$key] as $item) {
             addAsset($first, $item['asset'], $item['quantity']);
@@ -256,8 +257,8 @@ function getDataReadyAssets($array, $isCharacter = false) {
  *
  * @return array
  */
-function parseAssetData($array) {
-    $assets = createAssetsArray();
+function parseAssetData($array, $isCharacter = false) {
+    $assets = createAssetsArray($isCharacter);
     foreach ($array as $key => $contents) {
         $model = getAssetModelString($key);
         if ($model) {

--- a/app/Http/Controllers/Admin/Data/PromptController.php
+++ b/app/Http/Controllers/Admin/Data/PromptController.php
@@ -210,7 +210,7 @@ class PromptController extends Controller {
     public function postCreateEditPrompt(Request $request, PromptService $service, $id = null) {
         $id ? $request->validate(Prompt::$updateRules) : $request->validate(Prompt::$createRules);
         $data = $request->only([
-            'name', 'prompt_category_id', 'summary', 'description', 'start_at', 'end_at', 'hide_before_start', 'hide_after_end', 'is_active', 'rewardable_type', 'rewardable_id', 'quantity', 'image', 'remove_image', 'prefix', 'hide_submissions', 'staff_only',
+            'name', 'prompt_category_id', 'summary', 'description', 'start_at', 'end_at', 'hide_before_start', 'hide_after_end', 'is_active', 'rewardable_type', 'rewardable_id', 'quantity', 'image', 'remove_image', 'prefix', 'hide_submissions', 'staff_only', 'character_rewardable_type', 'character_rewardable_id', 'character_quantity',
         ]);
         if ($id && $service->updatePrompt(Prompt::find($id), $data, Auth::user())) {
             flash('Prompt updated successfully.')->success();

--- a/app/Http/Controllers/Admin/SubmissionController.php
+++ b/app/Http/Controllers/Admin/SubmissionController.php
@@ -152,7 +152,7 @@ class SubmissionController extends Controller {
      * @return \Illuminate\Http\RedirectResponse
      */
     public function postSubmission(Request $request, SubmissionManager $service, $id, $action) {
-        $data = $request->only(['slug',  'character_rewardable_quantity', 'character_rewardable_id',  'character_rewardable_type', 'character_currency_id', 'rewardable_type', 'rewardable_id', 'quantity', 'staff_comments','character_is_focus']);
+        $data = $request->only(['slug',  'character_rewardable_quantity', 'character_rewardable_id',  'character_rewardable_type', 'character_currency_id', 'rewardable_type', 'rewardable_id', 'quantity', 'staff_comments', 'character_is_focus']);
         if ($action == 'reject' && $service->rejectSubmission($request->only(['staff_comments']) + ['id' => $id], Auth::user())) {
             flash('Submission rejected successfully.')->success();
         } elseif ($action == 'cancel' && $service->cancelSubmission($request->only(['staff_comments']) + ['id' => $id], Auth::user())) {

--- a/app/Http/Controllers/Admin/SubmissionController.php
+++ b/app/Http/Controllers/Admin/SubmissionController.php
@@ -152,7 +152,7 @@ class SubmissionController extends Controller {
      * @return \Illuminate\Http\RedirectResponse
      */
     public function postSubmission(Request $request, SubmissionManager $service, $id, $action) {
-        $data = $request->only(['slug',  'character_rewardable_quantity', 'character_rewardable_id',  'character_rewardable_type', 'character_currency_id', 'rewardable_type', 'rewardable_id', 'quantity', 'staff_comments']);
+        $data = $request->only(['slug',  'character_rewardable_quantity', 'character_rewardable_id',  'character_rewardable_type', 'character_currency_id', 'rewardable_type', 'rewardable_id', 'quantity', 'staff_comments','character_is_focus']);
         if ($action == 'reject' && $service->rejectSubmission($request->only(['staff_comments']) + ['id' => $id], Auth::user())) {
             flash('Submission rejected successfully.')->success();
         } elseif ($action == 'cancel' && $service->cancelSubmission($request->only(['staff_comments']) + ['id' => $id], Auth::user())) {

--- a/app/Http/Controllers/Users/SubmissionController.php
+++ b/app/Http/Controllers/Users/SubmissionController.php
@@ -212,7 +212,7 @@ class SubmissionController extends Controller {
             $request->only([
                 'url', 'prompt_id', 'comments', 'slug', 'character_rewardable_type', 'character_rewardable_id', 'character_rewardable_quantity',
                 'rewardable_type', 'rewardable_id', 'quantity', 'stack_id', 'stack_quantity', 'currency_id', 'currency_quantity',
-                'gallery_submission_id',
+                'gallery_submission_id','character_is_focus'
             ]),
             Auth::user(),
             false,
@@ -257,13 +257,13 @@ class SubmissionController extends Controller {
         if ($submit && $service->editSubmission($submission, $request->only([
             'url', 'prompt_id', 'comments', 'slug', 'character_rewardable_type', 'character_rewardable_id', 'character_rewardable_quantity',
             'rewardable_type', 'rewardable_id', 'quantity', 'stack_id', 'stack_quantity', 'currency_id', 'currency_quantity',
-            'gallery_submission_id',
+            'gallery_submission_id','character_is_focus'
         ]), Auth::user(), false, $submit)) {
             flash('Draft submitted successfully.')->success();
         } elseif ($service->editSubmission($submission, $request->only([
             'url', 'prompt_id', 'comments', 'slug', 'character_rewardable_type', 'character_rewardable_id', 'character_rewardable_quantity',
             'rewardable_type', 'rewardable_id', 'quantity', 'stack_id', 'stack_quantity', 'currency_id', 'currency_quantity',
-            'gallery_submission_id',
+            'gallery_submission_id','character_is_focus'
         ]), Auth::user())) {
             flash('Draft saved successfully.')->success();
 

--- a/app/Http/Controllers/Users/SubmissionController.php
+++ b/app/Http/Controllers/Users/SubmissionController.php
@@ -212,7 +212,7 @@ class SubmissionController extends Controller {
             $request->only([
                 'url', 'prompt_id', 'comments', 'slug', 'character_rewardable_type', 'character_rewardable_id', 'character_rewardable_quantity',
                 'rewardable_type', 'rewardable_id', 'quantity', 'stack_id', 'stack_quantity', 'currency_id', 'currency_quantity',
-                'gallery_submission_id','character_is_focus'
+                'gallery_submission_id', 'character_is_focus',
             ]),
             Auth::user(),
             false,
@@ -257,13 +257,13 @@ class SubmissionController extends Controller {
         if ($submit && $service->editSubmission($submission, $request->only([
             'url', 'prompt_id', 'comments', 'slug', 'character_rewardable_type', 'character_rewardable_id', 'character_rewardable_quantity',
             'rewardable_type', 'rewardable_id', 'quantity', 'stack_id', 'stack_quantity', 'currency_id', 'currency_quantity',
-            'gallery_submission_id','character_is_focus'
+            'gallery_submission_id', 'character_is_focus',
         ]), Auth::user(), false, $submit)) {
             flash('Draft submitted successfully.')->success();
         } elseif ($service->editSubmission($submission, $request->only([
             'url', 'prompt_id', 'comments', 'slug', 'character_rewardable_type', 'character_rewardable_id', 'character_rewardable_quantity',
             'rewardable_type', 'rewardable_id', 'quantity', 'stack_id', 'stack_quantity', 'currency_id', 'currency_quantity',
-            'gallery_submission_id','character_is_focus'
+            'gallery_submission_id', 'character_is_focus',
         ]), Auth::user())) {
             flash('Draft saved successfully.')->success();
 

--- a/app/Models/Prompt/Prompt.php
+++ b/app/Models/Prompt/Prompt.php
@@ -79,7 +79,14 @@ class Prompt extends Model {
      * Get the rewards attached to this prompt.
      */
     public function rewards() {
-        return $this->hasMany(PromptReward::class, 'prompt_id');
+        return $this->hasMany(PromptReward::class, 'prompt_id')->where('earner_type', 'User');
+    }
+
+    /**
+     * Get the character rewards attached to this prompt.
+     */
+    public function characterRewards() {
+        return $this->hasMany(PromptReward::class, 'prompt_id')->where('earner_type', 'Character');
     }
 
     /**********************************************************************************************

--- a/app/Models/Prompt/PromptReward.php
+++ b/app/Models/Prompt/PromptReward.php
@@ -15,7 +15,7 @@ class PromptReward extends Model {
      * @var array
      */
     protected $fillable = [
-        'prompt_id', 'rewardable_type', 'rewardable_id', 'quantity','earner_type'
+        'prompt_id', 'rewardable_type', 'rewardable_id', 'quantity', 'earner_type',
     ];
 
     /**

--- a/app/Models/Prompt/PromptReward.php
+++ b/app/Models/Prompt/PromptReward.php
@@ -15,7 +15,7 @@ class PromptReward extends Model {
      * @var array
      */
     protected $fillable = [
-        'prompt_id', 'rewardable_type', 'rewardable_id', 'quantity',
+        'prompt_id', 'rewardable_type', 'rewardable_id', 'quantity','earner_type'
     ];
 
     /**

--- a/app/Models/Submission/SubmissionCharacter.php
+++ b/app/Models/Submission/SubmissionCharacter.php
@@ -12,7 +12,7 @@ class SubmissionCharacter extends Model {
      * @var array
      */
     protected $fillable = [
-        'submission_id', 'character_id', 'data','is_focus'
+        'submission_id', 'character_id', 'data', 'is_focus',
     ];
 
     /**

--- a/app/Models/Submission/SubmissionCharacter.php
+++ b/app/Models/Submission/SubmissionCharacter.php
@@ -12,7 +12,7 @@ class SubmissionCharacter extends Model {
      * @var array
      */
     protected $fillable = [
-        'submission_id', 'character_id', 'data',
+        'submission_id', 'character_id', 'data','is_focus'
     ];
 
     /**

--- a/app/Services/PromptService.php
+++ b/app/Services/PromptService.php
@@ -384,10 +384,10 @@ class PromptService extends Service {
         if (isset($data['rewardable_type'])) {
             foreach ($data['rewardable_type'] as $key => $type) {
                 PromptReward::create([
-                    'prompt_id'       => $prompt->id,
-                    'rewardable_type' => $type,
-                    'rewardable_id'   => $data['rewardable_id'][$key],
-                    'quantity'        => $data['quantity'][$key],
+                    'prompt_id'          => $prompt->id,
+                    'rewardable_type'    => $type,
+                    'rewardable_id'      => $data['rewardable_id'][$key],
+                    'quantity'           => $data['quantity'][$key],
                     'earner_type'        => 'User',
                 ]);
             }
@@ -396,10 +396,10 @@ class PromptService extends Service {
         if (isset($data['character_rewardable_type'])) {
             foreach ($data['character_rewardable_type'] as $key => $type) {
                 PromptReward::create([
-                    'prompt_id'       => $prompt->id,
-                    'rewardable_type' => $type,
-                    'rewardable_id'   => $data['character_rewardable_id'][$key],
-                    'quantity'        => $data['character_quantity'][$key],
+                    'prompt_id'          => $prompt->id,
+                    'rewardable_type'    => $type,
+                    'rewardable_id'      => $data['character_rewardable_id'][$key],
+                    'quantity'           => $data['character_quantity'][$key],
                     'earner_type'        => 'Character',
                 ]);
             }

--- a/app/Services/PromptService.php
+++ b/app/Services/PromptService.php
@@ -208,7 +208,7 @@ class PromptService extends Service {
                 $this->handleImage($image, $prompt->imagePath, $prompt->imageFileName);
             }
 
-            $this->populateRewards(Arr::only($data, ['rewardable_type', 'rewardable_id', 'quantity']), $prompt);
+            $this->populateRewards(Arr::only($data, ['rewardable_type', 'rewardable_id', 'quantity', 'character_rewardable_type', 'character_rewardable_id', 'character_quantity']), $prompt);
 
             return $this->commitReturn($prompt);
         } catch (\Exception $e) {
@@ -266,7 +266,7 @@ class PromptService extends Service {
                 $this->handleImage($image, $prompt->imagePath, $prompt->imageFileName);
             }
 
-            $this->populateRewards(Arr::only($data, ['rewardable_type', 'rewardable_id', 'quantity']), $prompt);
+            $this->populateRewards(Arr::only($data, ['rewardable_type', 'rewardable_id', 'quantity', 'character_rewardable_type', 'character_rewardable_id', 'character_quantity']), $prompt);
 
             return $this->commitReturn($prompt);
         } catch (\Exception $e) {
@@ -293,6 +293,7 @@ class PromptService extends Service {
             }
 
             $prompt->rewards()->delete();
+            $prompt->characterRewards()->delete();
             if ($prompt->has_image) {
                 $this->deleteImage($prompt->imagePath, $prompt->imageFileName);
             }
@@ -378,6 +379,7 @@ class PromptService extends Service {
     private function populateRewards($data, $prompt) {
         // Clear the old rewards...
         $prompt->rewards()->delete();
+        $prompt->characterRewards()->delete();
 
         if (isset($data['rewardable_type'])) {
             foreach ($data['rewardable_type'] as $key => $type) {
@@ -386,6 +388,19 @@ class PromptService extends Service {
                     'rewardable_type' => $type,
                     'rewardable_id'   => $data['rewardable_id'][$key],
                     'quantity'        => $data['quantity'][$key],
+                    'earner_type'        => 'User',
+                ]);
+            }
+        }
+
+        if (isset($data['character_rewardable_type'])) {
+            foreach ($data['character_rewardable_type'] as $key => $type) {
+                PromptReward::create([
+                    'prompt_id'       => $prompt->id,
+                    'rewardable_type' => $type,
+                    'rewardable_id'   => $data['character_rewardable_id'][$key],
+                    'quantity'        => $data['character_quantity'][$key],
+                    'earner_type'        => 'Character',
                 ]);
             }
         }

--- a/app/Services/SubmissionManager.php
+++ b/app/Services/SubmissionManager.php
@@ -18,8 +18,7 @@ use Carbon\Carbon;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 
-class SubmissionManager extends Service
-{
+class SubmissionManager extends Service {
     /*
     |--------------------------------------------------------------------------
     | Submission Manager
@@ -39,8 +38,7 @@ class SubmissionManager extends Service
      *
      * @return mixed
      */
-    public function createSubmission($data, $user, $isClaim = false, $isDraft = false)
-    {
+    public function createSubmission($data, $user, $isClaim = false, $isDraft = false) {
         DB::beginTransaction();
 
         try {
@@ -70,11 +68,11 @@ class SubmissionManager extends Service
 
             // Create the submission itself.
             $submission = Submission::create([
-                'user_id' => $user->id,
-                'url' => $data['url'] ?? null,
-                'status' => $isDraft ? 'Draft' : 'Pending',
+                'user_id'  => $user->id,
+                'url'      => $data['url'] ?? null,
+                'status'   => $isDraft ? 'Draft' : 'Pending',
                 'comments' => $data['comments'],
-                'data' => null,
+                'data'     => null,
             ] + ($isClaim ? [] : [
                 'prompt_id' => $prompt->id,
             ]));
@@ -86,7 +84,7 @@ class SubmissionManager extends Service
 
             $submission->update([
                 'data' => json_encode([
-                    'user' => Arr::only(getDataReadyAssets($userAssets), ['user_items', 'currencies']),
+                    'user'    => Arr::only(getDataReadyAssets($userAssets), ['user_items', 'currencies']),
                     'rewards' => getDataReadyAssets($promptRewards),
                 ] + (config('lorekeeper.settings.allow_gallery_submissions_on_prompts') ? ['gallery_submission_id' => $data['gallery_submission_id'] ?? null] : [])),
             ]);
@@ -113,8 +111,7 @@ class SubmissionManager extends Service
      *
      * @return mixed
      */
-    public function editSubmission($submission, $data, $user, $isClaim = false, $isSubmit = false)
-    {
+    public function editSubmission($submission, $data, $user, $isClaim = false, $isSubmit = false) {
         DB::beginTransaction();
 
         try {
@@ -155,11 +152,11 @@ class SubmissionManager extends Service
 
             // Modify submission
             $submission->update([
-                'url' => $data['url'] ?? null,
+                'url'        => $data['url'] ?? null,
                 'updated_at' => Carbon::now(),
-                'comments' => $data['comments'],
-                'data' => json_encode([
-                    'user' => Arr::only(getDataReadyAssets($userAssets), ['user_items', 'currencies']),
+                'comments'   => $data['comments'],
+                'data'       => json_encode([
+                    'user'    => Arr::only(getDataReadyAssets($userAssets), ['user_items', 'currencies']),
                     'rewards' => getDataReadyAssets($promptRewards),
                 ] + (config('lorekeeper.settings.allow_gallery_submissions_on_prompts') ? ['gallery_submission_id' => $data['gallery_submission_id'] ?? null] : [])),
             ] + ($isClaim ? [] : ['prompt_id' => $prompt->id]));
@@ -178,8 +175,7 @@ class SubmissionManager extends Service
      * @param mixed $data the submission data
      * @param mixed $user the user performing the cancellation
      */
-    public function cancelSubmission($data, $user)
-    {
+    public function cancelSubmission($data, $user) {
         DB::beginTransaction();
 
         try {
@@ -221,31 +217,31 @@ class SubmissionManager extends Service
                 // 2. staff ID
                 // 3. status
                 $submission->update([
-                    'staff_comments' => $data['staff_comments'],
+                    'staff_comments'        => $data['staff_comments'],
                     'parsed_staff_comments' => $data['parsed_staff_comments'],
-                    'updated_at' => Carbon::now(),
-                    'staff_id' => $user->id,
-                    'status' => 'Draft',
-                    'data' => json_encode([
-                        'user' => $userAssets,
-                        'rewards' => getDataReadyAssets($promptRewards),
+                    'updated_at'            => Carbon::now(),
+                    'staff_id'              => $user->id,
+                    'status'                => 'Draft',
+                    'data'                  => json_encode([
+                        'user'                  => $userAssets,
+                        'rewards'               => getDataReadyAssets($promptRewards),
                         'gallery_submission_id' => $submission->data['gallery_submission_id'] ?? null,
                     ]), // list of rewards and addons
                 ]);
 
                 Notifications::create($submission->prompt_id ? 'SUBMISSION_CANCELLED' : 'CLAIM_CANCELLED', $submission->user, [
-                    'staff_url' => $user->url,
-                    'staff_name' => $user->name,
+                    'staff_url'     => $user->url,
+                    'staff_name'    => $user->name,
                     'submission_id' => $submission->id,
                 ]);
             } else {
                 // This is when a user cancels their own submission back into draft form
                 $submission->update([
-                    'status' => 'Draft',
+                    'status'     => 'Draft',
                     'updated_at' => Carbon::now(),
-                    'data' => json_encode([
-                        'user' => $userAssets,
-                        'rewards' => getDataReadyAssets($promptRewards),
+                    'data'       => json_encode([
+                        'user'                  => $userAssets,
+                        'rewards'               => getDataReadyAssets($promptRewards),
                         'gallery_submission_id' => $submission->data['gallery_submission_id'] ?? null,
                     ]), // list of rewards and addons
                 ]);
@@ -267,8 +263,7 @@ class SubmissionManager extends Service
      *
      * @return mixed
      */
-    public function rejectSubmission($data, $user)
-    {
+    public function rejectSubmission($data, $user) {
         DB::beginTransaction();
 
         try {
@@ -299,19 +294,19 @@ class SubmissionManager extends Service
             // 2. staff ID
             // 3. status
             $submission->update([
-                'staff_comments' => $data['staff_comments'],
+                'staff_comments'        => $data['staff_comments'],
                 'parsed_staff_comments' => $data['parsed_staff_comments'],
-                'staff_id' => $user->id,
-                'status' => 'Rejected',
+                'staff_id'              => $user->id,
+                'status'                => 'Rejected',
             ]);
 
             Notifications::create($submission->prompt_id ? 'SUBMISSION_REJECTED' : 'CLAIM_REJECTED', $submission->user, [
-                'staff_url' => $user->url,
-                'staff_name' => $user->name,
+                'staff_url'     => $user->url,
+                'staff_name'    => $user->name,
                 'submission_id' => $submission->id,
             ]);
 
-            if (!$this->logAdminAction($user, 'Submission Rejected', 'Rejected submission <a href="' . $submission->viewurl . '">#' . $submission->id . '</a>')) {
+            if (!$this->logAdminAction($user, 'Submission Rejected', 'Rejected submission <a href="'.$submission->viewurl.'">#'.$submission->id.'</a>')) {
                 throw new \Exception('Failed to log admin action.');
             }
 
@@ -331,8 +326,7 @@ class SubmissionManager extends Service
      *
      * @return mixed
      */
-    public function approveSubmission($data, $user)
-    {
+    public function approveSubmission($data, $user) {
         DB::beginTransaction();
 
         try {
@@ -351,10 +345,10 @@ class SubmissionManager extends Service
                 foreach ($addonData['user_items'] as $userItemId => $quantity) {
                     $userItemRow = UserItem::find($userItemId);
                     if (!$userItemRow) {
-                        throw new \Exception('Cannot return an invalid item. (' . $userItemId . ')');
+                        throw new \Exception('Cannot return an invalid item. ('.$userItemId.')');
                     }
                     if ($userItemRow->submission_count < $quantity) {
-                        throw new \Exception('Cannot return more items than was held. (' . $userItemId . ')');
+                        throw new \Exception('Cannot return more items than was held. ('.$userItemId.')');
                     }
                     $userItemRow->submission_count -= $quantity;
                     $userItemRow->save();
@@ -366,7 +360,7 @@ class SubmissionManager extends Service
                 foreach ($stacks as $stackId => $quantity) {
                     $stack = UserItem::find($stackId);
                     $user = User::find($submission->user_id);
-                    if (!$inventoryManager->debitStack($user, $submission->prompt_id ? 'Prompt Approved' : 'Claim Approved', ['data' => 'Item used in submission (<a href="' . $submission->viewUrl . '">#' . $submission->id . '</a>)'], $stack, $quantity)) {
+                    if (!$inventoryManager->debitStack($user, $submission->prompt_id ? 'Prompt Approved' : 'Claim Approved', ['data' => 'Item used in submission (<a href="'.$submission->viewUrl.'">#'.$submission->id.'</a>)'], $stack, $quantity)) {
                         throw new \Exception('Failed to create log for item stack.');
                     }
                 }
@@ -386,7 +380,7 @@ class SubmissionManager extends Service
                         null,
                         null,
                         $submission->prompt_id ? 'Prompt Approved' : 'Claim Approved',
-                        'Used in ' . ($submission->prompt_id ? 'prompt' : 'claim') . ' (<a href="' . $submission->viewUrl . '">#' . $submission->id . '</a>)',
+                        'Used in '.($submission->prompt_id ? 'prompt' : 'claim').' (<a href="'.$submission->viewUrl.'">#'.$submission->id.'</a>)',
                         $currencyId,
                         $quantity
                     )) {
@@ -414,7 +408,7 @@ class SubmissionManager extends Service
             // Logging data
             $promptLogType = $submission->prompt_id ? 'Prompt Rewards' : 'Claim Rewards';
             $promptData = [
-                'data' => 'Received rewards for ' . ($submission->prompt_id ? 'submission' : 'claim') . ' (<a href="' . $submission->viewUrl . '">#' . $submission->id . '</a>)',
+                'data' => 'Received rewards for '.($submission->prompt_id ? 'submission' : 'claim').' (<a href="'.$submission->viewUrl.'">#'.$submission->id.'</a>)',
             ];
 
             // Distribute user rewards
@@ -467,9 +461,9 @@ class SubmissionManager extends Service
                 }
 
                 SubmissionCharacter::create([
-                    'character_id' => $c->id,
+                    'character_id'  => $c->id,
                     'submission_id' => $submission->id,
-                    'data' => json_encode(getDataReadyAssets($assets)),
+                    'data'          => json_encode(getDataReadyAssets($assets)),
                 ]);
             }
 
@@ -491,24 +485,24 @@ class SubmissionManager extends Service
             // 3. status
             // 4. final rewards
             $submission->update([
-                'staff_comments' => $data['staff_comments'],
+                'staff_comments'        => $data['staff_comments'],
                 'parsed_staff_comments' => $data['parsed_staff_comments'],
-                'staff_id' => $user->id,
-                'status' => 'Approved',
-                'data' => json_encode([
-                    'user' => $addonData,
-                    'rewards' => getDataReadyAssets($rewards),
+                'staff_id'              => $user->id,
+                'status'                => 'Approved',
+                'data'                  => json_encode([
+                    'user'                  => $addonData,
+                    'rewards'               => getDataReadyAssets($rewards),
                     'gallery_submission_id' => $submission->data['gallery_submission_id'] ?? null,
                 ]), // list of rewards
             ]);
 
             Notifications::create($submission->prompt_id ? 'SUBMISSION_APPROVED' : 'CLAIM_APPROVED', $submission->user, [
-                'staff_url' => $user->url,
-                'staff_name' => $user->name,
+                'staff_url'     => $user->url,
+                'staff_name'    => $user->name,
                 'submission_id' => $submission->id,
             ]);
 
-            if (!$this->logAdminAction($user, 'Submission Approved', 'Approved submission <a href="' . $submission->viewurl . '">#' . $submission->id . '</a>')) {
+            if (!$this->logAdminAction($user, 'Submission Approved', 'Approved submission <a href="'.$submission->viewurl.'">#'.$submission->id.'</a>')) {
                 throw new \Exception('Failed to log admin action.');
             }
 
@@ -526,8 +520,7 @@ class SubmissionManager extends Service
      * @param mixed $data the data of the submission to be deleted
      * @param mixed $user the user performing the deletion
      */
-    public function deleteSubmission($data, $user)
-    {
+    public function deleteSubmission($data, $user) {
         DB::beginTransaction();
         try {
             // 1. check that the submission exists
@@ -572,8 +565,7 @@ class SubmissionManager extends Service
      *
      * @return array
      */
-    private function innerNull($value)
-    {
+    private function innerNull($value) {
         return array_values(array_filter($value));
     }
 
@@ -587,8 +579,7 @@ class SubmissionManager extends Service
      *
      * @return array
      */
-    private function processRewards($data, $isCharacter, $isStaff = false, $isClaim = false)
-    {
+    private function processRewards($data, $isCharacter, $isStaff = false, $isClaim = false) {
         if ($isCharacter) {
             $assets = createAssetsArray(true);
 
@@ -604,14 +595,14 @@ class SubmissionManager extends Service
                 foreach ($data['character_rewardable_id'][$data['character_id']] as $key => $reward) {
                     switch ($data['character_rewardable_type'][$data['character_id']][$key]) {
                         case 'Currency':if ($data['character_rewardable_quantity'][$data['character_id']][$key]) {
-                                addAsset($assets, $data['currencies'][$reward], $data['character_rewardable_quantity'][$data['character_id']][$key]);
-                            }break;
+                            addAsset($assets, $data['currencies'][$reward], $data['character_rewardable_quantity'][$data['character_id']][$key]);
+                        }break;
                         case 'Item':if ($data['character_rewardable_quantity'][$data['character_id']][$key]) {
-                                addAsset($assets, $data['items'][$reward], $data['character_rewardable_quantity'][$data['character_id']][$key]);
-                            }break;
+                            addAsset($assets, $data['items'][$reward], $data['character_rewardable_quantity'][$data['character_id']][$key]);
+                        }break;
                         case 'LootTable':if ($data['character_rewardable_quantity'][$data['character_id']][$key]) {
-                                addAsset($assets, $data['tables'][$reward], $data['character_rewardable_quantity'][$data['character_id']][$key]);
-                            }break;
+                            addAsset($assets, $data['tables'][$reward], $data['character_rewardable_quantity'][$data['character_id']][$key]);
+                        }break;
                     }
                 }
             }
@@ -670,8 +661,7 @@ class SubmissionManager extends Service
      * @param mixed $data       the data for creating the attachments
      * @param mixed $user       the user object
      */
-    private function createUserAttachments($submission, $data, $user)
-    {
+    private function createUserAttachments($submission, $data, $user) {
         $userAssets = createAssetsArray();
 
         // Attach items. Technically, the user doesn't lose ownership of the item - we're just adding an additional holding field.
@@ -729,7 +719,7 @@ class SubmissionManager extends Service
         $promptRewards = mergeAssetsArrays($promptRewards, $this->processRewards($data, false));
 
         return [
-            'userAssets' => $userAssets,
+            'userAssets'    => $userAssets,
             'promptRewards' => $promptRewards,
         ];
     }
@@ -739,8 +729,7 @@ class SubmissionManager extends Service
      *
      * @param mixed $submission the submission object
      */
-    private function removePromptAttachments($submission)
-    {
+    private function removePromptAttachments($submission) {
         $assets = $submission->data;
         // Get a list of rewards, then create the submission itself
         $promptRewards = createAssetsArray();
@@ -758,9 +747,9 @@ class SubmissionManager extends Service
      * Removes the attachments associated with a prompt from a submission.
      *
      * @param mixed $submission the submission object
+     * @param mixed $character
      */
-    private function removeCharacterPromptAttachments($submission, $character)
-    {
+    private function removeCharacterPromptAttachments($submission, $character) {
         $assets = $character->data;
         // Get a list of rewards, then create the submission itself
         $promptRewards = createAssetsArray(true);
@@ -780,8 +769,7 @@ class SubmissionManager extends Service
      * @param mixed $submission the submission object
      * @param mixed $data       the data for creating character attachments
      */
-    private function createCharacterAttachments($submission, $data)
-    {
+    private function createCharacterAttachments($submission, $data) {
         // The character identification comes in both the slug field and as character IDs
         // that key the reward ID/quantity arrays.
         // We'll need to match characters to the rewards for them.
@@ -847,10 +835,10 @@ class SubmissionManager extends Service
             // Now we have a clean set of assets (redundant data is gone, duplicate entries are merged)
             // so we can attach the character to the submission
             SubmissionCharacter::create([
-                'character_id' => $c->id,
+                'character_id'  => $c->id,
                 'submission_id' => $submission->id,
-                'data' => json_encode(getDataReadyAssets($assets)),
-                'is_focus' => isset($data['character_is_focus']) && $data['character_is_focus'][$c->id] ? $data['character_is_focus'][$c->id] : 0,
+                'data'          => json_encode(getDataReadyAssets($assets)),
+                'is_focus'      => isset($data['character_is_focus']) && $data['character_is_focus'][$c->id] ? $data['character_is_focus'][$c->id] : 0,
             ]);
         }
 
@@ -862,8 +850,7 @@ class SubmissionManager extends Service
      *
      * @param mixed $submission the submission object
      */
-    private function removeAttachments($submission)
-    {
+    private function removeAttachments($submission) {
         // This occurs when a draft is edited or rejected.
 
         // Return all added items
@@ -872,10 +859,10 @@ class SubmissionManager extends Service
             foreach ($addonData['user_items'] as $userItemId => $quantity) {
                 $userItemRow = UserItem::find($userItemId);
                 if (!$userItemRow) {
-                    throw new \Exception('Cannot return an invalid item. (' . $userItemId . ')');
+                    throw new \Exception('Cannot return an invalid item. ('.$userItemId.')');
                 }
                 if ($userItemRow->submission_count < $quantity) {
-                    throw new \Exception('Cannot return more items than was held. (' . $userItemId . ')');
+                    throw new \Exception('Cannot return more items than was held. ('.$userItemId.')');
                 }
                 $userItemRow->submission_count -= $quantity;
                 $userItemRow->save();
@@ -888,10 +875,10 @@ class SubmissionManager extends Service
             foreach ($addonData['currencies'] as $currencyId => $quantity) {
                 $currency = Currency::find($currencyId);
                 if (!$currency) {
-                    throw new \Exception('Cannot return an invalid currency. (' . $currencyId . ')');
+                    throw new \Exception('Cannot return an invalid currency. ('.$currencyId.')');
                 }
                 if (!$currencyManager->creditCurrency(null, $submission->user, null, null, $currency, $quantity)) {
-                    throw new \Exception('Could not return currency to user. (' . $currencyId . ')');
+                    throw new \Exception('Could not return currency to user. ('.$currencyId.')');
                 }
             }
         }

--- a/database/migrations/2024_10_14_165017_add_character_prompt_rewards.php
+++ b/database/migrations/2024_10_14_165017_add_character_prompt_rewards.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        //snatching this flag from newt, less overlap means more Good
+        //this is assuming that people have pulled and migrated claymores first-- which at the moment is very likely, but it isn't 100% foolproof as people with newer LKs arise...
+        //the solution would be pretty simple in removing the 'is_focus' migration if a duplicate column error occurs
+        //alas i cannot prevent every possible error, merely mitigate the damage as much as i can :pensive:
+        if (!Schema::hasColumn('submission_characters', 'is_focus')) {
+            Schema::table('submission_characters', function (Blueprint $table) {
+                $table->boolean('is_focus')->default(0);
+            });
+        }
+        Schema::table('prompt_rewards', function (Blueprint $table) {
+            $table->string('earner_type')->default('User');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('submission_characters', function (Blueprint $table) {
+            $table->dropColumn('is_focus');
+        });
+        Schema::table('prompt_rewards', function (Blueprint $table) {
+            $table->dropColumn('earner_type');
+        });
+    }
+};

--- a/database/migrations/2024_10_14_165017_add_character_prompt_rewards.php
+++ b/database/migrations/2024_10_14_165017_add_character_prompt_rewards.php
@@ -4,13 +4,11 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     /**
      * Run the migrations.
      */
-    public function up(): void
-    {
+    public function up(): void {
         //snatching this flag from newt, less overlap means more Good
         //this is assuming that people have pulled and migrated claymores first-- which at the moment is very likely, but it isn't 100% foolproof as people with newer LKs arise...
         //the solution would be pretty simple in removing the 'is_focus' migration if a duplicate column error occurs
@@ -28,8 +26,7 @@ return new class extends Migration
     /**
      * Reverse the migrations.
      */
-    public function down(): void
-    {
+    public function down(): void {
         Schema::table('submission_characters', function (Blueprint $table) {
             $table->dropColumn('is_focus');
         });

--- a/resources/views/admin/prompts/create_edit_prompt.blade.php
+++ b/resources/views/admin/prompts/create_edit_prompt.blade.php
@@ -91,9 +91,15 @@
     </div>
 
     <h3>Rewards</h3>
-    <p>Rewards are credited on a per-user basis. Mods are able to modify the specific rewards granted at approval time.</p>
+    <p>Mods are able to modify the specific rewards granted at approval time.</p>
     <p>You can add loot tables containing any kind of currencies (both user- and character-attached), but be sure to keep track of which are being distributed! Character-only currencies cannot be given to users.</p>
+    <h4>User Rewards <i class="fas fa-user"></i></h4>
+    <p>User rewards are credited on a per-user basis.</p>
     @include('widgets._loot_select', ['loots' => $prompt->rewards, 'showLootTables' => true, 'showRaffles' => true])
+
+    <h4>Character Rewards <i class="fas fa-paw"></i></h4>
+    <p>Character rewards are only credited to the focus characters of a submission, both users and moderators can add and edit this status. There can be multiple focus characters.</p>
+    @include('widgets._loot_select', ['loots' => $prompt->characterRewards, 'showLootTables' => true, 'showRaffles' => true, 'prefix' => 'character_', 'isCharacter' => true])
 
     <div class="text-right">
         {!! Form::submit($prompt->id ? 'Edit' : 'Create', ['class' => 'btn btn-primary']) !!}
@@ -102,6 +108,7 @@
     {!! Form::close() !!}
 
     @include('widgets._loot_select_row', ['showLootTables' => true, 'showRaffles' => true])
+    @include('widgets._loot_select_row', ['showLootTables' => true, 'showRaffles' => true, 'prefix' => 'character_', 'isCharacter' => true])
 
     @if ($prompt->id)
         <h3>Preview</h3>
@@ -116,6 +123,7 @@
 @section('scripts')
     @parent
     @include('js._loot_js', ['showLootTables' => true, 'showRaffles' => true])
+    @include('js._loot_js', ['showLootTables' => true, 'showRaffles' => true, 'prefix' => 'character_', 'isCharacter' => true])
     @include('widgets._datetimepicker_js')
     <script>
         $(document).ready(function() {

--- a/resources/views/home/_prompt.blade.php
+++ b/resources/views/home/_prompt.blade.php
@@ -12,6 +12,7 @@
                 <p>You have completed this prompt <strong>{{ $count }}</strong> time{{ $count == 1 ? '' : 's' }}.</p>
             @endif
         @endif
+        <h4>User Rewards <i class="fas fa-user"></i></h4>
         <table class="table table-sm mb-0">
             <thead>
                 <tr>
@@ -21,6 +22,24 @@
             </thead>
             <tbody>
                 @foreach ($prompt->rewards as $reward)
+                    <tr>
+                        <td>{!! $reward->reward->displayName !!}</td>
+                        <td>{{ $reward->quantity }}</td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+        <h4>Character Rewards <i class="fas fa-paw"></i></h4>
+        <p>Only focus characters will recieve these rewards.</p>
+        <table class="table table-sm mb-0">
+            <thead>
+                <tr>
+                    <th width="70%">Reward</th>
+                    <th width="30%">Amount</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach ($prompt->characterRewards as $reward)
                     <tr>
                         <td>{!! $reward->reward->displayName !!}</td>
                         <td>{{ $reward->quantity }}</td>

--- a/resources/views/home/_submission_content.blade.php
+++ b/resources/views/home/_submission_content.blade.php
@@ -119,7 +119,9 @@
                 <div class="submission-character-info card ml-2">
                     <div class="card-body">
                         <div class="submission-character-info-content">
-                            <h3 class="mb-2 submission-character-info-header"><a href="{{ $character->character->url }}">{{ $character->character->fullName }}</a></h3>
+                            <h3 class="mb-2 submission-character-info-header"><a href="{{ $character->character->url }}">{{ $character->character->fullName }}@if ($character->is_focus)
+                                <i class="fas fa-bullseye float-right mr-2" data-toggle="tooltip" data-placement="top" title="This character is the focus of the submission!"></i>
+                            @endif</a></h3>
                             <div class="submission-character-info-body">
                                 @if (array_filter(parseAssetData($character->data)))
                                     <table class="table table-sm mb-0">

--- a/resources/views/home/_submission_content.blade.php
+++ b/resources/views/home/_submission_content.blade.php
@@ -120,8 +120,9 @@
                     <div class="card-body">
                         <div class="submission-character-info-content">
                             <h3 class="mb-2 submission-character-info-header"><a href="{{ $character->character->url }}">{{ $character->character->fullName }}@if ($character->is_focus)
-                                <i class="fas fa-bullseye float-right mr-2" data-toggle="tooltip" data-placement="top" title="This character is the focus of the submission!"></i>
-                            @endif</a></h3>
+                                        <i class="fas fa-bullseye float-right mr-2" data-toggle="tooltip" data-placement="top" title="This character is the focus of the submission!"></i>
+                                    @endif
+                                </a></h3>
                             <div class="submission-character-info-body">
                                 @if (array_filter(parseAssetData($character->data)))
                                     <table class="table table-sm mb-0">

--- a/resources/views/home/_submission_form.blade.php
+++ b/resources/views/home/_submission_form.blade.php
@@ -113,7 +113,8 @@
         @if ($isClaim)
             <p>If there are character-specific rewards you would like to claim, attach them here. Otherwise, this section can be left blank.</p>
         @else
-            <p>Note that any rewards added here are <u>in addition</u> to the default character rewards. Only the focus characters will receive these rewards (in the case of a submission featuring other attached characters that are not intended to recieve rewards.)</p>
+            <p>Note that any rewards added here are <u>in addition</u> to the default character rewards. Only the focus characters will receive these rewards (in the case of a submission featuring other attached characters that are not intended to
+                recieve rewards.)</p>
         @endif
         <div id="characters" class="mb-3">
             @foreach ($submission->characters as $character)

--- a/resources/views/home/_submission_form.blade.php
+++ b/resources/views/home/_submission_form.blade.php
@@ -112,6 +112,8 @@
     <div class="card-body" style="clear:both;">
         @if ($isClaim)
             <p>If there are character-specific rewards you would like to claim, attach them here. Otherwise, this section can be left blank.</p>
+        @else
+            <p>Note that any rewards added here are <u>in addition</u> to the default character rewards. Only the focus characters will receive these rewards (in the case of a submission featuring other attached characters that are not intended to recieve rewards.)</p>
         @endif
         <div id="characters" class="mb-3">
             @foreach ($submission->characters as $character)

--- a/resources/views/home/submissions_closed.blade.php
+++ b/resources/views/home/submissions_closed.blade.php
@@ -55,7 +55,8 @@
     @if ($isClaim)
         <p>If there are character-specific rewards you would like to claim, attach them here. Otherwise, this section can be left blank.</p>
     @else
-        <p>Note that any rewards added here are <u>in addition</u> to the default character rewards. Only the focus characters will receive these rewards (in the case of a submission featuring other attached characters that are not intended to recieve rewards.)</p>
+        <p>Note that any rewards added here are <u>in addition</u> to the default character rewards. Only the focus characters will receive these rewards (in the case of a submission featuring other attached characters that are not intended to recieve
+            rewards.)</p>
     @endif
     <div id="characters" class="mb-3">
     </div>

--- a/resources/views/home/submissions_closed.blade.php
+++ b/resources/views/home/submissions_closed.blade.php
@@ -54,6 +54,8 @@
     <h2>Characters</h2>
     @if ($isClaim)
         <p>If there are character-specific rewards you would like to claim, attach them here. Otherwise, this section can be left blank.</p>
+    @else
+        <p>Note that any rewards added here are <u>in addition</u> to the default character rewards. Only the focus characters will receive these rewards (in the case of a submission featuring other attached characters that are not intended to recieve rewards.)</p>
     @endif
     <div id="characters" class="mb-3">
     </div>

--- a/resources/views/js/_character_select_js.blade.php
+++ b/resources/views/js/_character_select_js.blade.php
@@ -74,6 +74,7 @@
         function updateRewardNames(node, id) {
             node.find('.character-rewardable-type').attr('name', 'character_rewardable_type[' + id + '][]');
             node.find('.character-rewardable-quantity').attr('name', 'character_rewardable_quantity[' + id + '][]');
+            node.find('.character-is-focus').attr('name', 'character_is_focus[' + id + ']');
             node.find('.character-currency-id').attr('name', 'character_rewardable_id[' + id + '][]');
             node.find('.character-item-id').attr('name', 'character_rewardable_id[' + id + '][]');
             node.find('.character-table-id').attr('name', 'character_rewardable_id[' + id + '][]');

--- a/resources/views/js/_loot_js.blade.php
+++ b/resources/views/js/_loot_js.blade.php
@@ -1,30 +1,36 @@
+@php
+    $prefix = $prefix ?? '';
+@endphp
 <script>
     $(document).ready(function() {
-        var $lootTable = $('#lootTableBody');
-        var $lootRow = $('#lootRow').find('.loot-row');
-        var $itemSelect = $('#lootRowData').find('.item-select');
-        var $currencySelect = $('#lootRowData').find('.currency-select');
+        var $lootTable = $('#{{ $prefix }}lootTableBody');
+        var $lootRow = $('#{{ $prefix }}lootRow').find('.{{ $prefix }}loot-row');
+        var $itemSelect = $('#{{ $prefix }}lootRowData').find('.{{ $prefix }}item-select');
+        var $currencySelect = $('#{{ $prefix }}lootRowData').find('.{{ $prefix }}currency-select');
+
         @if ($showLootTables)
-            var $tableSelect = $('#lootRowData').find('.table-select');
+            var $tableSelect = $('#{{ $prefix }}lootRowData').find('.{{ $prefix }}table-select');
         @endif
-        @if ($showRaffles)
-            var $raffleSelect = $('#lootRowData').find('.raffle-select');
+        @if (!isset($isCharacter))
+            @if ($showRaffles)
+                var $raffleSelect = $('#{{ $prefix }}lootRowData').find('.{{ $prefix }}raffle-select');
+            @endif
         @endif
 
-        $('#lootTableBody .selectize').selectize();
-        attachRemoveListener($('#lootTableBody .remove-loot-button'));
+        $('#{{ $prefix }}lootTableBody .selectize').selectize();
+        attachRemoveListener($('#{{ $prefix }}lootTableBody .{{ $prefix }}remove-loot-button'));
 
-        $('#addLoot').on('click', function(e) {
+        $('#{{ $prefix }}addLoot').on('click', function(e) {
             e.preventDefault();
             var $clone = $lootRow.clone();
             $lootTable.append($clone);
-            attachRewardTypeListener($clone.find('.reward-type'));
-            attachRemoveListener($clone.find('.remove-loot-button'));
+            attachRewardTypeListener($clone.find('.{{ $prefix }}reward-type'));
+            attachRemoveListener($clone.find('.{{ $prefix }}remove-loot-button'));
         });
 
-        $('.reward-type').on('change', function(e) {
+        $('.{{ $prefix }}reward-type').on('change', function(e) {
             var val = $(this).val();
-            var $cell = $(this).parent().parent().find('.loot-row-select');
+            var $cell = $(this).parent().parent().find('.{{ $prefix }}loot-row-select');
 
             var $clone = null;
             if (val == 'Item') $clone = $itemSelect.clone();
@@ -32,8 +38,10 @@
             @if ($showLootTables)
                 else if (val == 'LootTable') $clone = $tableSelect.clone();
             @endif
-            @if ($showRaffles)
-                else if (val == 'Raffle') $clone = $raffleSelect.clone();
+            @if (!isset($isCharacter))
+                @if ($showRaffles)
+                    else if (val == 'Raffle') $clone = $raffleSelect.clone();
+                @endif
             @endif
 
             $cell.html('');
@@ -43,7 +51,7 @@
         function attachRewardTypeListener(node) {
             node.on('change', function(e) {
                 var val = $(this).val();
-                var $cell = $(this).parent().parent().find('.loot-row-select');
+                var $cell = $(this).parent().parent().find('.{{ $prefix }}loot-row-select');
 
                 var $clone = null;
                 if (val == 'Item') $clone = $itemSelect.clone();
@@ -51,8 +59,10 @@
                 @if ($showLootTables)
                     else if (val == 'LootTable') $clone = $tableSelect.clone();
                 @endif
-                @if ($showRaffles)
-                    else if (val == 'Raffle') $clone = $raffleSelect.clone();
+                @if (!isset($isCharacter))
+                    @if ($showRaffles)
+                        else if (val == 'Raffle') $clone = $raffleSelect.clone();
+                    @endif
                 @endif
 
                 $cell.html('');

--- a/resources/views/prompts/_prompt_entry.blade.php
+++ b/resources/views/prompts/_prompt_entry.blade.php
@@ -36,8 +36,9 @@
                 @endif
             </div>
             <h3>Rewards</h3>
+            <h4>User Rewards <i class="fas fa-user"></i></h4>
             @if (!count($prompt->rewards))
-                No rewards.
+                No user rewards.
             @else
                 <table class="table table-sm">
                     <thead>
@@ -48,6 +49,27 @@
                     </thead>
                     <tbody>
                         @foreach ($prompt->rewards as $reward)
+                            <tr>
+                                <td>{!! $reward->reward->displayName !!}</td>
+                                <td>{{ $reward->quantity }}</td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            @endif
+            <h4>Character Rewards <i class="fas fa-paw"></i></h4>
+            @if (!count($prompt->characterRewards))
+                No character rewards.
+            @else
+                <table class="table table-sm">
+                    <thead>
+                        <tr>
+                            <th width="70%">Reward</th>
+                            <th width="30%">Amount</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach ($prompt->characterRewards as $reward)
                             <tr>
                                 <td>{!! $reward->reward->displayName !!}</td>
                                 <td>{{ $reward->quantity }}</td>

--- a/resources/views/widgets/_character_select.blade.php
+++ b/resources/views/widgets/_character_select.blade.php
@@ -24,6 +24,10 @@
                         {!! Form::label('slug[]', 'Character Code') !!}
                         {!! Form::select('slug[]', $characters, null, ['class' => 'form-control character-code', 'placeholder' => 'Select Character']) !!}
                     </div>
+                    <div class="form-group col-6">
+                        {!! Form::label('character-is-focus[]', 'Focus Character?', ['class' => 'form-check-label mr-2 character-is-focus']) !!}
+                        {!! Form::select('character-is-focus[]', [0 => 'No', 1 => 'Yes'], 0, ['class' => 'form-control character-is-focus']) !!}
+                    </div>
                     <div class="character-rewards hide">
                         <h4>Character Rewards</h4>
                         <table class="table table-sm">

--- a/resources/views/widgets/_character_select_entry.blade.php
+++ b/resources/views/widgets/_character_select_entry.blade.php
@@ -25,6 +25,12 @@
                     {!! Form::label('slug[]', 'Character Code') !!}
                     {!! Form::select('slug[]', $characters, $character->character ? $character->character->slug : $character->slug, ['class' => 'form-control character-code', 'placeholder' => 'Select Character']) !!}
                 </div>
+                @if (isset($submission))
+                    <div class="form-group col-6">
+                        {!! Form::label('character_is_focus[' . ($character->character ? $character->character->id : $character->id) . ']', 'Focus Character?', ['class' => 'mr-2']) !!}
+                        {!! Form::select('character_is_focus[' . ($character->character ? $character->character->id : $character->id) . ']', [0 => 'No', 1 => 'Yes'], $character->is_focus, ['class' => 'form-control character-is-focus']) !!}
+                    </div>
+                @endif
                 <div class="character-rewards">
                     <h4>Character Rewards</h4>
                     <table class="table table-sm">

--- a/resources/views/widgets/_loot_select.blade.php
+++ b/resources/views/widgets/_loot_select.blade.php
@@ -2,21 +2,33 @@
     // This file represents a common source and definition for assets used in loot_select
     // While it is not per se as tidy as defining these in the controller(s),
     // doing so this way enables better compatibility across disparate extensions
-    $characterCurrencies = \App\Models\Currency\Currency::where('is_character_owned', 1)->orderBy('sort_character', 'DESC')->pluck('name', 'id');
-    $items = \App\Models\Item\Item::orderBy('name')->pluck('name', 'id');
-    $currencies = \App\Models\Currency\Currency::where('is_user_owned', 1)->orderBy('name')->pluck('name', 'id');
+
+    if (!isset($isCharacter)) {
+        $items = \App\Models\Item\Item::orderBy('name')->pluck('name', 'id');
+        $currencies = \App\Models\Currency\Currency::where('is_user_owned', 1)->orderBy('name')->pluck('name', 'id');
+        if ($showRaffles) {
+            $raffles = \App\Models\Raffle\Raffle::where('rolled_at', null)->where('is_active', 1)->orderBy('name')->pluck('name', 'id');
+        }
+    } else {
+        $items = \App\Models\Item\Item::whereIn('item_category_id', \App\Models\Item\ItemCategory::where('is_character_owned', 1)->pluck('id')->toArray())
+            ->orderBy('name')
+            ->pluck('name', 'id');
+            $characterCurrencies = \App\Models\Currency\Currency::where('is_character_owned', 1)->orderBy('sort_character', 'DESC')->pluck('name', 'id');
+    }
+
     if ($showLootTables) {
         $tables = \App\Models\Loot\LootTable::orderBy('name')->pluck('name', 'id');
     }
-    if ($showRaffles) {
-        $raffles = \App\Models\Raffle\Raffle::where('rolled_at', null)->where('is_active', 1)->orderBy('name')->pluck('name', 'id');
+
+    if (!isset($prefix)) {
+        $prefix = '';
     }
 @endphp
 
 <div class="text-right mb-3">
-    <a href="#" class="btn btn-outline-info" id="addLoot">Add Reward</a>
+    <a href="#" class="btn btn-outline-info" id="{{ $prefix }}addLoot">Add Reward</a>
 </div>
-<table class="table table-sm" id="lootTable">
+<table class="table table-sm" id="{{ $prefix }}lootTable">
     <thead>
         <tr>
             <th width="35%">Reward Type</th>
@@ -25,27 +37,27 @@
             <th width="10%"></th>
         </tr>
     </thead>
-    <tbody id="lootTableBody">
+    <tbody id="{{ $prefix }}lootTableBody">
         @if ($loots)
             @foreach ($loots as $loot)
-                <tr class="loot-row">
-                    <td>{!! Form::select('rewardable_type[]', ['Item' => 'Item', 'Currency' => 'Currency'] + ($showLootTables ? ['LootTable' => 'Loot Table'] : []) + ($showRaffles ? ['Raffle' => 'Raffle Ticket'] : []), $loot->rewardable_type, [
-                        'class' => 'form-control reward-type',
+                <tr class="{{ $prefix }}loot-row">
+                    <td>{!! Form::select($prefix . 'rewardable_type[]', ['Item' => 'Item', 'Currency' => 'Currency'] + (!isset($isCharacter) ? ($showLootTables ? ['LootTable' => 'Loot Table'] : []) + ($showRaffles ? ['Raffle' => 'Raffle Ticket'] : []) : []), $loot->rewardable_type, [
+                        'class' => 'form-control ' . $prefix . 'reward-type',
                         'placeholder' => 'Select Reward Type',
                     ]) !!}</td>
-                    <td class="loot-row-select">
+                    <td class="{{ $prefix }}loot-row-select">
                         @if ($loot->rewardable_type == 'Item')
-                            {!! Form::select('rewardable_id[]', $items, $loot->rewardable_id, ['class' => 'form-control item-select selectize', 'placeholder' => 'Select Item']) !!}
+                            {!! Form::select($prefix . 'rewardable_id[]', $items, $loot->rewardable_id, ['class' => 'form-control ' . $prefix . 'item-select selectize', 'placeholder' => 'Select Item']) !!}
                         @elseif($loot->rewardable_type == 'Currency')
-                            {!! Form::select('rewardable_id[]', $currencies, $loot->rewardable_id, ['class' => 'form-control currency-select selectize', 'placeholder' => 'Select Currency']) !!}
+                            {!! Form::select($prefix . 'rewardable_id[]', !isset($isCharacter) ? $currencies : $characterCurrencies, $loot->rewardable_id, ['class' => 'form-control ' . $prefix . 'currency-select selectize', 'placeholder' => 'Select Currency']) !!}
                         @elseif($showLootTables && $loot->rewardable_type == 'LootTable')
-                            {!! Form::select('rewardable_id[]', $tables, $loot->rewardable_id, ['class' => 'form-control table-select selectize', 'placeholder' => 'Select Loot Table']) !!}
-                        @elseif($showRaffles && $loot->rewardable_type == 'Raffle')
-                            {!! Form::select('rewardable_id[]', $raffles, $loot->rewardable_id, ['class' => 'form-control raffle-select selectize', 'placeholder' => 'Select Raffle']) !!}
+                            {!! Form::select($prefix . 'rewardable_id[]', $tables, $loot->rewardable_id, ['class' => 'form-control ' . $prefix . 'table-select selectize', 'placeholder' => 'Select Loot Table']) !!}
+                        @elseif(!isset($isCharacter) + $showRaffles && $loot->rewardable_type == 'Raffle')
+                            {!! Form::select($prefix . 'rewardable_id[]', $raffles, $loot->rewardable_id, ['class' => 'form-control ' . $prefix . 'raffle-select selectize', 'placeholder' => 'Select Raffle']) !!}
                         @endif
                     </td>
-                    <td>{!! Form::text('quantity[]', $loot->quantity, ['class' => 'form-control']) !!}</td>
-                    <td class="text-right"><a href="#" class="btn btn-danger remove-loot-button">Remove</a></td>
+                    <td>{!! Form::text($prefix . 'quantity[]', $loot->quantity, ['class' => 'form-control']) !!}</td>
+                    <td class="text-right"><a href="#" class="btn btn-danger {{ $prefix }}remove-loot-button">Remove</a></td>
                 </tr>
             @endforeach
         @endif

--- a/resources/views/widgets/_loot_select.blade.php
+++ b/resources/views/widgets/_loot_select.blade.php
@@ -13,7 +13,7 @@
         $items = \App\Models\Item\Item::whereIn('item_category_id', \App\Models\Item\ItemCategory::where('is_character_owned', 1)->pluck('id')->toArray())
             ->orderBy('name')
             ->pluck('name', 'id');
-            $characterCurrencies = \App\Models\Currency\Currency::where('is_character_owned', 1)->orderBy('sort_character', 'DESC')->pluck('name', 'id');
+        $characterCurrencies = \App\Models\Currency\Currency::where('is_character_owned', 1)->orderBy('sort_character', 'DESC')->pluck('name', 'id');
     }
 
     if ($showLootTables) {
@@ -41,10 +41,15 @@
         @if ($loots)
             @foreach ($loots as $loot)
                 <tr class="{{ $prefix }}loot-row">
-                    <td>{!! Form::select($prefix . 'rewardable_type[]', ['Item' => 'Item', 'Currency' => 'Currency'] + (!isset($isCharacter) ? ($showLootTables ? ['LootTable' => 'Loot Table'] : []) + ($showRaffles ? ['Raffle' => 'Raffle Ticket'] : []) : []), $loot->rewardable_type, [
-                        'class' => 'form-control ' . $prefix . 'reward-type',
-                        'placeholder' => 'Select Reward Type',
-                    ]) !!}</td>
+                    <td>{!! Form::select(
+                        $prefix . 'rewardable_type[]',
+                        ['Item' => 'Item', 'Currency' => 'Currency'] + (!isset($isCharacter) ? ($showLootTables ? ['LootTable' => 'Loot Table'] : []) + ($showRaffles ? ['Raffle' => 'Raffle Ticket'] : []) : []),
+                        $loot->rewardable_type,
+                        [
+                            'class' => 'form-control ' . $prefix . 'reward-type',
+                            'placeholder' => 'Select Reward Type',
+                        ],
+                    ) !!}</td>
                     <td class="{{ $prefix }}loot-row-select">
                         @if ($loot->rewardable_type == 'Item')
                             {!! Form::select($prefix . 'rewardable_id[]', $items, $loot->rewardable_id, ['class' => 'form-control ' . $prefix . 'item-select selectize', 'placeholder' => 'Select Item']) !!}

--- a/resources/views/widgets/_loot_select_row.blade.php
+++ b/resources/views/widgets/_loot_select_row.blade.php
@@ -2,37 +2,51 @@
     // This file represents a common source and definition for assets used in loot_select
     // While it is not per se as tidy as defining these in the controller(s),
     // doing so this way enables better compatibility across disparate extensions
-    $characterCurrencies = \App\Models\Currency\Currency::where('is_character_owned', 1)->orderBy('sort_character', 'DESC')->pluck('name', 'id');
-    $items = \App\Models\Item\Item::orderBy('name')->pluck('name', 'id');
-    $currencies = \App\Models\Currency\Currency::where('is_user_owned', 1)->orderBy('name')->pluck('name', 'id');
+
+    if (!isset($isCharacter)) {
+        $items = \App\Models\Item\Item::orderBy('name')->pluck('name', 'id');
+        $currencies = \App\Models\Currency\Currency::where('is_user_owned', 1)->orderBy('name')->pluck('name', 'id');
+        if ($showRaffles) {
+            $raffles = \App\Models\Raffle\Raffle::where('rolled_at', null)->where('is_active', 1)->orderBy('name')->pluck('name', 'id');
+        }
+    } else {
+        $items = \App\Models\Item\Item::whereIn('item_category_id', \App\Models\Item\ItemCategory::where('is_character_owned', 1)->pluck('id')->toArray())
+            ->orderBy('name')
+            ->pluck('name', 'id');
+        $characterCurrencies = \App\Models\Currency\Currency::where('is_character_owned', 1)->orderBy('sort_character', 'DESC')->pluck('name', 'id');
+    }
+
     if ($showLootTables) {
         $tables = \App\Models\Loot\LootTable::orderBy('name')->pluck('name', 'id');
     }
-    if ($showRaffles) {
-        $raffles = \App\Models\Raffle\Raffle::where('rolled_at', null)->where('is_active', 1)->orderBy('name')->pluck('name', 'id');
+
+    if (!isset($prefix)) {
+        $prefix = '';
     }
 @endphp
 
-<div id="lootRowData" class="hide">
+<div id="{{ $prefix }}lootRowData" class="hide">
     <table class="table table-sm">
-        <tbody id="lootRow">
-            <tr class="loot-row">
-                <td>{!! Form::select('rewardable_type[]', ['Item' => 'Item', 'Currency' => 'Currency'] + ($showLootTables ? ['LootTable' => 'Loot Table'] : []) + ($showRaffles ? ['Raffle' => 'Raffle Ticket'] : []), null, [
-                    'class' => 'form-control reward-type',
+        <tbody id="{{ $prefix }}lootRow">
+            <tr class="{{ $prefix }}loot-row">
+                <td>{!! Form::select($prefix . 'rewardable_type[]', ['Item' => 'Item', 'Currency' => 'Currency'] + (!isset($isCharacter) ? ($showLootTables ? ['LootTable' => 'Loot Table'] : []) + ($showRaffles ? ['Raffle' => 'Raffle Ticket'] : []) : []), null, [
+                    'class' => 'form-control ' . $prefix . 'reward-type',
                     'placeholder' => 'Select Reward Type',
                 ]) !!}</td>
-                <td class="loot-row-select"></td>
-                <td>{!! Form::text('quantity[]', 1, ['class' => 'form-control']) !!}</td>
-                <td class="text-right"><a href="#" class="btn btn-danger remove-loot-button">Remove</a></td>
+                <td class="{{ $prefix }}loot-row-select"></td>
+                <td>{!! Form::text($prefix . 'quantity[]', 1, ['class' => 'form-control']) !!}</td>
+                <td class="text-right"><a href="#" class="btn btn-danger {{ $prefix }}remove-loot-button">Remove</a></td>
             </tr>
         </tbody>
     </table>
-    {!! Form::select('rewardable_id[]', $items, null, ['class' => 'form-control item-select', 'placeholder' => 'Select Item']) !!}
-    {!! Form::select('rewardable_id[]', $currencies, null, ['class' => 'form-control currency-select', 'placeholder' => 'Select Currency']) !!}
+    {!! Form::select($prefix . 'rewardable_id[]', $items, null, ['class' => 'form-control ' . $prefix . 'item-select', 'placeholder' => 'Select Item']) !!}
+    {!! Form::select($prefix . 'rewardable_id[]', !isset($isCharacter) ? $currencies : $characterCurrencies, null, ['class' => 'form-control ' . $prefix . 'currency-select', 'placeholder' => 'Select Currency']) !!}
     @if ($showLootTables)
-        {!! Form::select('rewardable_id[]', $tables, null, ['class' => 'form-control table-select', 'placeholder' => 'Select Loot Table']) !!}
+        {!! Form::select($prefix . 'rewardable_id[]', $tables, null, ['class' => 'form-control ' . $prefix . 'table-select', 'placeholder' => 'Select Loot Table']) !!}
     @endif
-    @if ($showRaffles)
-        {!! Form::select('rewardable_id[]', $raffles, null, ['class' => 'form-control raffle-select', 'placeholder' => 'Select Raffle']) !!}
+    @if (!isset($isCharacter))
+        @if ($showRaffles)
+            {!! Form::select($prefix . 'rewardable_id[]', $raffles, null, ['class' => 'form-control ' . $prefix . 'raffle-select', 'placeholder' => 'Select Raffle']) !!}
+        @endif
     @endif
 </div>


### PR DESCRIPTION
-Add default prompt rewards for characters. (Surprised this wasn't a thing already.)
-Rewards are handled with a flag that determines if they are the focus of the prompt (multiple can be designated if need be, but this prevents submissions handing out rewards automatically to every tagged character even if they're just a small cameo or whatever)
-Did something similar to prompts where submission of the prompt adds the rewards to the asset list, so those can be edited as well, like user rewards they will be removed upon cancellation so no duplication occurs

Ty to @ScuffedNewt for handing me the loot_select prefixes so two loot_selects can exist on the same page, and also for the is_focus flag (going to PR a check on the claymores ext so no possible migration issues can occur)

Let me know if i missed anything weird here or went about it wrong HAHAHAH my brain is a little on the fritz rn