### PR TITLE
feat(pages): Allow admin with manage rights to view pages that arent visible

### DIFF
--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -23,7 +23,7 @@ class PageController extends Controller {
      * @return \Illuminate\Contracts\Support\Renderable
      */
     public function getPage($key) {
-        $page = SitePage::where('key', $key)->where('is_visible', 1)->first();
+        $page = SitePage::where('key', $key)->visible(Auth::user() ?? null)->first();
         if (!$page) {
             abort(404);
         }

--- a/app/Models/SitePage.php
+++ b/app/Models/SitePage.php
@@ -56,7 +56,7 @@ class SitePage extends Model {
         SCOPES
     **********************************************************************************************/
     /**
-     * Scope a query to only include visible posts.
+     * Scope a query to only include visible pages.
      *
      * @param \Illuminate\Database\Eloquent\Builder $query
      * @param mixed|null                            $user

--- a/app/Models/SitePage.php
+++ b/app/Models/SitePage.php
@@ -52,6 +52,28 @@ class SitePage extends Model {
         'text'  => 'nullable',
     ];
 
+    /**********************************************************************************************
+        SCOPES
+    **********************************************************************************************/
+    /**
+     * Scope a query to only include visible posts.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param mixed|null                            $user
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeVisible($query, $user = null) {
+        if ($user && $user->hasPower('edit_pages')) {
+            return $query;
+        }
+
+        return $query->where('is_visible', 1);
+    }
+
+    /**********************************************************************************************
+        ACCESSORS
+    **********************************************************************************************/
     /**
      * Gets the URL of the public-facing page.
      *

--- a/resources/views/pages/page.blade.php
+++ b/resources/views/pages/page.blade.php
@@ -7,7 +7,12 @@
 @section('content')
     <x-admin-edit title="Page" :object="$page" />
     {!! breadcrumbs([$page->title => $page->url]) !!}
-    <h1>{{ $page->title }}</h1>
+    <h1>
+        @if (!$page->is_visible)
+            <i class="fas fa-eye-slash mr-1"></i>
+        @endif
+        {{ $page->title }}
+    </h1>
     <div class="mb-4">
         <div><strong>Created:</strong> {!! format_date($page->created_at) !!}</div>
         <div><strong>Last updated:</strong> {!! format_date($page->updated_at) !!}</div>


### PR DESCRIPTION
Let us preview the pages! We're admin! We got rank powers!.. wait, I feel like I said this before.

Anyway, allows users with the edit_pages rank power to view pages while they're not viewable.

And of course, my traditional fa-eye-slash icon for those invisible items.

...Feels like I should've done this at the same time I added the functionality for sales and news posts, huh..