### PR TITLE
fix(galleries): prevent editing rejected submissions

### DIFF
--- a/app/Http/Controllers/GalleryController.php
+++ b/app/Http/Controllers/GalleryController.php
@@ -301,7 +301,7 @@ class GalleryController extends Controller {
             abort(404);
         }
         $submission = GallerySubmission::find($id);
-        if (!$submission) {
+        if (!$submission || $submission->status == 'Rejected') {
             abort(404);
         }
         $isMod = Auth::user()->hasPower('manage_submissions');

--- a/app/Services/GalleryManager.php
+++ b/app/Services/GalleryManager.php
@@ -189,6 +189,10 @@ class GalleryManager extends Service {
                 throw new \Exception("You can't edit this submission.");
             }
 
+            if ($submission->status == 'Rejected') {
+                throw new \Exception('This submission has been rejected and cannot be edited.');
+            }
+
             // Check that there is text and/or an image, including if there is an existing image (via the existence of a hash)
             if ((!isset($data['image']) && !isset($submission->hash)) && !$data['text']) {
                 throw new \Exception('Please submit either text or an image.');

--- a/resources/views/galleries/submission.blade.php
+++ b/resources/views/galleries/submission.blade.php
@@ -28,7 +28,9 @@
                 @endif
                 @if ($submission->user->id == Auth::user()->id || Auth::user()->hasPower('manage_submissions'))
                     <a class="btn btn-outline-primary" href="/gallery/queue/{{ $submission->id }}" data-toggle="tooltip" title="View Log Details"><i class="fas fa-clipboard-list"></i></a>
-                    <a class="btn btn-outline-primary" href="/gallery/edit/{{ $submission->id }}"><i class="fas fa-edit"></i> Edit</a>
+                    @if ($submission->status != 'Rejected')
+                        <a class="btn btn-outline-primary" href="/gallery/edit/{{ $submission->id }}"><i class="fas fa-edit"></i> Edit</a>
+                    @endif
                 @endif
                 {!! Form::close() !!}
             @endif


### PR DESCRIPTION
Realized while picking at refactors that it's a little odd to be able to edit rejected submissions...