### PR TITLE
fix(galleries): implement eager loading, refactor queries

### DIFF
--- a/app/Http/Controllers/GalleryController.php
+++ b/app/Http/Controllers/GalleryController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers;
 
 use App\Facades\Settings;
 use App\Models\Character\Character;
-use App\Models\Comment\Comment;
 use App\Models\Currency\Currency;
 use App\Models\Gallery\Gallery;
 use App\Models\Gallery\GallerySubmission;
@@ -13,7 +12,7 @@ use App\Models\User\User;
 use App\Services\GalleryManager;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use View;
+use Illuminate\Support\Facades\View;
 
 class GalleryController extends Controller {
     /*
@@ -39,10 +38,13 @@ class GalleryController extends Controller {
      * @return \Illuminate\Contracts\Support\Renderable
      */
     public function getGalleryIndex() {
+        $galleries = Gallery::whereNull('parent_id')->active()->sort()->with('children', 'children.submissions', 'submissions')->withCount('submissions', 'children');
+
         return view('galleries.index', [
-            'galleries'   => Gallery::sort()->active()->whereNull('parent_id')->paginate(10),
-            'galleryPage' => false,
-            'sideGallery' => null,
+            'galleries'       => $galleries->paginate(10),
+            'galleryPage'     => false,
+            'sideGallery'     => null,
+            'submissionsOpen' => Settings::get('gallery_submissions_open'),
         ]);
     }
 
@@ -54,12 +56,12 @@ class GalleryController extends Controller {
      * @return \Illuminate\Contracts\Support\Renderable
      */
     public function getGallery($id, Request $request) {
-        $gallery = Gallery::visible()->where('id', $id)->first();
+        $gallery = Gallery::visible()->where('id', $id)->withCount('submissions')->first();
         if (!$gallery) {
             abort(404);
         }
 
-        $query = GallerySubmission::where('gallery_id', $gallery->id)->visible(Auth::check() ? Auth::user() : null)->accepted();
+        $query = GallerySubmission::where('gallery_id', $gallery->id)->visible(Auth::check() ? Auth::user() : null);
         $sort = $request->only(['sort']);
 
         if ($request->get('title')) {
@@ -99,8 +101,8 @@ class GalleryController extends Controller {
         return view('galleries.gallery', [
             'gallery'          => $gallery,
             'submissions'      => $query->paginate(20)->appends($request->query()),
-            'prompts'          => [0 => 'Any Prompt'] + Prompt::whereIn('id', GallerySubmission::where('gallery_id', $gallery->id)->visible(Auth::check() ? Auth::user() : null)->accepted()->whereNotNull('prompt_id')->select('prompt_id')->distinct()->pluck('prompt_id')->toArray())->orderBy('name')->pluck('name', 'id')->toArray(),
-            'childSubmissions' => GallerySubmission::whereIn('gallery_id', $gallery->children->pluck('id')->toArray())->where('is_visible', 1)->where('status', 'Accepted'),
+            'prompts'          => [0 => 'Any Prompt'] + Prompt::whereIn('id', GallerySubmission::where('gallery_id', $gallery->id)->withOnly('prompt')->visible(Auth::user() ?? null)->whereNotNull('prompt_id')->select('prompt_id')->distinct()->pluck('prompt_id')->toArray())->orderBy('name')->pluck('name', 'id')->toArray(),
+            'childSubmissions' => $gallery->through('children')->has('submissions')->where('is_visible', 1)->where('status', 'Accepted'),
             'galleryPage'      => true,
             'sideGallery'      => $gallery,
         ]);
@@ -155,7 +157,7 @@ class GalleryController extends Controller {
 
         return view('galleries.showall', [
             'submissions' => $query->paginate(20)->appends($request->query()),
-            'prompts'     => [0 => 'Any Prompt'] + Prompt::whereIn('id', GallerySubmission::visible(Auth::check() ? Auth::user() : null)->accepted()->whereNotNull('prompt_id')->pluck('prompt_id')->toArray())->orderBy('name')->pluck('name', 'id')->toArray(),
+            'prompts'     => [0 => 'Any Prompt'] + Prompt::whereIn('id', GallerySubmission::visible(Auth::user() ?? null)->accepted()->withOnly('prompt')->whereNotNull('prompt_id')->pluck('prompt_id')->toArray())->orderBy('name')->pluck('name', 'id')->toArray(),
             'galleryPage' => false,
         ]);
     }
@@ -168,7 +170,7 @@ class GalleryController extends Controller {
      * @return \Illuminate\Contracts\Support\Renderable
      */
     public function getSubmission($id) {
-        $submission = GallerySubmission::find($id);
+        $submission = GallerySubmission::where('id', $id)->with('gallery', 'participants', 'characters')->first();
         if (!$submission) {
             abort(404);
         }
@@ -187,7 +189,6 @@ class GalleryController extends Controller {
 
         return view('galleries.submission', [
             'submission'   => $submission,
-            'commentCount' => Comment::where('commentable_type', 'App\Models\Gallery\GallerySubmission')->where('commentable_id', $submission->id)->where('type', 'User-User')->count(),
             'galleryPage'  => true,
             'sideGallery'  => $submission->gallery,
         ]);
@@ -201,10 +202,12 @@ class GalleryController extends Controller {
      * @return \Illuminate\Contracts\Support\Renderable
      */
     public function getSubmissionFavorites($id) {
-        $submission = GallerySubmission::find($id);
+        $submission = GallerySubmission::where('id', $id)->withOnly('favorites')->first();
+        $favorites = $submission->favorites()->with('user')->get();
 
         return view('galleries._submission_favorites', [
             'submission' => $submission,
+            'favorites'  => $favorites,
         ]);
     }
 
@@ -216,7 +219,7 @@ class GalleryController extends Controller {
      * @return \Illuminate\Contracts\Support\Renderable
      */
     public function getSubmissionLog($id) {
-        $submission = GallerySubmission::find($id);
+        $submission = GallerySubmission::where('id', $id)->with('participants')->without('favorites', 'comments')->first();
         if (!$submission) {
             abort(404);
         }
@@ -242,12 +245,12 @@ class GalleryController extends Controller {
     /**
      * Shows the user's gallery submission log.
      *
-     * @param mixed $type
+     * @param string $type
      *
      * @return \Illuminate\Contracts\Support\Renderable
      */
     public function getUserSubmissions(Request $request, $type) {
-        $submissions = GallerySubmission::userSubmissions(Auth::user());
+        $submissions = GallerySubmission::userSubmissions(Auth::user())->with('gallery')->without('favorites', 'comments');
         if (!$type) {
             $type = 'Pending';
         }
@@ -300,7 +303,7 @@ class GalleryController extends Controller {
         if (!Auth::check()) {
             abort(404);
         }
-        $submission = GallerySubmission::find($id);
+        $submission = GallerySubmission::where('id', $id)->with('gallery')->with('participants', 'characters')->without('comments', 'favorites')->first();
         if (!$submission || $submission->status == 'Rejected') {
             abort(404);
         }

--- a/app/Models/Gallery/Gallery.php
+++ b/app/Models/Gallery/Gallery.php
@@ -2,7 +2,6 @@
 
 namespace App\Models\Gallery;
 
-use App\Facades\Settings;
 use App\Models\Model;
 use Carbon\Carbon;
 
@@ -202,12 +201,13 @@ class Gallery extends Model {
     /**
      * Gets whether or not the user can submit to the gallery.
      *
+     * @param bool       $submissionsOpen
      * @param mixed|null $user
      *
      * @return string
      */
-    public function canSubmit($user = null) {
-        if (Settings::get('gallery_submissions_open')) {
+    public function canSubmit($submissionsOpen, $user = null) {
+        if ($submissionsOpen) {
             if ((isset($this->start_at) && $this->start_at->isFuture()) || (isset($this->end_at) && $this->end_at->isPast())) {
                 return false;
             } elseif ($user && $user->hasPower('manage_submissions')) {

--- a/app/Models/Gallery/GalleryCollaborator.php
+++ b/app/Models/Gallery/GalleryCollaborator.php
@@ -25,6 +25,15 @@ class GalleryCollaborator extends Model {
      */
     protected $table = 'gallery_submission_collaborators';
 
+    /**
+     * The relationships that should always be loaded.
+     *
+     * @var array
+     */
+    protected $with = [
+        'user',
+    ];
+
     /**********************************************************************************************
 
         RELATIONS

--- a/app/Models/Gallery/GallerySubmission.php
+++ b/app/Models/Gallery/GallerySubmission.php
@@ -3,6 +3,7 @@
 namespace App\Models\Gallery;
 
 use App\Facades\Settings;
+use App\Models\Comment\Comment;
 use App\Models\Currency\Currency;
 use App\Models\Model;
 use App\Models\Prompt\Prompt;
@@ -33,6 +34,24 @@ class GallerySubmission extends Model {
      * @var string
      */
     protected $table = 'gallery_submissions';
+
+    /**
+     * The relationships that should always be loaded.
+     *
+     * @var array
+     */
+    protected $with = [
+        'user', 'collaborators', 'prompt:id,name,prefix', 'favorites', 'comments:id,commentable_type,commentable_id,type',
+    ];
+
+    /**
+     * 	The relationship counts that should be eager loaded on every query.
+     *
+     * @var array
+     */
+    protected $withCount = [
+        'favorites',
+    ];
 
     /**
      * Whether the model contains timestamps to be saved and updated.
@@ -74,7 +93,7 @@ class GallerySubmission extends Model {
      * Get the user who made the submission.
      */
     public function user() {
-        return $this->belongsTo(User::class, 'user_id');
+        return $this->belongsTo(User::class);
     }
 
     /**
@@ -88,42 +107,49 @@ class GallerySubmission extends Model {
      * Get the collaborating users on the submission.
      */
     public function collaborators() {
-        return $this->hasMany(GalleryCollaborator::class, 'gallery_submission_id')->where('type', 'Collab');
+        return $this->hasMany(GalleryCollaborator::class)->where('type', 'Collab');
     }
 
     /**
      * Get the user(s) who are related to the submission in some way.
      */
     public function participants() {
-        return $this->hasMany(GalleryCollaborator::class, 'gallery_submission_id')->where('type', '!=', 'Collab');
+        return $this->hasMany(GalleryCollaborator::class)->where('type', '!=', 'Collab');
     }
 
     /**
      * Get the characters associated with the submission.
      */
     public function characters() {
-        return $this->hasMany(GalleryCharacter::class, 'gallery_submission_id');
+        return $this->hasMany(GalleryCharacter::class);
     }
 
     /**
      * Get any favorites on the submission.
      */
     public function favorites() {
-        return $this->hasMany(GalleryFavorite::class, 'gallery_submission_id');
+        return $this->hasMany(GalleryFavorite::class);
     }
 
     /**
      * Get the gallery this submission is in.
      */
     public function gallery() {
-        return $this->belongsTo(Gallery::class, 'gallery_id');
+        return $this->belongsTo(Gallery::class);
     }
 
     /**
      * Get the prompt this submission is for if relevant.
      */
     public function prompt() {
-        return $this->belongsTo(Prompt::class, 'prompt_id');
+        return $this->belongsTo(Prompt::class);
+    }
+
+    /**
+     * Get comments made on this submission.
+     */
+    public function comments() {
+        return $this->morphMany(Comment::class, 'commentable');
     }
 
     /**********************************************************************************************
@@ -151,7 +177,9 @@ class GallerySubmission extends Model {
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeCollaboratorApproved($query) {
-        return $query->whereNotIn('id', GalleryCollaborator::where('has_approved', 0)->pluck('gallery_submission_id')->toArray());
+        return $query->whereHas('collaborators', function ($query) {
+            $query->where('has_approved', 1);
+        })->orWhereDoesntHave('collaborators');
     }
 
     /**
@@ -200,7 +228,9 @@ class GallerySubmission extends Model {
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeUserSubmissions($query, $user) {
-        return $query->where('user_id', $user->id)->orWhereIn('id', GalleryCollaborator::where('user_id', $user->id)->where('type', 'Collab')->pluck('gallery_submission_id')->toArray());
+        return $query->where('user_id', $user->id)->orWhereHas('collaborators', function ($query) use ($user) {
+            $query->where('user_id', $user->id)->where('type', 'Collab');
+        });
     }
 
     /**
@@ -328,15 +358,6 @@ class GallerySubmission extends Model {
     }
 
     /**
-     * Gets the voting data of the gallery submission.
-     *
-     * @return string
-     */
-    public function getVoteDataAttribute() {
-        return collect(json_decode($this->attributes['vote_data'], true));
-    }
-
-    /**
      * Get the title of the submission, with prefix.
      *
      * @return string
@@ -364,13 +385,11 @@ class GallerySubmission extends Model {
     }
 
     /**
-     * Checks if all of a submission's collaborators have approved or no.
+     * Get the prefix for a submission.
      *
      * @return string
      */
     public function getPrefixAttribute() {
-        $currencyName = Currency::find(Settings::get('group_currency'))->abbreviation ? Currency::find(Settings::get('group_currency'))->abbreviation : Currency::find(Settings::get('group_currency'))->name;
-
         $prefixList = [];
         if ($this->promptSubmissions->count()) {
             foreach ($this->prompts as $prompt) {
@@ -394,6 +413,8 @@ class GallerySubmission extends Model {
                     $prefixList[] = 'Comm';
                     break;
                 case 'Comm (Currency)':
+                    $currencyName = Currency::find(Settings::get('group_currency'))->abbreviation ? Currency::find(Settings::get('group_currency'))->abbreviation : Currency::find(Settings::get('group_currency'))->name;
+
                     $prefixList[] = 'Comm ('.$currencyName.')';
                     break;
             }
@@ -432,7 +453,7 @@ class GallerySubmission extends Model {
      */
     public function getCreditsAttribute() {
         if ($this->collaborators->count()) {
-            foreach ($this->collaborators as $count=> $collaborator) {
+            foreach ($this->collaborators as $collaborator) {
                 $collaboratorList[] = $collaborator->user->displayName;
             }
 
@@ -449,7 +470,7 @@ class GallerySubmission extends Model {
      */
     public function getCreditsPlainAttribute() {
         if ($this->collaborators->count()) {
-            foreach ($this->collaborators as $count=> $collaborator) {
+            foreach ($this->collaborators as $collaborator) {
                 $collaboratorList[] = $collaborator->user->name;
             }
 
@@ -464,7 +485,7 @@ class GallerySubmission extends Model {
      *
      * @return string
      */
-    public function getCollaboratorApprovedAttribute() {
+    public function getCollaboratorApprovalAttribute() {
         if ($this->collaborators->where('has_approved', 0)->count()) {
             return false;
         }
@@ -505,5 +526,51 @@ class GallerySubmission extends Model {
         } else {
             return strip_tags(substr($this->parsed_text, 0, 500)).(strlen($this->parsed_text) > 500 ? '...' : '');
         }
+    }
+
+    /**********************************************************************************************
+
+        OTHER FUNCTIONS
+
+     **********************************************************************************************/
+
+    /**
+     * Gets the voting data of the gallery submission and performs preliminary processing.
+     *
+     * @param bool $withUsers
+     *
+     * @return array
+     */
+    public function getVoteData($withUsers = 0) {
+        $voteData['raw'] = json_decode($this->attributes['vote_data'], true);
+
+        // Only query users if necessary, and condense to one query per submission
+        if ($withUsers) {
+            $users = User::whereIn('id', array_keys($voteData['raw']))->select('id', 'name', 'rank_id')->get();
+        } else {
+            $users = null;
+        }
+
+        $voteData['raw'] = collect($voteData['raw'])->mapWithKeys(function ($vote, $id) use ($users) {
+            return [$id => [
+                'vote' => $vote,
+                'user' => $users ? $users->where('id', $id)->first() : $id,
+            ]];
+        });
+
+        // Tally approve/reject sums for ease
+        $voteData['approve'] = $voteData['reject'] = 0;
+        foreach ($voteData['raw'] as $vote) {
+            switch ($vote['vote']) {
+                case 1:
+                    $voteData['reject'] += 1;
+                    break;
+                case 2:
+                    $voteData['approve'] += 1;
+                    break;
+            }
+        }
+
+        return $voteData;
     }
 }

--- a/app/Services/GalleryManager.php
+++ b/app/Services/GalleryManager.php
@@ -372,7 +372,7 @@ class GalleryManager extends Service {
 
                 // Check if all collaborators have approved, and if so send a notification to the
                 // submitting user (unless they are the last to approve-- which shouldn't happen, but)
-                if ($submission->collaboratorApproved) {
+                if ($submission->collaboratorApproval) {
                     if (Settings::get('gallery_submissions_require_approval') && $submission->gallery->votes_required > 0) {
                         if ($submission->user->id != $user->id) {
                             Notifications::create('GALLERY_COLLABORATORS_APPROVED', $submission->user, [
@@ -410,7 +410,7 @@ class GalleryManager extends Service {
             if ($submission->status != 'Pending') {
                 throw new \Exception('This request cannot be processed.');
             }
-            if (!$submission->collaboratorApproved) {
+            if (!$submission->collaboratorApproval) {
                 throw new \Exception("This submission's collaborators have not all approved yet.");
             }
 
@@ -428,30 +428,18 @@ class GalleryManager extends Service {
 
             // Get existing vote data if it exists, remove any existing vote data for the user,
             // add the new vote data, and json encode it
-            $voteData = (isset($submission->vote_data) ? collect(json_decode($submission->vote_data, true)) : collect([]));
+            $voteData = (isset($submission->attributes['vote_data']) ? collect(json_decode($submission->attributes['vote_data'], true)) : collect([]));
             $voteData->get($user->id) ? $voteData->pull($user->id) : null;
             $voteData->put($user->id, $vote);
             $submission->vote_data = $voteData->toJson();
 
             $submission->save();
 
-            // Count up the existing votes to see if the required number has been reached
-            $rejectSum = 0;
-            $approveSum = 0;
-            foreach ($submission->voteData as $voter=> $vote) {
-                if ($vote == 1) {
-                    $rejectSum += 1;
-                }
-                if ($vote == 2) {
-                    $approveSum += 1;
-                }
-            }
-
-            // And if so, process the submission
-            if ($action == 'reject' && $rejectSum >= $submission->gallery->votes_required) {
+            // Process the submission if the required number of votes has been reached
+            if ($action == 'reject' && $submission->getVoteData()['reject'] >= $submission->gallery->votes_required) {
                 $this->rejectSubmission($submission, $user);
             }
-            if ($action == 'accept' && $approveSum >= $submission->gallery->votes_required) {
+            if ($action == 'accept' && $submission->getVoteData()['approve'] >= $submission->gallery->votes_required) {
                 $this->acceptSubmission($submission);
             }
 

--- a/resources/views/galleries/_queue_submission.blade.php
+++ b/resources/views/galleries/_queue_submission.blade.php
@@ -15,39 +15,29 @@
                 In {!! $submission->gallery->displayName !!} ・ By {!! $submission->credits !!}<br />
                 Submitted {!! pretty_date($submission->created_at) !!} ・ Last updated {!! pretty_date($submission->updated_at) !!}
 
-                @if ($submission->status == 'Pending' && $submission->collaboratorApproved && Auth::user()->hasPower('manage_submissions'))
-                    <?php
-                    $rejectSum[$key] = 0;
-                    $approveSum[$key] = 0;
-                    foreach ($submission->voteData as $voter => $vote) {
-                        if ($vote == 1) {
-                            $rejectSum[$key] += 1;
-                        }
-                        if ($vote == 2) {
-                            $approveSum[$key] += 1;
-                        }
-                    }
-                    ?>
+                @if ($submission->status == 'Pending' && $submission->collaboratorApproval && Auth::user()->hasPower('manage_submissions'))
                     <div class="row mt-2">
                         <div class="col-6 text-right text-danger">
-                            {{ $rejectSum[$key] }}/{{ $submission->gallery->votes_required }}
+                            {{ $submission->getVoteData()['reject'] }}/{{ $submission->gallery->votes_required }}
                             {!! Form::open(['url' => 'admin/gallery/edit/' . $submission->id . '/reject', 'id' => 'voteRejectForm']) !!}
-                            <button class="btn {{ $submission->voteData->get(Auth::user()->id) == 1 ? 'btn-danger' : 'btn-outline-danger' }}" style="min-width:40px;" data-action="reject"><i class="fas fa-times"></i></button>
+                            <button class="btn {{ ($submission->getVoteData()['raw']->get(Auth::user()->id)['vote'] ?? 0) == 1 ? 'btn-danger' : 'btn-outline-danger' }}" style="min-width:40px;" data-action="reject"><i
+                                    class="fas fa-times"></i></button>
                             {!! Form::close() !!}
                         </div>
                         <div class="col-6 text-left text-success">
-                            {{ $approveSum[$key] }}/{{ $submission->gallery->votes_required }}
+                            {{ $submission->getVoteData()['approve'] }}/{{ $submission->gallery->votes_required }}
                             {!! Form::open(['url' => 'admin/gallery/edit/' . $submission->id . '/accept', 'id' => 'voteApproveForm']) !!}
-                            <button class="btn {{ $submission->voteData->get(Auth::user()->id) == 2 ? 'btn-success' : 'btn-outline-success' }}" style="min-width:40px;" data-action="approve"><i class="fas fa-check"></i></button>
+                            <button class="btn {{ ($submission->getVoteData()['raw']->get(Auth::user()->id)['vote'] ?? 0) == 2 ? 'btn-success' : 'btn-outline-success' }}" style="min-width:40px;" data-action="approve"><i
+                                    class="fas fa-check"></i></button>
                             {!! Form::close() !!}
                         </div>
                     </div>
                 @endif
 
                 @if (isset($queue) && $queue)
-                    <h6 class="mt-2">{{ App\Models\Comment\Comment::where('commentable_type', 'App\Models\Gallery\GallerySubmission')->where('commentable_id', $submission->id)->where('type', 'Staff-User')->count() }}
-                        {{ Auth::user()->hasPower('manage_submissions')? 'Staff↔User Comment' .(App\Models\Comment\Comment::where('commentable_type', 'App\Models\Gallery\GallerySubmission')->where('commentable_id', $submission->id)->where('type', 'Staff-User')->count() != 1? 's': '') .' ・ ': 'Staff Comment' }}
-                        {{ Auth::user()->hasPower('manage_submissions')? App\Models\Comment\Comment::where('commentable_type', 'App\Models\Gallery\GallerySubmission')->where('commentable_id', $submission->id)->where('type', 'Staff-Staff')->count() .' Staff↔Staff Comment' .(App\Models\Comment\Comment::where('commentable_type', 'App\Models\Gallery\GallerySubmission')->where('commentable_id', $submission->id)->where('type', 'Staff-Staff')->count() != 1? 's': ''): '' }}
+                    <h6 class="mt-2">{{ $submission->comments->where('type', 'Staff-User')->count() }}
+                        {{ Auth::user()->hasPower('manage_submissions') ? 'Staff↔User Comment' . ($submission->comments->where('type', 'Staff-User')->count() != 1 ? 's' : '') . ' ・ ' : 'Staff Comment' }}
+                        {{ Auth::user()->hasPower('manage_submissions') ? $submission->comments->where('type', 'Staff-Staff')->count() . ' Staff↔Staff Comment' . ($submission->comments->where('type', 'Staff-Staff')->count() != 1 ? 's' : '') : '' }}
                     </h6>
                     <h6 class="mt-2"><a href="{{ $submission->queueUrl }}">Detailed Log</a></h6>
                 @endif

--- a/resources/views/galleries/_submission_favorites.blade.php
+++ b/resources/views/galleries/_submission_favorites.blade.php
@@ -1,6 +1,6 @@
 @if ($submission)
     <ul>
-        @foreach ($submission->favorites as $favorite)
+        @foreach ($favorites as $favorite)
             <li>{!! $favorite->user->displayName !!}</li>
         @endforeach
     </ul>

--- a/resources/views/galleries/_thumb.blade.php
+++ b/resources/views/galleries/_thumb.blade.php
@@ -27,14 +27,14 @@
             @else
                 ・
             @endif
-            {{ $submission->favorites->count() }} {!! Form::button('<i class="fas fa-star"></i> ', [
+            {{ $submission->favorites_count }} {!! Form::button('<i class="fas fa-star"></i> ', [
                 'style' => 'border:0; border-radius:.5em;',
                 'class' => $submission->favorites->where('user_id', Auth::user()->id)->first() != null ? 'btn-success' : '',
                 'data-toggle' => 'tooltip',
                 'title' => ($submission->favorites->where('user_id', Auth::user()->id)->first() == null ? 'Add to' : 'Remove from') . ' your Favorites',
                 'type' => 'submit',
             ]) !!} ・
-            {{ App\Models\Comment\Comment::where('commentable_type', 'App\Models\Gallery\GallerySubmission')->where('commentable_id', $submission->id)->where('type', 'User-User')->count() }}
+            {{ $submission->comments->where('type', 'User-User')->count() }}
             <i class="fas fa-comment"></i>
             {!! Form::close() !!}
         @else
@@ -47,9 +47,8 @@
             @else
                 ・
             @endif
-            {{ $submission->favorites->count() }} <i class="fas fa-star" data-toggle="tooltip" title="Favorites"></i> ・
-            {{ App\Models\Comment\Comment::where('commentable_type', 'App\Models\Gallery\GallerySubmission')->where('commentable_id', $submission->id)->where('type', 'User-User')->count() }} <i class="fas fa-comment" data-toggle="tooltip"
-                title="Comments"></i>
+            {{ $submission->favorites_count }} <i class="fas fa-star" data-toggle="tooltip" title="Favorites"></i> ・
+            {{ $submission->comments->where('type', 'User-User')->count() }} <i class="fas fa-comment" data-toggle="tooltip" title="Comments"></i>
         @endif
     </div>
 </div>

--- a/resources/views/galleries/gallery.blade.php
+++ b/resources/views/galleries/gallery.blade.php
@@ -10,7 +10,7 @@
 
     <h1>
         {{ $gallery->name }}
-        @if (Auth::check() && $gallery->canSubmit(Auth::user()))
+        @if (Auth::check() && $gallery->canSubmit(Settings::get('gallery_submissions_open'), Auth::user()))
             <a href="{{ url('gallery/submit/' . $gallery->id) }}" class="btn btn-primary float-right"><i class="fas fa-plus mr-1"></i> Submit</a>
         @endif
     </h1>
@@ -26,7 +26,7 @@
         </p>
     @endif
     <p>{!! $gallery->description !!}</p>
-    @if (!$gallery->submissions()->count() && $gallery->children->count() && $childSubmissions->count())
+    @if (!$gallery->submissions_count && $gallery->children->count() && $childSubmissions->count())
         <p>This gallery has no submissions; instead, displayed is a selection of the most recent submissions from its sub-galleries. Please navigate to one of the sub-galleries to view more.</p>
     @endif
 
@@ -59,7 +59,7 @@
         {!! Form::close() !!}
     </div>
 
-    @if ($gallery->submissions()->count())
+    @if ($gallery->submissions_count)
         {!! $submissions->render() !!}
 
         <div class="d-flex align-content-around flex-wrap mb-2">

--- a/resources/views/galleries/index.blade.php
+++ b/resources/views/galleries/index.blade.php
@@ -25,11 +25,11 @@
                 <div class="card-header">
                     <h4>
                         {!! $gallery->displayName !!}
-                        @if (Auth::check() && $gallery->canSubmit(Auth::user()))
+                        @if (Auth::check() && $gallery->canSubmit($submissionsOpen, Auth::user()))
                             <a href="{{ url('gallery/submit/' . $gallery->id) }}" class="btn btn-primary float-right"><i class="fas fa-plus"></i></a>
                         @endif
                     </h4>
-                    @if ($gallery->children->count() || (isset($gallery->start_at) || isset($gallery->end_at)))
+                    @if ($gallery->children_count || (isset($gallery->start_at) || isset($gallery->end_at)))
                         <p>
                             @if (isset($gallery->start_at) || isset($gallery->end_at))
                                 @if ($gallery->start_at)
@@ -40,10 +40,10 @@
                                     <strong>Close{{ $gallery->end_at->isFuture() ? 's' : 'ed' }}: </strong>{!! pretty_date($gallery->end_at) !!}
                                 @endif
                             @endif
-                            {{ $gallery->children->count() && (isset($gallery->start_at) || isset($gallery->end_at)) ? ' ・ ' : '' }}
-                            @if ($gallery->children->count())
+                            {{ $gallery->children_count && (isset($gallery->start_at) || isset($gallery->end_at)) ? ' ・ ' : '' }}
+                            @if ($gallery->children_count)
                                 Sub-galleries:
-                                @foreach ($gallery->children()->visible()->get() as $count => $child)
+                                @foreach ($gallery->children()->visible()->get() as $child)
                                     {!! $child->displayName !!}{{ !$loop->last ? ', ' : '' }}
                                 @endforeach
                             @endif
@@ -51,22 +51,22 @@
                     @endif
                 </div>
                 <div class="card-body">
-                    @if ($gallery->submissions()->where('status', 'Accepted')->count())
+                    @if ($gallery->submissions_count)
                         <div class="row">
-                            @foreach ($gallery->submissions()->where('is_visible', 1)->where('status', 'Accepted')->take(4)->get() as $submission)
+                            @foreach ($gallery->submissions->take(4) as $submission)
                                 <div class="col-md-3 text-center align-self-center">
                                     @include('galleries._thumb', ['submission' => $submission, 'gallery' => true])
                                 </div>
                             @endforeach
                         </div>
-                        @if ($gallery->submissions()->where('status', 'Accepted')->count() > 4)
+                        @if ($gallery->submissions_count > 4)
                             <div class="text-right"><a href="{{ url('gallery/' . $gallery->id) }}">See More...</a></div>
                         @endif
                     @elseif(
-                        $gallery->children->count() &&
-                            App\Models\Gallery\GallerySubmission::whereIn('gallery_id', $gallery->children->pluck('id')->toArray())->where('is_visible', 1)->where('status', 'Accepted')->count())
+                        $gallery->children_count &&
+                            $gallery->through('children')->has('submissions')->where('is_visible', 1)->where('status', 'Accepted')->count())
                         <div class="row">
-                            @foreach (App\Models\Gallery\GallerySubmission::whereIn('gallery_id', $gallery->children->pluck('id')->toArray())->where('is_visible', 1)->where('status', 'Accepted')->orderBy('created_at', 'DESC')->get()->take(4) as $submission)
+                            @foreach ($gallery->through('children')->has('submissions')->where('is_visible', 1)->where('status', 'Accepted')->orderBy('created_at', 'DESC')->get()->take(4) as $submission)
                                 <div class="col-md-3 text-center align-self-center">
                                     @include('galleries._thumb', ['submission' => $submission, 'gallery' => false])
                                 </div>

--- a/resources/views/galleries/submission.blade.php
+++ b/resources/views/galleries/submission.blade.php
@@ -43,7 +43,8 @@
                 By {!! $submission->credits !!}
             </div>
             <div class="col-md text-right">
-                {{ $submission->favorites->count() }} Favorite{{ $submission->favorites->count() != 1 ? 's' : '' }} ・ {{ $commentCount }} Comment{{ $commentCount != 1 ? 's' : '' }}
+                {{ $submission->favorites_count }} Favorite{{ $submission->favorites_count != 1 ? 's' : '' }} ・ {{ $submission->comments->where('type', 'User-User')->count() }}
+                Comment{{ $submission->comments->where('type', 'User-User')->count() != 1 ? 's' : '' }}
             </div>
         </diV>
     </div>
@@ -92,10 +93,11 @@
                                         'data-toggle' => 'tooltip',
                                         'title' => ($submission->favorites->where('user_id', Auth::user()->id)->first() == null ? 'Add to' : 'Remove from') . ' your Favorites',
                                         'type' => 'submit',
-                                    ]) !!} ・ {{ $commentCount }} <i class="fas fa-comment"></i>
+                                    ]) !!} ・ {{ $submission->comments->where('type', 'User-User')->count() }} <i class="fas fa-comment"></i>
                                     {!! Form::close() !!}
                                 @else
-                                    {{ $submission->favorites->count() }} <i class="fas fa-star" data-toggle="tooltip" title="Favorites"></i> ・ {{ $commentCount }} <i class="fas fa-comment" data-toggle="tooltip" title="Comments"></i>
+                                    {{ $submission->favorites->count() }} <i class="fas fa-star" data-toggle="tooltip" title="Favorites"></i> ・ {{ $submission->comments->where('type', 'User-User')->count() }} <i class="fas fa-comment"
+                                        data-toggle="tooltip" title="Comments"></i>
                                 @endif
                             </div>
                             In {!! $submission->gallery->displayName !!} ・ By {!! $submission->credits !!}

--- a/resources/views/galleries/submission_log.blade.php
+++ b/resources/views/galleries/submission_log.blade.php
@@ -9,7 +9,7 @@
 
     <h1>Log Details
         <span
-            class="float-right badge badge-{{ $submission->status == 'Pending' ? 'secondary' : ($submission->status == 'Accepted' ? 'success' : 'danger') }}">{{ $submission->collaboratorApproved ? $submission->status : 'Pending Collaborator Approval' }}</span>
+            class="float-right badge badge-{{ $submission->status == 'Pending' ? 'secondary' : ($submission->status == 'Accepted' ? 'success' : 'danger') }}">{{ $submission->collaboratorApproval ? $submission->status : 'Pending Collaborator Approval' }}</span>
     </h1>
 
     @include('galleries._queue_submission', ['key' => 0])
@@ -129,7 +129,7 @@
                                             @if (config('lorekeeper.group_currency_form')[$key]['type'] == 'choice')
                                                 @if (isset(config('lorekeeper.group_currency_form')[$key]['multiple']) && config('lorekeeper.group_currency_form')[$key]['multiple'] == 'true')
                                                     @foreach ($data as $answer)
-                                                        {{ config('lorekeeper.group_currency_form')[$key]['choices'][$answer] }}<br />
+                                                        {{ config('lorekeeper.group_currency_form')[$key]['choices'][$answer] ?? '-' }}<br />
                                                     @endforeach
                                                 @else
                                                     {{ config('lorekeeper.group_currency_form')[$key]['choices'][$data] }}
@@ -182,17 +182,17 @@
                 </div>
             </div>
         </div>
-        @if (Auth::user()->hasPower('manage_submissions') && $submission->collaboratorApproved)
+        @if (Auth::user()->hasPower('manage_submissions') && $submission->collaboratorApproval)
             <div class="col-12 col-md-5">
                 <div class="card mb-4">
                     <div class="card-header">
                         <h5>[Admin] Vote Info</h5>
                     </div>
                     <div class="card-body">
-                        @if (isset($submission->vote_data) && $submission->voteData->count())
-                            @foreach ($submission->voteData as $voter => $vote)
+                        @if ($submission->getVoteData()['raw']->count())
+                            @foreach ($submission->getVoteData(1)['raw'] as $vote)
                                 <li>
-                                    {!! App\Models\User\User::find($voter)->displayName !!} {{ $voter == Auth::user()->id ? '(you)' : '' }}: <span {!! $vote == 2 ? 'class="text-success">Accept' : 'class="text-danger">Reject' !!}</span>
+                                    {!! $vote['user']->displayName !!} {{ $vote['user']->id == Auth::user()->id ? '(you)' : '' }}: <span {!! $vote['vote'] == 2 ? 'class="text-success">Accept' : 'class="text-danger">Reject' !!}</span>
                                 </li>
                             @endforeach
                         @else

--- a/resources/views/galleries/submissions.blade.php
+++ b/resources/views/galleries/submissions.blade.php
@@ -26,7 +26,7 @@
         </li>
     </ul>
 
-    @if (count($submissions))
+    @if ($submissions->count())
         {!! $submissions->render() !!}
 
         @foreach ($submissions as $key => $submission)


### PR DESCRIPTION
- refactor gallery index queries to take better advantage of eager loading
- add "with", "withCount" properties to relevant models
- add comment relation to gallery submissions
- only get site currency name for currency comms
- rename gallery submission collaboratorApproved attribute to not conflict with scope
- refactor gallery submission scopes
-move gallery submission vote data preprocessing to model function

General effort to improve performance around gallery functionality, primarily aimed at the non-admin areas. A lot of eager loading, rewriting queries to take advantage of it (and/or to be cleaner and more readable), and generally endeavoring to reduce query counts (with a few as much as halved) across the board. Functionality should be the same everywhere-- just more efficient.

~~Might hammer on this more, but it's being stubborn enough for me to put it up somewhere, haha.~~
Did in fact hammer on it more! That said, it's conflicted with #1176, so I'll mark this ready once that's merged and I can resolve the conflict here.