### PR TITLE
Bug(Throttle): Update throttling to only return error alerts if request is an ajax request

### DIFF
--- a/app/Http/Middleware/PostRequestThrottleMiddleware.php
+++ b/app/Http/Middleware/PostRequestThrottleMiddleware.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\RateLimiter;
 use Symfony\Component\HttpFoundation\Response;
-use Illuminate\Support\Facades\Blade;
 
 class PostRequestThrottleMiddleware {
     /**
@@ -44,7 +43,10 @@ class PostRequestThrottleMiddleware {
                 Log::channel('throttle')->info('Rate limited user', ['url' => $request->fullUrl(), 'user' => $request->user()?->name ?: $request->ip()]);
             }
 
-            return redirect()->back();
+            // If the response is from ajax it's not expecting a full redirect with the entire site bundled in as a response
+            return $request->ajax() ?
+                response("<div class='alert alert-danger mb-2'>Too many requests - please try again later.</div><div class='alert alert-success'>Your initial action has likely been performed successfully. Please check to ensure this is the case before trying again.</div>")
+                : redirect()->back();
         }
 
         RateLimiter::hit($key, $decaySeconds);

--- a/app/Http/Middleware/PostRequestThrottleMiddleware.php
+++ b/app/Http/Middleware/PostRequestThrottleMiddleware.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\RateLimiter;
 use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Support\Facades\Blade;
 
 class PostRequestThrottleMiddleware {
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "lorekeeper",
+    "name": "lorekeeper-extensions",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {


### PR DESCRIPTION
If throttling is done on an ajax request it'll try to return the whole site redirect back which can look... really odd. 
This makes it so that instead it only returns the two alert boxes for ajax.
(If there's an alternative way we'd prefer I do the alerts besides the hard-coded/hand-typed version I did here very open to updating that, but it felt too small to make into it's own blade template)

To test this _easily_ I removed the admin url guard and the `get` request guard temporarily and used the edit traits modal to recreate the problem:
![Screenshot 2024-12-01 at 3 24 37 PM](https://github.com/user-attachments/assets/d00626ae-fc1a-42f5-8c91-93c85e87efbc)

And then with this fix:
![Screenshot 2024-12-01 at 3 19 33 PM](https://github.com/user-attachments/assets/0490fc0f-ac0b-4f5b-ab14-981700f92137)

And for future reference it's possible to do something like this blade side too with an alt layout:
`@extends(Request::ajax() ? 'layouts.ajax' : 'layouts.app')`

In case it ever comes up for things like the blocked page.