### PR TITLE
fix(command): whereNotNull for Subtype images

### DIFF
--- a/app/Console/Commands/FixImageHashes.php
+++ b/app/Console/Commands/FixImageHashes.php
@@ -57,7 +57,7 @@ class FixImageHashes extends Command {
         $images = $images->concat(Rarity::where('has_image', 1)->whereNotNull('hash')->get());
         $images = $images->concat(Shop::where('has_image', 1)->whereNotNull('hash')->get());
         $images = $images->concat(Species::where('has_image', 1)->whereNotNull('hash')->get());
-        $images = $images->concat(Subtype::where('has_image', 1)->whereNull('hash')->get());
+        $images = $images->concat(Subtype::where('has_image', 1)->whereNotNull('hash')->get());
 
         if ($images->count()) {
             $this->line('Updating images...');


### PR DESCRIPTION
Discovered that the images Subtypes are in fact not handled properly; on account of the command saying 'whereNull' instead of 'whereNotNull', like the others.