### PR TITLE
feat(design): Remove Manual Thumbnail Image Upload (+minor text alterations)

### DIFF
--- a/config/lorekeeper/settings.php
+++ b/config/lorekeeper/settings.php
@@ -255,7 +255,7 @@ return [
     | This disables the option for users to manually upload their own
     | thumbnail images in design updates, including use of the cropper.
     | Note that this does not prevent permissioned staff from uploading
-    | custom thumbnail images. 
+    | custom thumbnail images.
     |
     | 0: Allows custom thumbnail uploads.
     | 1: Disallows custom thumbnail uploads.
@@ -274,7 +274,7 @@ return [
     | This disables the option for users to manually upload their own
     | thumbnail images in design updates, requiring use of the cropper.
     | Note that this does not prevent permissioned staff from uploading
-    | custom thumbnail images. 
+    | custom thumbnail images.
     |
     | 0: Allows custom thumbnail uploads.
     | 1: Disallows custom thumbnail uploads.

--- a/config/lorekeeper/settings.php
+++ b/config/lorekeeper/settings.php
@@ -246,39 +246,38 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Masterlist Image Automation Removing Manual Upload For Users
+    | Masterlist Image Automation Hide Manual Thumbnail
     |--------------------------------------------------------------------------
     |
-    | NOTE: This feature will only function if the above feature, the
-    | Masterlist Image Automation Replacing Cropper, is also enabled.
+    | NOTE: If the "Masterlist Image Automation Replacing Cropper"
+    | setting above is enabled, this setting has no effect.
     |
-    | The following option is for if you DO want to disable the manual uploading
-    | of thumbnail images, to ensure users do not attempt to upload their
-    | own thumbnail images, regardless of the automation.
-    | This will remove it purely for users, not administration.
+    | This disables the option for users to manually upload their own
+    | thumbnail images in design updates, including use of the cropper.
+    | Note that this does not prevent permissioned staff from uploading
+    | custom thumbnail images. 
     |
-    | 0: Keeps the manual thumbnail upload for users.
-    | 1: Hides the thumbnail upload for users.
+    | 0: Allows custom thumbnail uploads.
+    | 1: Disallows custom thumbnail uploads.
     |
     */
     'masterlist_image_automation_hide_manual_thumbnail' => 0,
 
     /*
     |--------------------------------------------------------------------------
-    | Remove Manual Thumbnail Image Upload Anyway
+    | Remove Manual Thumbnail Image Upload
     |--------------------------------------------------------------------------
     |
-    | NOTE: If the above feature, the Masterlist Image Automation Removing
-    | Manual Upload For Users is enabled, this option is irrelevant.
+    | NOTE: If the "Masterlist Image Automation Hide Manual Thumbnail"
+    | setting above is enabled, this setting has no effect.
     |
-    | The following option is for if you want to disable the manual uploading
-    | of thumbnail images, to ensure users do not attempt to upload their
-    | own images, even despite the lack of automation.
-    | This essentially forces users to use the cropper, instead.
-    | This will remove it purely for users, not administration.
+    | This disables the option for users to manually upload their own
+    | thumbnail images in design updates, requiring use of the cropper.
+    | Note that this does not prevent permissioned staff from uploading
+    | custom thumbnail images. 
     |
-    | 0: Keeps the manual thumbnail image upload for users.
-    | 1: Hides the thumbnail upload for users.
+    | 0: Allows custom thumbnail uploads.
+    | 1: Disallows custom thumbnail uploads.
     |
     */
     'hide_manual_thumbnail_image_upload' => 0,

--- a/config/lorekeeper/settings.php
+++ b/config/lorekeeper/settings.php
@@ -237,7 +237,7 @@ return [
     | It will automatically add transparent borders to the images to make them square,
     | based on the bigger dimension (between width/height).
     | Thumbnails will effectively be small previews of the full masterlist images.
-    | This feature will not replace the manual uploading of thumbnails.
+    | This feature does not disable the manual uploading of thumbnail images.
     |
     | Simply change to "1" to enable, or keep at "0" to disable.
     |
@@ -253,8 +253,8 @@ return [
     | Masterlist Image Automation Replacing Cropper, is also enabled.
     |
     | The following option is for if you DO want to disable the manual uploading
-    | of thumbnails, to ensure users do not attempt to upload their
-    | own thumbnails regardless of the automation.
+    | of thumbnail images, to ensure users do not attempt to upload their
+    | own thumbnail images, regardless of the automation.
     | This will remove it purely for users, not administration.
     |
     | 0: Keeps the manual thumbnail upload for users.
@@ -273,8 +273,8 @@ return [
     |
     | The following option is for if you want to disable the manual uploading
     | of thumbnail images, to ensure users do not attempt to upload their
-    | own images, even despite the lack of automation. This essentially forces
-    | users to use the cropper, instead.
+    | own images, even despite the lack of automation.
+    | This essentially forces users to use the cropper, instead.
     | This will remove it purely for users, not administration.
     |
     | 0: Keeps the manual thumbnail image upload for users.

--- a/config/lorekeeper/settings.php
+++ b/config/lorekeeper/settings.php
@@ -250,7 +250,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | NOTE: If the "Masterlist Image Automation Replacing Cropper"
-    | setting above is enabled, this setting has no effect.
+    | setting above is disabled, this setting has no effect.
     |
     | This disables the option for users to manually upload their own
     | thumbnail images in design updates, including use of the cropper.

--- a/config/lorekeeper/settings.php
+++ b/config/lorekeeper/settings.php
@@ -265,6 +265,26 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Remove Manual Thumbnail Image Upload Anyway
+    |--------------------------------------------------------------------------
+    |
+    | NOTE: If the above feature, the Masterlist Image Automation Removing
+    | Manual Upload For Users is enabled, this option is irrelevant.
+    |
+    | The following option is for if you want to disable the manual uploading
+    | of thumbnail images, to ensure users do not attempt to upload their
+    | own images, even despite the lack of automation. This essentially forces
+    | users to use the cropper, instead.
+    | This will remove it purely for users, not administration.
+    |
+    | 0: Keeps the manual thumbnail image upload for users.
+    | 1: Hides the thumbnail upload for users.
+    |
+    */
+    'hide_manual_thumbnail_image_upload' => 0,
+
+    /*
+    |--------------------------------------------------------------------------
     | Gallery Image Settings
     |--------------------------------------------------------------------------
     |

--- a/resources/views/character/design/image.blade.php
+++ b/resources/views/character/design/image.blade.php
@@ -116,7 +116,7 @@
                 </div>
             </div>
         @endif
-        @if (config('lorekeeper.settings.masterlist_image_automation') === 0 || config('lorekeeper.settings.masterlist_image_automation_hide_manual_thumbnail') === 0 || Auth::user()->hasPower('manage_characters'))
+        @if (((config('lorekeeper.settings.masterlist_image_automation') === 0 || config('lorekeeper.settings.masterlist_image_automation_hide_manual_thumbnail') === 0) && config('lorekeeper.settings.hide_manual_thumbnail_image_upload') === 0) || Auth::user()->hasPower('manage_characters'))
             <div class="card mb-3" id="thumbnailUpload">
                 <div class="card-body">
                     {!! Form::label('Thumbnail Image') !!} {!! add_help('This image is shown on the masterlist page.') !!}

--- a/resources/views/character/design/image.blade.php
+++ b/resources/views/character/design/image.blade.php
@@ -116,7 +116,9 @@
                 </div>
             </div>
         @endif
-        @if (((config('lorekeeper.settings.masterlist_image_automation') === 0 || config('lorekeeper.settings.masterlist_image_automation_hide_manual_thumbnail') === 0) && config('lorekeeper.settings.hide_manual_thumbnail_image_upload') === 0) || Auth::user()->hasPower('manage_characters'))
+        @if (
+            ((config('lorekeeper.settings.masterlist_image_automation') === 0 || config('lorekeeper.settings.masterlist_image_automation_hide_manual_thumbnail') === 0) && config('lorekeeper.settings.hide_manual_thumbnail_image_upload') === 0) ||
+                Auth::user()->hasPower('manage_characters'))
             <div class="card mb-3" id="thumbnailUpload">
                 <div class="card-body">
                     {!! Form::label('Thumbnail Image') !!} {!! add_help('This image is shown on the masterlist page.') !!}


### PR DESCRIPTION
Simple change, but requested apparently. Adds an additional setting to disallow users from uploading a manual thumbnail image, instead forcing them to use the cropper, if automation is disabled.

(Also slightly modifies wording for the automation, as to ensure there is clarity between options.)