### PR TITLE
fix(parsing) add criteria to excludedFields to keep expanded loot tables from breaking

### DIFF
--- a/app/Http/Middleware/ParsePostRequestFields.php
+++ b/app/Http/Middleware/ParsePostRequestFields.php
@@ -16,7 +16,7 @@ class ParsePostRequestFields
      */
     public function handle(Request $request, Closure $next) {
         if ($request->isMethod('post')) {
-            $excludedFields = ['_token', 'password', 'email', 'description', 'text'];
+            $excludedFields = ['_token', 'password', 'email', 'description', 'text', 'criteria'];
             $strippedFields = ['name', 'title'];
 
             $parsedFields = [];


### PR DESCRIPTION
Prevents symbols like < and > from being filtered and breaking tables in the case of loot table expansion being enabled in extensions.php 