### PR TITLE
fix(comments): Stops replacement regex at any opening tag

### DIFF
--- a/app/Models/Comment/Comment.php
+++ b/app/Models/Comment/Comment.php
@@ -153,7 +153,7 @@ class Comment extends Model {
     public function getCommentAttribute() {
         if (config('lorekeeper.settings.wysiwyg_comments')) {
             return preg_replace_callback(
-                '/(?<!href=")(?<!src=")(?<!\()(https?:\/\/[^\s]+)/',
+                '/(?<!href=")(?<!src=")(?<!\()(https?:\/\/[^\s<]+)/',
                 function ($matches) {
                     $url = $matches[1];
                     $parsedUrl = parse_url($url);


### PR DESCRIPTION
Found out earlier that links, pre-formatted or by the user, cause issues due to the regex, as it includes the ending </a> tag.

![example made using regexr](https://github.com/user-attachments/assets/812739d6-d09c-4d52-bfd8-435aebfd0643)

With my suggested change, this no longer occurs.

![example made using regexr 2](https://github.com/user-attachments/assets/2a63658b-5a5d-4d27-a15f-c5a5f1f0d5ff)

RegEx check done on https://regexr.com/, and yes, double checked with https://regex101.com/ and a LIVE SITE.