### PR TITLE
feat(news/sales): Allow admin with manage rights to view news/sales that arent visible

### DIFF
--- a/app/Http/Controllers/NewsController.php
+++ b/app/Http/Controllers/NewsController.php
@@ -45,17 +45,11 @@ class NewsController extends Controller {
      * @return \Illuminate\Contracts\Support\Renderable
      */
     public function getNews($id, $slug = null) {
-        $news = News::where('id', $id)->first();
+        $news = News::where('id', $id)->visible(Auth::user() ?? null)->first();
         if (!$news) {
             abort(404);
         }
 
-        if (!$news->is_visible) {
-            $user = Auth::user() ?? null;
-            if ($user == null || !$user->hasPower('manage_news')) {
-                abort(404);
-            }
-        }
 
         return view('news.news', ['news' => $news]);
     }

--- a/app/Http/Controllers/NewsController.php
+++ b/app/Http/Controllers/NewsController.php
@@ -50,7 +50,6 @@ class NewsController extends Controller {
             abort(404);
         }
 
-
         return view('news.news', ['news' => $news]);
     }
 }

--- a/app/Http/Controllers/NewsController.php
+++ b/app/Http/Controllers/NewsController.php
@@ -45,9 +45,16 @@ class NewsController extends Controller {
      * @return \Illuminate\Contracts\Support\Renderable
      */
     public function getNews($id, $slug = null) {
-        $news = News::where('id', $id)->where('is_visible', 1)->first();
+        $news = News::where('id', $id)->first();
         if (!$news) {
             abort(404);
+        }
+
+        if (!$news->is_visible) {
+            $user = Auth::user() ?? null;
+            if ($user == null || !$user->hasPower('manage_news')) {
+                abort(404);
+            }
         }
 
         return view('news.news', ['news' => $news]);

--- a/app/Http/Controllers/SalesController.php
+++ b/app/Http/Controllers/SalesController.php
@@ -83,9 +83,16 @@ class SalesController extends Controller {
      * @return \Illuminate\Contracts\Support\Renderable
      */
     public function getSales($id, $slug = null) {
-        $sales = Sales::where('id', $id)->where('is_visible', 1)->first();
+        $sales = Sales::where('id', $id)->first();
         if (!$sales) {
             abort(404);
+        }
+
+        if (!$sales->is_visible) {
+            $user = Auth::user() ?? null;
+            if ($user == null || !$user->hasPower('manage_sales')) {
+                abort(404);
+            }
         }
 
         return view('sales.sales', ['sales' => $sales]);

--- a/app/Http/Controllers/SalesController.php
+++ b/app/Http/Controllers/SalesController.php
@@ -83,16 +83,9 @@ class SalesController extends Controller {
      * @return \Illuminate\Contracts\Support\Renderable
      */
     public function getSales($id, $slug = null) {
-        $sales = Sales::where('id', $id)->first();
+        $sales = Sales::where('id', $id)->visible(Auth::user() ?? null)->first();
         if (!$sales) {
             abort(404);
-        }
-
-        if (!$sales->is_visible) {
-            $user = Auth::user() ?? null;
-            if ($user == null || !$user->hasPower('manage_sales')) {
-                abort(404);
-            }
         }
 
         return view('sales.sales', ['sales' => $sales]);

--- a/app/Models/News.php
+++ b/app/Models/News.php
@@ -86,6 +86,7 @@ class News extends Model implements Feedable {
      * Scope a query to only include visible posts.
      *
      * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param mixed|null                            $user
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */
@@ -93,6 +94,7 @@ class News extends Model implements Feedable {
         if ($user && $user->hasPower('manage_news')) {
             return $query;
         }
+
         return $query->where('is_visible', 1);
     }
 

--- a/app/Models/News.php
+++ b/app/Models/News.php
@@ -89,7 +89,10 @@ class News extends Model implements Feedable {
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function scopeVisible($query) {
+    public function scopeVisible($query, $user = null) {
+        if ($user && $user->hasPower('manage_news')) {
+            return $query;
+        }
         return $query->where('is_visible', 1);
     }
 

--- a/app/Models/Sales/Sales.php
+++ b/app/Models/Sales/Sales.php
@@ -99,7 +99,10 @@ class Sales extends Model implements Feedable {
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function scopeVisible($query) {
+    public function scopeVisible($query, $user = null) {
+        if ($user && $user->hasPower('manage_sales')) {
+            return $query;
+        }
         return $query->where('is_visible', 1);
     }
 

--- a/app/Models/Sales/Sales.php
+++ b/app/Models/Sales/Sales.php
@@ -96,6 +96,7 @@ class Sales extends Model implements Feedable {
      * Scope a query to only include visible posts.
      *
      * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param mixed|null                            $user
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */
@@ -103,6 +104,7 @@ class Sales extends Model implements Feedable {
         if ($user && $user->hasPower('manage_sales')) {
             return $query;
         }
+
         return $query->where('is_visible', 1);
     }
 

--- a/resources/views/admin/news/create_edit_news.blade.php
+++ b/resources/views/admin/news/create_edit_news.blade.php
@@ -10,6 +10,7 @@
     <h1>{{ $news->id ? 'Edit' : 'Create' }} News Post
         @if ($news->id)
             <a href="#" class="btn btn-danger float-right delete-news-button">Delete Post</a>
+            <a href="{{ $news->url }}" class="btn btn-info float-right mr-md-2">View Post</a>
         @endif
     </h1>
 

--- a/resources/views/admin/sales/create_edit_sales.blade.php
+++ b/resources/views/admin/sales/create_edit_sales.blade.php
@@ -10,6 +10,7 @@
     <h1>{{ $sales->id ? 'Edit' : 'Create' }} Sales Post
         @if ($sales->id)
             <a href="#" class="btn btn-danger float-right delete-sales-button">Delete Post</a>
+            <a href="{{ $sales->url }}" class="btn btn-info float-right mr-md-2">View Post</a>
         @endif
     </h1>
 

--- a/resources/views/news/_news.blade.php
+++ b/resources/views/news/_news.blade.php
@@ -1,7 +1,12 @@
 <div class="card mb-3">
     <div class="card-header">
         <x-admin-edit title="News Post" :object="$news" />
-        <h2 class="card-title mb-0">{!! $news->displayName !!}</h2>
+        <h2 class="card-title mb-0">
+            @if (!$news->is_visible)
+                <i class="fas fa-eye-slash mr-1"></i>
+            @endif
+            {!! $news->displayName !!}
+        </h2>
         <small>
             Posted {!! $news->post_at ? pretty_date($news->post_at) : pretty_date($news->created_at) !!} :: Last edited {!! pretty_date($news->updated_at) !!} by {!! $news->user->displayName !!}
         </small>

--- a/resources/views/sales/_sales.blade.php
+++ b/resources/views/sales/_sales.blade.php
@@ -1,7 +1,12 @@
 <div class="card mb-3">
     <div class="card-header">
         <x-admin-edit title="Sale" :object="$sales" />
-        <h2 class="card-title mb-0">{!! $sales->displayName !!}</h2>
+        <h2 class="card-title mb-0">
+            @if (!$sales->is_visible)
+                <i class="fas fa-eye-slash mr-1"></i>
+            @endif
+            {!! $sales->displayName !!}
+        </h2>
         <small>
             Posted {!! $sales->post_at ? pretty_date($sales->post_at) : pretty_date($sales->created_at) !!} :: Last edited {!! pretty_date($sales->updated_at) !!} by {!! $sales->user->displayName !!}
         </small>


### PR DESCRIPTION
Let us preview the news and sales! We're admin! We got rank powers!

..Basically, allows users with the manage_news rank power to view news posts while they're not viewable
and likewise allows users with the manage_sales rank power to view sales posts while they're not viewable.

Adds a 'View Post' button to both create_edit pages when the post has an id, that links to said post.
And of course, my traditional fa-eye-slash icon for those invisible items.

...Only question I had was.. should I also add non-visible posts to the sidebar for admin only? Or.. just.. leave 'em only accessible through the admin area..?