### PR TITLE
fix: decode HTML special chars after parsing

### DIFF
--- a/app/Http/Middleware/ParsePostRequestFields.php
+++ b/app/Http/Middleware/ParsePostRequestFields.php
@@ -32,6 +32,9 @@ class ParsePostRequestFields {
                     } else {
                         $parsedFields[$key] = parse($value);
                     }
+
+                    // Decode HTML special chars
+                    $parsedFields[$key] = htmlspecialchars_decode($parsedFields[$key]);
                 }
             }
 
@@ -58,6 +61,9 @@ class ParsePostRequestFields {
                 } else {
                     $array[$key] = parse($value);
                 }
+
+                // Decode HTML special chars
+                $array[$key] = htmlspecialchars_decode($array[$key]);
             }
         }
 


### PR DESCRIPTION
Fixes e.g. ampersands run through the request field parsing getting encoded into HTML special chars and displaying oddly when just printed outright.
Not retroactive, naturally, but works in testing for anything newly parsed. Might be a bit of a scuffed fix though. |D