### PR TITLE
feat(users): add "is admin" flag to ranks

### DIFF
--- a/app/Console/Commands/SetIsAdmin.php
+++ b/app/Console/Commands/SetIsAdmin.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Rank\Rank;
+use Illuminate\Console\Command;
+
+class SetIsAdmin extends Command {
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:set-is-admin';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Sets the "is admin" property for existing ranks.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle() {
+        $adminRank = Rank::orderBy('sort', 'DESC')->first();
+
+        $adminRank->update([
+            'is_admin' => 1,
+        ]);
+    }
+}

--- a/app/Console/Commands/SetupAdminUser.php
+++ b/app/Console/Commands/SetupAdminUser.php
@@ -49,6 +49,7 @@ class SetupAdminUser extends Command {
                 'name'        => 'Admin',
                 'description' => 'The site admin. Has the ability to view/edit any data on the site.',
                 'sort'        => 1,
+                'is_admin'    => 1,
             ]);
             Rank::create([
                 'name'        => 'Member',

--- a/app/Models/Rank/Rank.php
+++ b/app/Models/Rank/Rank.php
@@ -13,6 +13,7 @@ class Rank extends Model {
      */
     protected $fillable = [
         'name', 'description', 'parsed_description', 'sort', 'color', 'icon',
+        'is_admin',
     ];
 
     /**
@@ -21,6 +22,7 @@ class Rank extends Model {
      * @var string
      */
     protected $table = 'ranks';
+
     /**
      * Validation rules for ranks.
      *
@@ -71,11 +73,7 @@ class Rank extends Model {
      * @return bool
      */
     public function getIsAdminAttribute() {
-        if ($this->id == self::orderBy('sort', 'DESC')->first()->id) {
-            return true;
-        }
-
-        return false;
+        return $this->attributes['is_admin'];
     }
 
     /**********************************************************************************************
@@ -123,7 +121,7 @@ class Rank extends Model {
             return true;
         }
 
-        return $this->powers()->where('power', $power)->exists();
+        return $this->powers->where('power', $power)->exists();
     }
 
     /**

--- a/app/Services/RankService.php
+++ b/app/Services/RankService.php
@@ -170,14 +170,14 @@ class RankService extends Service {
             $sort = array_reverse(explode(',', $data));
 
             // Check if the array contains the admin rank, or anything non-numeric
-            $adminRank = Rank::orderBy('sort', 'DESC')->first();
+            $adminRank = Rank::where('is_admin', 1)->first();
             $count = 0;
             foreach ($sort as $key => $s) {
                 if (!is_numeric($s) || !is_numeric($key)) {
                     throw new \Exception('Invalid sort order.');
                 }
                 if ($s == $adminRank->id) {
-                    throw new \Exception('Sort order of admin rank cannot be changed.');
+                    throw new \Exception('The sort order of the admin rank cannot be changed.');
                 }
 
                 Rank::where('id', $s)->update(['sort' => $key]);

--- a/database/migrations/2025_01_02_210931_add_is_admin_to_ranks.php
+++ b/database/migrations/2025_01_02_210931_add_is_admin_to_ranks.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void {
+        Schema::table('ranks', function (Blueprint $table) {
+            $table->boolean('is_admin')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void {
+        Schema::table('ranks', function (Blueprint $table) {
+            $table->dropColumn('is_admin');
+        });
+    }
+};


### PR DESCRIPTION
Functionally a really minor performance improvement; rather than determine the admin rank via sort (as is currently the case), just has it as a bool. This saves some queries and thus some fractions of a second wherever powers are checked.

Includes relevant adjustments to the admin user setup command, as well as a new command, `php artisan app:set-is-admin`, to set it for an existing admin rank.