### PR TITLE
fix(character): Nitpick- description says 'no additional notes given'

### DIFF
--- a/resources/views/character/_tab_notes.blade.php
+++ b/resources/views/character/_tab_notes.blade.php
@@ -1,7 +1,7 @@
 @if ($character->parsed_description)
     <div class="parsed-text descriptioneditingparse">{!! $character->parsed_description !!}</div>
 @else
-    <div class="parsed-text descriptioneditingparse">No additional notes given.</div>
+    <div class="parsed-text descriptioneditingparse">No description given.</div>
 @endif
 @if (Auth::check() && Auth::user()->hasPower('manage_characters'))
     <div class="mt-3">


### PR DESCRIPTION
While 'no additional notes given' makes sense for the NOTES section, this is in fact the description.

Extremely minor, very nitpick, but come on.