### PR TITLE
fix(characters): improve fullsize image format handling around design updates

### DIFF
--- a/app/Console/Commands/FixCharacterImageFormats.php
+++ b/app/Console/Commands/FixCharacterImageFormats.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Character\CharacterDesignUpdate;
+use App\Models\Character\CharacterImage;
+use Illuminate\Console\Command;
+use Intervention\Image\Facades\Image;
+
+class FixCharacterImageFormats extends Command {
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:fix-character-image-formats';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Converts existing fullsize character and design update images not stored as the configured file format.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle() {
+        $masterlistFormat = config('lorekeeper.settings.masterlist_image_format');
+        $fullsizeFormat = config('lorekeeper.settings.masterlist_fullsizes_format');
+
+        $images = CharacterImage::where('fullsize_extension', '!=', $fullsizeFormat);
+        if ($images->count()) {
+            $this->info('Processing '.$images->count().' images...');
+            $images->update(['fullsize_extension' => $fullsizeFormat]);
+
+            foreach ($images->get() as $image) {
+                if (file_exists($image->imagePath.'/'.$image->id.'_'.$image->hash.'_'.$image->fullsize_hash.'_full.'.$masterlistFormat)) {
+                    Image::make($image->imagePath.'/'.$image->id.'_'.$image->hash.'_'.$image->fullsize_hash.'_full.'.$masterlistFormat)->save($image->imagePath.'/'.$image->fullsizeFileName, 100, $fullsizeFormat);
+
+                    if (file_exists($image->imagePath.'/'.$image->fullsizeFileName)) {
+                        unlink($image->imagePath.'/'.$image->id.'_'.$image->hash.'_'.$image->fullsize_hash.'_full.'.$masterlistFormat);
+                    }
+                }
+            }
+        }
+
+        $updates = CharacterDesignUpdate::where('status', '!=', 'Approved');
+        if ($updates->count()) {
+            $this->info('Processing '.$updates->count().' updates...');
+            foreach ($updates->get() as $update) {
+                $updates->update(['extension' => $fullsizeFormat]);
+
+                if (file_exists($update->imagePath.'/'.$update->id.'_'.$update->hash.'.'.$masterlistFormat)) {
+                    Image::make($update->imagePath.'/'.$update->id.'_'.$update->hash.'.'.$masterlistFormat)->save($update->imagePath.'/'.$update->imageFileName, 100, $fullsizeFormat);
+
+                    if (file_exists($update->imagePath.'/'.$update->imageFileName)) {
+                        unlink($update->imagePath.'/'.$update->id.'_'.$update->hash.'.'.$masterlistFormat);
+                    }
+                }
+
+                if (!file_exists($update->imagePath.'/'.$update->thumbnailFileName) && file_exists($update->imagePath.'/'.$update->id.'_'.$update->hash.'_th.'.$fullsizeFormat)) {
+                    Image::make($update->imagePath.'/'.$update->id.'_'.$update->hash.'_th.'.$fullsizeFormat)->save($update->imagePath.'/'.$update->thumbnailFileName, 100, $masterlistFormat);
+
+                    if (file_exists($update->imagePath.'/'.$update->thumbnailFileName)) {
+                        unlink($update->imagePath.'/'.$update->id.'_'.$update->hash.'_th.'.$fullsizeFormat);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/Models/Character/CharacterDesignUpdate.php
+++ b/app/Models/Character/CharacterDesignUpdate.php
@@ -302,7 +302,7 @@ class CharacterDesignUpdate extends Model {
      * @return string
      */
     public function getThumbnailFileNameAttribute() {
-        return $this->id.'_'.$this->hash.'_th.'.$this->extension;
+        return $this->id.'_'.$this->hash.'_th.'.(config('lorekeeper.settings.masterlist_image_format') != $this->extension ? config('lorekeeper.settings.masterlist_image_format') : $this->extension);
     }
 
     /**

--- a/app/Services/CharacterManager.php
+++ b/app/Services/CharacterManager.php
@@ -243,7 +243,7 @@ class CharacterManager extends Service {
             }
 
             // Save the processed image
-            $image->save($characterImage->imagePath.'/'.$characterImage->fullsizeFileName, 100, config('lorekeeper.settings.masterlist_fullsizes_format'));
+            $image->save($characterImage->imagePath.'/'.$characterImage->fullsizeFileName, 100, config('lorekeeper.settings.masterlist_fullsizes_format') != null ? config('lorekeeper.settings.masterlist_fullsizes_format') : $characterImage->fullsize_extension);
         } else {
             // Delete fullsize if it was previously created.
             if (isset($characterImage->fullsize_hash) ? file_exists(public_path($characterImage->imageDirectory.'/'.$characterImage->fullsizeFileName)) : false) {

--- a/app/Services/DesignUpdateManager.php
+++ b/app/Services/DesignUpdateManager.php
@@ -157,7 +157,13 @@ class DesignUpdateManager extends Service {
                     $imageData['use_cropper'] = isset($data['use_cropper']);
                 }
                 if (!$isAdmin && isset($data['image'])) {
-                    $imageData['extension'] = (config('lorekeeper.settings.masterlist_image_format') ? config('lorekeeper.settings.masterlist_image_format') : ($data['extension'] ?? $data['image']->getClientOriginalExtension()));
+                    if (config('lorekeeper.settings.store_masterlist_fullsizes') != null) {
+                        $imageData['extension'] = config('lorekeeper.settings.masterlist_fullsizes_format');
+                    } elseif (config('lorekeeper.settings.masterlist_image_format') != null) {
+                        $imageData['extension'] = config('lorekeeper.settings.masterlist_image_format');
+                    } else {
+                        $imageData['extension'] = $data['image']->getClientOriginalExtension();
+                    }
                     $imageData['has_image'] = true;
                 }
                 $request->update($imageData);
@@ -550,24 +556,23 @@ class DesignUpdateManager extends Service {
                 }
             }
 
-            $extension = config('lorekeeper.settings.masterlist_image_format') != null ? config('lorekeeper.settings.masterlist_image_format') : $request->extension;
-
             // Create a new image with the request data
             $image = CharacterImage::create([
-                'character_id'  => $request->character_id,
-                'is_visible'    => 1,
-                'hash'          => $request->hash,
-                'fullsize_hash' => $request->fullsize_hash ? $request->fullsize_hash : randomString(15),
-                'extension'     => $extension,
-                'use_cropper'   => $request->use_cropper,
-                'x0'            => $request->x0,
-                'x1'            => $request->x1,
-                'y0'            => $request->y0,
-                'y1'            => $request->y1,
-                'species_id'    => $request->species_id,
-                'subtype_id'    => ($request->character->is_myo_slot && isset($request->character->image->subtype_id)) ? $request->character->image->subtype_id : $request->subtype_id,
-                'rarity_id'     => $request->rarity_id,
-                'sort'          => 0,
+                'character_id'       => $request->character_id,
+                'is_visible'         => 1,
+                'hash'               => $request->hash,
+                'fullsize_hash'      => $request->fullsize_hash ? $request->fullsize_hash : randomString(15),
+                'extension'          => config('lorekeeper.settings.masterlist_image_format') != null ? config('lorekeeper.settings.masterlist_image_format') : $request->extension,
+                'fullsize_extension' => config('lorekeeper.settings.masterlist_fullsizes_format') != null ? config('lorekeeper.settings.masterlist_fullsizes_format') : $request->extension,
+                'use_cropper'        => $request->use_cropper,
+                'x0'                 => $request->x0,
+                'x1'                 => $request->x1,
+                'y0'                 => $request->y0,
+                'y1'                 => $request->y1,
+                'species_id'         => $request->species_id,
+                'subtype_id'         => ($request->character->is_myo_slot && isset($request->character->image->subtype_id)) ? $request->character->image->subtype_id : $request->subtype_id,
+                'rarity_id'          => $request->rarity_id,
+                'sort'               => 0,
             ]);
 
             // Shift the image credits over to the new image


### PR DESCRIPTION
- use display image format for thumbnails, fullsize format for design update image
- set fullsize extension when approving design update
- add character image format fix command

Dug down and realized that the issue with incoming fullsize character images not being in the correct file format was largely that design updates weren't handling the distinction very well.
We've been using a version of these fixes successfully for a while now; however this version is, naturally, rendered a little more generic and should be tested regardless to make sure the effects are as intended. 
This is also disentangled from changes made on a few branches and coalesced into one change, so it's worth testing on that basis as well.