### PR TITLE
fix(galleries): ignore protocol when finding prompt submissions using a gallery submission

### DIFF
--- a/app/Models/Gallery/GallerySubmission.php
+++ b/app/Models/Gallery/GallerySubmission.php
@@ -480,7 +480,7 @@ class GallerySubmission extends Model {
     public function getPromptSubmissionsAttribute() {
         // Only returns submissions which are viewable to everyone,
         // but given that this is for the sake of public display, that's fine
-        return Submission::viewable()->whereNotNull('prompt_id')->where('url', $this->url)->get();
+        return Submission::viewable()->whereNotNull('prompt_id')->where('url', 'like', '%'.request()->getHost().'/gallery/view/'.$this->id)->get();
     }
 
     /**


### PR DESCRIPTION
Alternately put: makes it so that `www.` vs not doesn't cause problems. We've been using this for a bit without issue, but more eyes always welcome.