### PR TITLE
fix: only decode parsed HTML special chars if not null

### DIFF
--- a/app/Http/Middleware/ParsePostRequestFields.php
+++ b/app/Http/Middleware/ParsePostRequestFields.php
@@ -34,7 +34,9 @@ class ParsePostRequestFields {
                     }
 
                     // Decode HTML special chars
-                    $parsedFields[$key] = htmlspecialchars_decode($parsedFields[$key]);
+                    if ($parsedFields[$key] != null) {
+                        $parsedFields[$key] = htmlspecialchars_decode($parsedFields[$key]);
+                    }
                 }
             }
 
@@ -63,7 +65,9 @@ class ParsePostRequestFields {
                 }
 
                 // Decode HTML special chars
-                $array[$key] = htmlspecialchars_decode($array[$key]);
+                if ($array[$key] != null) {
+                    $array[$key] = htmlspecialchars_decode($array[$key]);
+                }
             }
         }
 


### PR DESCRIPTION
Re the bug report in the server earlier; tested locally.