### PR TITLE
feat(currencies): add currency categories

### DIFF
--- a/app/Http/Controllers/Admin/Data/CurrencyController.php
+++ b/app/Http/Controllers/Admin/Data/CurrencyController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Admin\Data;
 
 use App\Http\Controllers\Controller;
 use App\Models\Currency\Currency;
+use App\Models\Currency\CurrencyCategory;
 use App\Services\CurrencyService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -14,16 +15,150 @@ class CurrencyController extends Controller {
     | Admin / Currency Controller
     |--------------------------------------------------------------------------
     |
-    | Handles creation/editing of currencies.
+    | Handles creation/editing of currency categories and currencies.
     |
     */
+
+    /**********************************************************************************************
+
+        CURRENCY CATEGORIES
+
+    **********************************************************************************************/
+
+    /**
+     * Shows the currency category index.
+     *
+     * @return \Illuminate\Contracts\Support\Renderable
+     */
+    public function getIndex() {
+        return view('admin.currencies.currency_categories', [
+            'categories' => CurrencyCategory::orderBy('sort', 'DESC')->get(),
+        ]);
+    }
+
+    /**
+     * Shows the create currency category page.
+     *
+     * @return \Illuminate\Contracts\Support\Renderable
+     */
+    public function getCreateCurrencyCategory() {
+        return view('admin.currencies.create_edit_currency_category', [
+            'category' => new CurrencyCategory,
+        ]);
+    }
+
+    /**
+     * Shows the edit currency category page.
+     *
+     * @param int $id
+     *
+     * @return \Illuminate\Contracts\Support\Renderable
+     */
+    public function getEditCurrencyCategory($id) {
+        $category = CurrencyCategory::find($id);
+        if (!$category) {
+            abort(404);
+        }
+
+        return view('admin.currencies.create_edit_currency_category', [
+            'category' => $category,
+        ]);
+    }
+
+    /**
+     * Creates or edits a currency category.
+     *
+     * @param App\Services\CurrencyService $service
+     * @param int|null                     $id
+     *
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function postCreateEditCurrencyCategory(Request $request, CurrencyService $service, $id = null) {
+        $id ? $request->validate(CurrencyCategory::$updateRules) : $request->validate(CurrencyCategory::$createRules);
+        $data = $request->only([
+            'name', 'description', 'image', 'remove_image', 'is_visible',
+        ]);
+        if ($id && $service->updateCurrencyCategory(CurrencyCategory::find($id), $data, Auth::user())) {
+            flash('Category updated successfully.')->success();
+        } elseif (!$id && $category = $service->createCurrencyCategory($data, Auth::user())) {
+            flash('Category created successfully.')->success();
+
+            return redirect()->to('admin/data/currency-categories/edit/'.$category->id);
+        } else {
+            foreach ($service->errors()->getMessages()['error'] as $error) {
+                flash($error)->error();
+            }
+        }
+
+        return redirect()->back();
+    }
+
+    /**
+     * Gets the currency category deletion modal.
+     *
+     * @param int $id
+     *
+     * @return \Illuminate\Contracts\Support\Renderable
+     */
+    public function getDeleteCurrencyCategory($id) {
+        $category = CurrencyCategory::find($id);
+
+        return view('admin.currencies._delete_currency_category', [
+            'category' => $category,
+        ]);
+    }
+
+    /**
+     * Deletes a currency category.
+     *
+     * @param App\Services\CurrencyService $service
+     * @param int                          $id
+     *
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function postDeleteCurrencyCategory(Request $request, CurrencyService $service, $id) {
+        if ($id && $service->deleteCurrencyCategory(CurrencyCategory::find($id), Auth::user())) {
+            flash('Category deleted successfully.')->success();
+        } else {
+            foreach ($service->errors()->getMessages()['error'] as $error) {
+                flash($error)->error();
+            }
+        }
+
+        return redirect()->to('admin/data/currency-categories');
+    }
+
+    /**
+     * Sorts currency categories.
+     *
+     * @param App\Services\CurrencyService $service
+     *
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function postSortCurrencyCategory(Request $request, CurrencyService $service) {
+        if ($service->sortCurrencyCategory($request->get('sort'))) {
+            flash('Category order updated successfully.')->success();
+        } else {
+            foreach ($service->errors()->getMessages()['error'] as $error) {
+                flash($error)->error();
+            }
+        }
+
+        return redirect()->back();
+    }
+
+    /**********************************************************************************************
+
+        CURRENCIES
+
+    **********************************************************************************************/
 
     /**
      * Shows the currency index.
      *
      * @return \Illuminate\Contracts\Support\Renderable
      */
-    public function getIndex() {
+    public function getCurrencyIndex() {
         return view('admin.currencies.currencies', [
             'currencies' => Currency::paginate(30),
         ]);
@@ -36,7 +171,8 @@ class CurrencyController extends Controller {
      */
     public function getCreateCurrency() {
         return view('admin.currencies.create_edit_currency', [
-            'currency' => new Currency,
+            'currency'   => new Currency,
+            'categories' => CurrencyCategory::orderBy('sort', 'DESC')->pluck('name', 'id')->toArray(),
         ]);
     }
 
@@ -71,7 +207,7 @@ class CurrencyController extends Controller {
         $id ? $request->validate(Currency::$updateRules) : $request->validate(Currency::$createRules);
         $data = $request->only([
             'is_user_owned', 'is_character_owned',
-            'name', 'abbreviation', 'description',
+            'name', 'abbreviation', 'description', 'currency_category_id',
             'is_displayed', 'allow_user_to_user', 'allow_user_to_character', 'allow_character_to_user',
             'icon', 'image', 'remove_icon', 'remove_image',
             'conversion_id', 'rate',

--- a/app/Models/Currency/Currency.php
+++ b/app/Models/Currency/Currency.php
@@ -11,7 +11,7 @@ class Currency extends Model {
      * @var array
      */
     protected $fillable = [
-        'is_user_owned', 'is_character_owned',
+        'is_user_owned', 'is_character_owned', 'currency_category_id',
         'name', 'abbreviation', 'description', 'parsed_description', 'sort_user', 'sort_character',
         'is_displayed', 'allow_user_to_user', 'allow_user_to_character', 'allow_character_to_user',
         'has_icon', 'has_image', 'hash',
@@ -48,6 +48,74 @@ class Currency extends Model {
         'icon'         => 'mimes:png',
         'image'        => 'mimes:png',
     ];
+
+    /**********************************************************************************************
+
+        RELATIONSHIPS
+
+    **********************************************************************************************/
+
+    /**
+     * Get the category the currency belongs to.
+     */
+    public function category() {
+        return $this->belongsTo(CurrencyCategory::class, 'currency_category_id');
+    }
+
+    /**********************************************************************************************
+
+        SCOPES
+
+    **********************************************************************************************/
+
+    /**
+     * Scope a query to sort currencies in alphabetical order.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param bool                                  $reverse
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeSortAlphabetical($query, $reverse = false) {
+        return $query->orderBy('name', $reverse ? 'DESC' : 'ASC');
+    }
+
+    /**
+     * Scope a query to sort currencies in category order.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeSortCategory($query) {
+        if (CurrencyCategory::all()->count()) {
+            return $query->orderBy(CurrencyCategory::select('sort')->whereColumn('currencies.currency_category_id', 'currency_categories.id'), 'DESC');
+        }
+
+        return $query;
+    }
+
+    /**
+     * Scope a query to sort currencies by newest first.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeSortNewest($query) {
+        return $query->orderBy('id', 'DESC');
+    }
+
+    /**
+     * Scope a query to sort currencies oldest first.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeSortOldest($query) {
+        return $query->orderBy('id');
+    }
 
     /**********************************************************************************************
 

--- a/app/Models/Currency/CurrencyCategory.php
+++ b/app/Models/Currency/CurrencyCategory.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace App\Models\Currency;
+
+use App\Models\Model;
+
+class CurrencyCategory extends Model {
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name', 'sort', 'has_image', 'description', 'parsed_description', 'is_visible', 'hash',
+    ];
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'currency_categories';
+
+    /**
+     * Validation rules for creation.
+     *
+     * @var array
+     */
+    public static $createRules = [
+        'name'        => 'required|unique:currency_categories|between:3,100',
+        'description' => 'nullable',
+        'image'       => 'mimes:png',
+    ];
+
+    /**
+     * Validation rules for updating.
+     *
+     * @var array
+     */
+    public static $updateRules = [
+        'name'        => 'required|between:3,100',
+        'description' => 'nullable',
+        'image'       => 'mimes:png',
+    ];
+
+    /**********************************************************************************************
+
+        SCOPES
+
+    **********************************************************************************************/
+
+    /**
+     * Scope a query to show only visible categories.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param mixed|null                            $user
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeVisible($query, $user = null) {
+        if ($user && $user->hasPower('edit_data')) {
+            return $query;
+        }
+
+        return $query->where('is_visible', 1);
+    }
+
+    /**********************************************************************************************
+
+        ACCESSORS
+
+    **********************************************************************************************/
+
+    /**
+     * Displays the model's name, linked to its encyclopedia page.
+     *
+     * @return string
+     */
+    public function getDisplayNameAttribute() {
+        return '<a href="'.$this->url.'" class="display-category">'.$this->name.'</a>';
+    }
+
+    /**
+     * Gets the file directory containing the model's image.
+     *
+     * @return string
+     */
+    public function getImageDirectoryAttribute() {
+        return 'images/data/currency-categories';
+    }
+
+    /**
+     * Gets the file name of the model's image.
+     *
+     * @return string
+     */
+    public function getCategoryImageFileNameAttribute() {
+        return $this->id.'-'.$this->hash.'-image.png';
+    }
+
+    /**
+     * Gets the path to the file directory containing the model's image.
+     *
+     * @return string
+     */
+    public function getCategoryImagePathAttribute() {
+        return public_path($this->imageDirectory);
+    }
+
+    /**
+     * Gets the URL of the model's image.
+     *
+     * @return string
+     */
+    public function getCategoryImageUrlAttribute() {
+        if (!$this->has_image) {
+            return null;
+        }
+
+        return asset($this->imageDirectory.'/'.$this->categoryImageFileName);
+    }
+
+    /**
+     * Gets the URL of the model's encyclopedia page.
+     *
+     * @return string
+     */
+    public function getUrlAttribute() {
+        return url('world/currency-categories?name='.$this->name);
+    }
+
+    /**
+     * Gets the URL for an encyclopedia search of currencies in this category.
+     *
+     * @return string
+     */
+    public function getSearchUrlAttribute() {
+        return url('world/currencies?currency_category_id='.$this->id);
+    }
+
+    /**
+     * Gets the admin edit URL.
+     *
+     * @return string
+     */
+    public function getAdminUrlAttribute() {
+        return url('admin/data/currency-categories/edit/'.$this->id);
+    }
+
+    /**
+     * Gets the power required to edit this model.
+     *
+     * @return string
+     */
+    public function getAdminPowerAttribute() {
+        return 'edit_data';
+    }
+}

--- a/app/Services/CurrencyService.php
+++ b/app/Services/CurrencyService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Models\Character\CharacterCurrency;
 use App\Models\Currency\Currency;
+use App\Models\Currency\CurrencyCategory;
 use App\Models\User\UserCurrency;
 use Illuminate\Support\Facades\DB;
 
@@ -13,9 +14,168 @@ class CurrencyService extends Service {
     | Currency Service
     |--------------------------------------------------------------------------
     |
-    | Handles the creation and editing of currency.
+    | Handles the creation and editing of currency categories and currencies.
     |
     */
+
+    /**********************************************************************************************
+
+        CURRENCY CATEGORIES
+
+    **********************************************************************************************/
+
+    /**
+     * Create a category.
+     *
+     * @param array                 $data
+     * @param \App\Models\User\User $user
+     *
+     * @return bool|CurrencyCategory
+     */
+    public function createCurrencyCategory($data, $user) {
+        DB::beginTransaction();
+
+        try {
+            $data = $this->populateCategoryData($data);
+
+            $image = null;
+            if (isset($data['image']) && $data['image']) {
+                $data['has_image'] = 1;
+                $data['hash'] = randomString(10);
+                $image = $data['image'];
+                unset($data['image']);
+            } else {
+                $data['has_image'] = 0;
+            }
+
+            $category = CurrencyCategory::create($data);
+
+            if (!$this->logAdminAction($user, 'Created Currency Category', 'Created '.$category->displayName)) {
+                throw new \Exception('Failed to log admin action.');
+            }
+
+            if ($image) {
+                $this->handleImage($image, $category->categoryImagePath, $category->categoryImageFileName);
+            }
+
+            return $this->commitReturn($category);
+        } catch (\Exception $e) {
+            $this->setError('error', $e->getMessage());
+        }
+
+        return $this->rollbackReturn(false);
+    }
+
+    /**
+     * Update a category.
+     *
+     * @param CurrencyCategory      $category
+     * @param array                 $data
+     * @param \App\Models\User\User $user
+     *
+     * @return bool|CurrencyCategory
+     */
+    public function updateCurrencyCategory($category, $data, $user) {
+        DB::beginTransaction();
+
+        try {
+            // More specific validation
+            if (CurrencyCategory::where('name', $data['name'])->where('id', '!=', $category->id)->exists()) {
+                throw new \Exception('The name has already been taken.');
+            }
+
+            $data = $this->populateCategoryData($data, $category);
+
+            $image = null;
+            if (isset($data['image']) && $data['image']) {
+                $data['has_image'] = 1;
+                $data['hash'] = randomString(10);
+                $image = $data['image'];
+                unset($data['image']);
+            }
+
+            $category->update($data);
+
+            if (!$this->logAdminAction($user, 'Updated Currency Category', 'Updated '.$category->displayName)) {
+                throw new \Exception('Failed to log admin action.');
+            }
+
+            if ($category) {
+                $this->handleImage($image, $category->categoryImagePath, $category->categoryImageFileName);
+            }
+
+            return $this->commitReturn($category);
+        } catch (\Exception $e) {
+            $this->setError('error', $e->getMessage());
+        }
+
+        return $this->rollbackReturn(false);
+    }
+
+    /**
+     * Delete a category.
+     *
+     * @param CurrencyCategory      $category
+     * @param \App\Models\User\User $user
+     *
+     * @return bool
+     */
+    public function deleteCurrencyCategory($category, $user) {
+        DB::beginTransaction();
+
+        try {
+            // Check first if the category is currently in use
+            if (Currency::where('currency_category_id', $category->id)->exists()) {
+                throw new \Exception('A currency with this category exists. Please change its category first.');
+            }
+            if (!$this->logAdminAction($user, 'Deleted Currency Category', 'Deleted '.$category->name)) {
+                throw new \Exception('Failed to log admin action.');
+            }
+
+            if ($category->has_image) {
+                $this->deleteImage($category->categoryImagePath, $category->categoryImageFileName);
+            }
+            $category->delete();
+
+            return $this->commitReturn(true);
+        } catch (\Exception $e) {
+            $this->setError('error', $e->getMessage());
+        }
+
+        return $this->rollbackReturn(false);
+    }
+
+    /**
+     * Sorts category order.
+     *
+     * @param string $data
+     *
+     * @return bool
+     */
+    public function sortCurrencyCategory($data) {
+        DB::beginTransaction();
+
+        try {
+            // explode the sort array and reverse it since the order is inverted
+            $sort = array_reverse(explode(',', $data));
+
+            foreach ($sort as $key => $s) {
+                CurrencyCategory::where('id', $s)->update(['sort' => $key]);
+            }
+
+            return $this->commitReturn(true);
+        } catch (\Exception $e) {
+            $this->setError('error', $e->getMessage());
+        }
+
+        return $this->rollbackReturn(false);
+    }
+
+    /**********************************************************************************************
+
+        CURRENCIES
+
+    **********************************************************************************************/
 
     /**
      * Creates a new currency.
@@ -32,6 +192,10 @@ class CurrencyService extends Service {
             // More specific validation
             if (!isset($data['is_user_owned']) && !isset($data['is_character_owned'])) {
                 throw new \Exception('Please choose if this currency is attached to users and/or characters.');
+            }
+
+            if ((isset($data['currency_category_id']) && $data['currency_category_id']) && !CurrencyCategory::where('id', $data['currency_category_id'])->exists()) {
+                throw new \Exception('The selected currency category is invalid.');
             }
 
             $data = $this->populateData($data);
@@ -97,6 +261,9 @@ class CurrencyService extends Service {
             }
             if (isset($data['abbreviation']) && Currency::where('abbreviation', $data['abbreviation'])->where('id', '!=', $currency->id)->exists()) {
                 throw new \Exception('The abbreviation has already been taken.');
+            }
+            if ((isset($data['currency_category_id']) && $data['currency_category_id']) && !CurrencyCategory::where('id', $data['currency_category_id'])->exists()) {
+                throw new \Exception('The selected currency category is invalid.');
             }
 
             $data = $this->populateData($data, $currency);
@@ -192,7 +359,7 @@ class CurrencyService extends Service {
     /**
      * Sorts currency order.
      *
-     * @param array  $data
+     * @param string $data
      * @param string $type
      *
      * @return bool
@@ -214,6 +381,40 @@ class CurrencyService extends Service {
         }
 
         return $this->rollbackReturn(false);
+    }
+
+    /**
+     * Handle category data.
+     *
+     * @param array                 $data
+     * @param CurrencyCategory|null $category
+     *
+     * @return array
+     */
+    private function populateCategoryData($data, $category = null) {
+        if (isset($data['description']) && $data['description']) {
+            $data['parsed_description'] = parse($data['description']);
+        } else {
+            $data['parsed_description'] = null;
+        }
+
+        isset($data['is_character_owned']) && $data['is_character_owned'] ? $data['is_character_owned'] : $data['is_character_owned'] = 0;
+        isset($data['character_limit']) && $data['character_limit'] ? $data['character_limit'] : $data['character_limit'] = 0;
+        isset($data['can_name']) && $data['can_name'] ? $data['can_name'] : $data['can_name'] = 0;
+
+        if (!isset($data['is_visible'])) {
+            $data['is_visible'] = 0;
+        }
+
+        if (isset($data['remove_image'])) {
+            if ($category && $category->has_image && $data['remove_image']) {
+                $data['has_image'] = 0;
+                $this->deleteImage($category->categoryImagePath, $category->categoryImageFileName);
+            }
+            unset($data['remove_image']);
+        }
+
+        return $data;
     }
 
     /**

--- a/database/migrations/2025_01_10_121504_create_currency_categories_table.php
+++ b/database/migrations/2025_01_10_121504_create_currency_categories_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void {
+        Schema::create('currency_categories', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            $table->increments('id');
+
+            $table->string('name');
+            $table->integer('sort')->default(0);
+            $table->text('description')->nullable()->default(null);
+            $table->text('parsed_description')->nullable()->default(null);
+
+            $table->boolean('has_image')->default(0);
+            $table->boolean('is_visible')->default(0);
+
+            $table->string('hash', 10)->nullable()->default(null);
+        });
+
+        Schema::table('currencies', function (Blueprint $table) {
+            $table->integer('currency_category_id')->nullable()->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void {
+        Schema::dropIfExists('currency_categories');
+
+        Schema::table('currencies', function (Blueprint $table) {
+            $table->dropColumn('currency_category_id');
+        });
+    }
+};

--- a/resources/views/admin/currencies/_delete_currency_category.blade.php
+++ b/resources/views/admin/currencies/_delete_currency_category.blade.php
@@ -1,0 +1,14 @@
+@if ($category)
+    {!! Form::open(['url' => 'admin/data/currency-categories/delete/' . $category->id]) !!}
+
+    <p>You are about to delete the category <strong>{{ $category->name }}</strong>. This is not reversible. If currencies in this category exist, you will not be able to delete this category.</p>
+    <p>Are you sure you want to delete <strong>{{ $category->name }}</strong>?</p>
+
+    <div class="text-right">
+        {!! Form::submit('Delete Category', ['class' => 'btn btn-danger']) !!}
+    </div>
+
+    {!! Form::close() !!}
+@else
+    Invalid category selected.
+@endif

--- a/resources/views/admin/currencies/create_edit_currency.blade.php
+++ b/resources/views/admin/currencies/create_edit_currency.blade.php
@@ -17,17 +17,21 @@
 
     <h3>Basic Information</h3>
     <div class="row">
-        <div class="col-md-6">
+        <div class="col-md-4">
             <div class="form-group">
                 {!! Form::label('Currency Name') !!}
                 {!! Form::text('name', $currency->name, ['class' => 'form-control']) !!}
             </div>
         </div>
-        <div class="col-md-6">
+        <div class="col-md-4">
             <div class="form-group">
                 {!! Form::label('Abbreviation (Optional)') !!} {!! add_help('This will be used to denote the currency if an icon is not provided. If an abbreviation is not given, the currency\'s full name will be used.') !!}
                 {!! Form::text('abbreviation', $currency->abbreviation, ['class' => 'form-control']) !!}
             </div>
+        </div>
+        <div class="col-md-4 form-group">
+            {!! Form::label('Currency Category (Optional)') !!}
+            {!! Form::select('currency_category_id', $categories, $currency->currency_category_id, ['class' => 'form-control', 'placeholder' => 'No category']) !!}
         </div>
     </div>
 

--- a/resources/views/admin/currencies/create_edit_currency_category.blade.php
+++ b/resources/views/admin/currencies/create_edit_currency_category.blade.php
@@ -1,0 +1,80 @@
+@extends('admin.layout')
+
+@section('admin-title')
+    {{ $category->id ? 'Edit' : 'Create' }} Currency Category
+@endsection
+
+@section('admin-content')
+    {!! breadcrumbs([
+        'Admin Panel' => 'admin',
+        'Currency Categories' => 'admin/data/currency-categories',
+        ($category->id ? 'Edit' : 'Create') . ' Category' => $category->id ? 'admin/data/currency-categories/edit/' . $category->id : 'admin/data/currency-categories/create',
+    ]) !!}
+
+    <h1>{{ $category->id ? 'Edit' : 'Create' }} Currency Category
+        @if ($category->id)
+            <a href="#" class="btn btn-danger float-right delete-category-button">Delete Category</a>
+        @endif
+    </h1>
+
+    {!! Form::open(['url' => $category->id ? 'admin/data/currency-categories/edit/' . $category->id : 'admin/data/currency-categories/create', 'files' => true]) !!}
+
+    <h3>Basic Information</h3>
+
+    <div class="form-group">
+        {!! Form::label('Name') !!}
+        {!! Form::text('name', $category->name, ['class' => 'form-control']) !!}
+    </div>
+
+    <div class="form-group">
+        {!! Form::label('World Page Image (Optional)') !!} {!! add_help('This image is used only on the world information pages.') !!}
+        <div class="custom-file">
+            {!! Form::label('image', 'Choose file...', ['class' => 'custom-file-label']) !!}
+            {!! Form::file('image', ['class' => 'custom-file-input']) !!}
+        </div>
+        <div class="text-muted">Recommended size: 200px x 200px</div>
+        @if ($category->has_image)
+            <div class="form-check">
+                {!! Form::checkbox('remove_image', 1, false, ['class' => 'form-check-input']) !!}
+                {!! Form::label('remove_image', 'Remove current image', ['class' => 'form-check-label']) !!}
+            </div>
+        @endif
+    </div>
+
+    <div class="form-group">
+        {!! Form::label('Description (Optional)') !!}
+        {!! Form::textarea('description', $category->description, ['class' => 'form-control wysiwyg']) !!}
+    </div>
+
+    <div class="form-group">
+        {!! Form::checkbox('is_visible', 1, $category->id ? $category->is_visible : 1, ['class' => 'form-check-input', 'data-toggle' => 'toggle']) !!}
+        {!! Form::label('is_visible', 'Is Visible', ['class' => 'form-check-label ml-3']) !!} {!! add_help('If turned off, the category will not be visible in the category list or available for selection in search. Permissioned staff will still be able to add currencies to them, however.') !!}
+    </div>
+
+    <div class="text-right">
+        {!! Form::submit($category->id ? 'Edit' : 'Create', ['class' => 'btn btn-primary']) !!}
+    </div>
+
+    {!! Form::close() !!}
+
+    @if ($category->id)
+        <h3>Preview</h3>
+        <div class="card mb-3">
+            <div class="card-body">
+                @include('world._entry', ['imageUrl' => $category->categoryImageUrl, 'name' => $category->displayName, 'description' => $category->parsed_description, 'category' => $category, 'visible' => $category->is_visible])
+            </div>
+        </div>
+    @endif
+@endsection
+
+@section('scripts')
+    @parent
+    <script>
+        $(document).ready(function() {
+            $('.delete-category-button').on('click', function(e) {
+                e.preventDefault();
+                loadModal("{{ url('admin/data/currency-categories/delete') }}/{{ $category->id }}", 'Delete Category');
+            });
+        });
+    </script>
+@endsection

--- a/resources/views/admin/currencies/currencies.blade.php
+++ b/resources/views/admin/currencies/currencies.blade.php
@@ -15,18 +15,25 @@
 
     <p>The order of currencies as displayed on user and character profiles can be edited from the <strong><a href="{{ url('admin/data/currencies/sort') }}">Sort Currencies</a></strong> page.</p>
 
-    <div class="text-right mb-3"><a class="btn btn-primary" href="{{ url('admin/data/currencies/create') }}"><i class="fas fa-plus"></i> Create New Currency</a></div>
+    <div class="text-right mb-3">
+        <a class="btn btn-primary" href="{{ url('admin/data/currency-categories') }}"><i class="fas fa-folder"></i> Currency Categories</a>
+        <a class="btn btn-primary" href="{{ url('admin/data/currencies/create') }}"><i class="fas fa-plus"></i> Create New Currency</a>
+    </div>
+
     {!! $currencies->render() !!}
     <div class="mb-4 logs-table">
         <div class="logs-table-header">
             <div class="row">
-                <div class="col-12 col-md-4">
+                <div class="col-12 col-md-3">
                     <div class="logs-table-cell">Name</div>
                 </div>
-                <div class="col-4 col-md-4">
-                    <div class="logs-table-cell">Displays As</div>
+                <div class="col-4 col-md-3">
+                    <div class="logs-table-cell">Category</div>
                 </div>
                 <div class="col-4 col-md-3">
+                    <div class="logs-table-cell">Displays As</div>
+                </div>
+                <div class="col-3 col-md-2">
                     <div class="logs-table-cell">Attaches To</div>
                 </div>
             </div>
@@ -35,19 +42,22 @@
             @foreach ($currencies as $currency)
                 <div class="logs-table-row">
                     <div class="row flex-wrap">
-                        <div class="col-12 col-md-4 ">
+                        <div class="col-12 col-md-3">
                             <div class="logs-table-cell">{{ $currency->name }} @if ($currency->abbreviation)
                                     ({{ $currency->abbreviation }})
                                 @endif
                             </div>
                         </div>
-                        <div class="col-4 col-md-4">
+                        <div class="col-3 col-md-3">
+                            <div class="logs-table-cell">{!! $currency->category ? $currency->category->displayName : '' !!}</div>
+                        </div>
+                        <div class="col-3 col-md-3">
                             <div class="logs-table-cell">{!! $currency->display(100) !!}</div>
                         </div>
-                        <div class="col-4 col-md-3">
+                        <div class="col-3 col-md-2">
                             <div class="logs-table-cell">{{ $currency->is_user_owned ? 'User' : '' }} {{ $currency->is_character_owned && $currency->is_user_owned ? '+' : '' }} {{ $currency->is_character_owned ? 'Character' : '' }}</div>
                         </div>
-                        <div class="col-4 col-md-1">
+                        <div class="col-3 col-md-1">
                             <div class="logs-table-cell"><a href="{{ url('admin/data/currencies/edit/' . $currency->id) }}" class="btn btn-primary">Edit</a></div>
                         </div>
                     </div>

--- a/resources/views/admin/currencies/currency_categories.blade.php
+++ b/resources/views/admin/currencies/currency_categories.blade.php
@@ -1,0 +1,74 @@
+@extends('admin.layout')
+
+@section('admin-title')
+    Currency Categories
+@endsection
+
+@section('admin-content')
+    {!! breadcrumbs(['Admin Panel' => 'admin', 'Currency Categories' => 'admin/data/currency-categories']) !!}
+
+    <h1>Currency Categories</h1>
+
+    <p>This is a list of currency categories that will be used to sort currencies. Creating currency categories is entirely optional, but recommended if you have a lot of currencies in the game.</p>
+    <p>The sorting order reflects the order in which currency categories will be displayed in the bank, as well as on the world pages.</p>
+
+    <div class="text-right mb-3"><a class="btn btn-primary" href="{{ url('admin/data/currency-categories/create') }}"><i class="fas fa-plus"></i> Create New Currency Category</a></div>
+
+    @if (!count($categories))
+        <p>No currency categories found.</p>
+    @else
+        <table class="table table-sm category-table">
+            <tbody id="sortable" class="sortable">
+                @foreach ($categories as $category)
+                    <tr class="sort-item" data-id="{{ $category->id }}">
+                        <td>
+                            <a class="fas fa-arrows-alt-v handle mr-3" href="#"></a>
+                            @if (!$category->is_visible)
+                                <i class="fas fa-eye-slash mr-1"></i>
+                            @endif
+                            {!! $category->displayName !!}
+                        </td>
+                        <td class="text-right">
+                            <a href="{{ url('admin/data/currency-categories/edit/' . $category->id) }}" class="btn btn-primary">Edit</a>
+                        </td>
+                    </tr>
+                @endforeach
+            </tbody>
+
+        </table>
+        <div class="mb-4">
+            {!! Form::open(['url' => 'admin/data/currency-categories/sort']) !!}
+            {!! Form::hidden('sort', '', ['id' => 'sortableOrder']) !!}
+            {!! Form::submit('Save Order', ['class' => 'btn btn-primary']) !!}
+            {!! Form::close() !!}
+        </div>
+    @endif
+
+@endsection
+
+@section('scripts')
+    @parent
+    <script>
+        $(document).ready(function() {
+            $('.handle').on('click', function(e) {
+                e.preventDefault();
+            });
+            $("#sortable").sortable({
+                items: '.sort-item',
+                handle: ".handle",
+                placeholder: "sortable-placeholder",
+                stop: function(event, ui) {
+                    $('#sortableOrder').val($(this).sortable("toArray", {
+                        attribute: "data-id"
+                    }));
+                },
+                create: function() {
+                    $('#sortableOrder').val($(this).sortable("toArray", {
+                        attribute: "data-id"
+                    }));
+                }
+            });
+            $("#sortable").disableSelection();
+        });
+    </script>
+@endsection

--- a/resources/views/home/bank.blade.php
+++ b/resources/views/home/bank.blade.php
@@ -12,32 +12,38 @@
     </h1>
 
     <h3>Currencies</h3>
-    <div class="card mb-2">
-        <ul class="list-group list-group-flush">
-
-            @foreach (Auth::user()->getCurrencies(true) as $currency)
-                <li class="list-group-item">
-                    <div class="row">
-                        <div class="col-lg-2 col-md-3 col-6 text-right">
-                            <strong>
-                                <a href="{{ $currency->url }}">
-                                    {{ $currency->name }}
-                                    @if ($currency->abbreviation)
-                                        ({{ $currency->abbreviation }})
-                                    @endif
-                                </a>
-                            </strong>
+    @foreach (Auth::user()->getCurrencies(true) as $category => $currencies)
+        <div class="card mb-2">
+            @if ($currencies->first()->category)
+                <div class="card-header">
+                    <h5 class="mb-0">{!! $currencies->first()->category->displayName !!}</h5>
+                </div>
+            @endif
+            <ul class="list-group list-group-flush">
+                @foreach ($currencies as $currency)
+                    <li class="list-group-item">
+                        <div class="row">
+                            <div class="col-lg-2 col-md-3 col-6 text-right">
+                                <strong>
+                                    <a href="{{ $currency->url }}">
+                                        {{ $currency->name }}
+                                        @if ($currency->abbreviation)
+                                            ({{ $currency->abbreviation }})
+                                        @endif
+                                    </a>
+                                </strong>
+                            </div>
+                            <div class="col-lg-10 col-md-9 col-6">
+                                {{ $currency->quantity }} @if ($currency->has_icon)
+                                    {!! $currency->displayIcon !!}
+                                @endif
+                            </div>
                         </div>
-                        <div class="col-lg-10 col-md-9 col-6">
-                            {{ $currency->quantity }} @if ($currency->has_icon)
-                                {!! $currency->displayIcon !!}
-                            @endif
-                        </div>
-                    </div>
-                </li>
-            @endforeach
-        </ul>
-    </div>
+                    </li>
+                @endforeach
+            </ul>
+        </div>
+    @endforeach
     <div class="text-right mb-4">
         <a href="{{ url(Auth::user()->url . '/currency-logs') }}">View logs...</a>
     </div>

--- a/resources/views/user/bank.blade.php
+++ b/resources/views/user/bank.blade.php
@@ -12,32 +12,38 @@
     </h1>
 
     <h3>Currencies</h3>
-    <div class="card mb-4">
-        <ul class="list-group list-group-flush">
-
-            @foreach ($user->getCurrencies(true) as $currency)
-                <li class="list-group-item">
-                    <div class="row">
-                        <div class="col-lg-2 col-md-3 col-6 text-right">
-                            <strong>
-                                <a href="{{ $currency->url }}">
-                                    {{ $currency->name }}
-                                    @if ($currency->abbreviation)
-                                        ({{ $currency->abbreviation }})
-                                    @endif
-                                </a>
-                            </strong>
+    @foreach ($user->getCurrencies(true) as $category => $currencies)
+        <div class="card mb-2">
+            @if ($currencies->first()->category)
+                <div class="card-header">
+                    <h5 class="mb-0">{!! $currencies->first()->category->displayName !!}</h5>
+                </div>
+            @endif
+            <ul class="list-group list-group-flush">
+                @foreach ($currencies as $currency)
+                    <li class="list-group-item">
+                        <div class="row">
+                            <div class="col-lg-2 col-md-3 col-6 text-right">
+                                <strong>
+                                    <a href="{{ $currency->url }}">
+                                        {{ $currency->name }}
+                                        @if ($currency->abbreviation)
+                                            ({{ $currency->abbreviation }})
+                                        @endif
+                                    </a>
+                                </strong>
+                            </div>
+                            <div class="col-lg-10 col-md-9 col-6">
+                                {{ $currency->quantity }} @if ($currency->has_icon)
+                                    {!! $currency->displayIcon !!}
+                                @endif
+                            </div>
                         </div>
-                        <div class="col-lg-10 col-md-9 col-6">
-                            {{ $currency->quantity }} @if ($currency->has_icon)
-                                {!! $currency->displayIcon !!}
-                            @endif
-                        </div>
-                    </div>
-                </li>
-            @endforeach
-        </ul>
-    </div>
+                    </li>
+                @endforeach
+            </ul>
+        </div>
+    @endforeach
 
     <h3>Latest Activity</h3>
     <div class="mb-4 logs-table">

--- a/resources/views/world/_currency_entry.blade.php
+++ b/resources/views/world/_currency_entry.blade.php
@@ -9,6 +9,17 @@
                 ({{ $currency->abbreviation }})
             @endif
         </h3>
+        @if (isset($currency->category) && $currency->category)
+            <div>
+                <strong>Category:</strong>
+                @if (!$currency->category->is_visible)
+                    <i class="fas fa-eye-slash mx-1 text-danger"></i>
+                @endif
+                <a href="{!! $currency->category->url !!}">
+                    {!! $currency->category->name !!}
+                </a>
+            </div>
+        @endif
         <div><strong>Displays as:</strong> {!! $currency->display(0) !!}</div>
         <div><strong>Held by:</strong> <?php echo ucfirst(implode(' and ', ($currency->is_user_owned ? ['users'] : []) + ($currency->is_character_owned ? ['characters'] : []))); ?></div>
         @if ($currency->conversions()->count())

--- a/resources/views/world/_sidebar.blade.php
+++ b/resources/views/world/_sidebar.blade.php
@@ -16,6 +16,7 @@
         <div class="sidebar-section-header">Items</div>
         <div class="sidebar-item"><a href="{{ url('world/item-categories') }}" class="{{ set_active('world/item-categories*') }}">Item Categories</a></div>
         <div class="sidebar-item"><a href="{{ url('world/items') }}" class="{{ set_active('world/items*') }}">All Items</a></div>
-        <div class="sidebar-item"><a href="{{ url('world/currencies') }}" class="{{ set_active('world/currencies*') }}">Currencies</a></div>
+        <div class="sidebar-item"><a href="{{ url('world/currency-categories') }}" class="{{ set_active('world/currency-categories*') }}">Currency Categories</a></div>
+        <div class="sidebar-item"><a href="{{ url('world/currencies') }}" class="{{ set_active('world/currencies*') }}">All Currencies</a></div>
     </li>
 </ul>

--- a/resources/views/world/currencies.blade.php
+++ b/resources/views/world/currencies.blade.php
@@ -9,12 +9,33 @@
     <h1>Currencies</h1>
 
     <div>
-        {!! Form::open(['method' => 'GET', 'class' => 'form-inline justify-content-end']) !!}
-        <div class="form-group mr-3 mb-3">
-            {!! Form::text('name', Request::get('name'), ['class' => 'form-control']) !!}
+        {!! Form::open(['method' => 'GET', 'class' => '']) !!}
+        <div class="form-inline justify-content-end">
+            <div class="form-group ml-3 mb-3">
+                {!! Form::text('name', Request::get('name'), ['class' => 'form-control']) !!}
+            </div>
+            <div class="form-group ml-3 mb-3">
+                {!! Form::select('currency_category_id', $categories, Request::get('currency_category_id'), ['class' => 'form-control', 'placeholder' => 'Any Category']) !!}
+            </div>
         </div>
-        <div class="form-group mb-3">
-            {!! Form::submit('Search', ['class' => 'btn btn-primary']) !!}
+        <div class="form-inline justify-content-end">
+            <div class="form-group ml-3 mb-3">
+                {!! Form::select(
+                    'sort',
+                    [
+                        'alpha' => 'Sort Alphabetically (A-Z)',
+                        'alpha-reverse' => 'Sort Alphabetically (Z-A)',
+                        'category' => 'Sort by Category',
+                        'newest' => 'Newest First',
+                        'oldest' => 'Oldest First',
+                    ],
+                    Request::get('sort') ?: 'category',
+                    ['class' => 'form-control'],
+                ) !!}
+            </div>
+            <div class="form-group ml-3 mb-3">
+                {!! Form::submit('Search', ['class' => 'btn btn-primary']) !!}
+            </div>
         </div>
         {!! Form::close() !!}
     </div>

--- a/resources/views/world/currency_categories.blade.php
+++ b/resources/views/world/currency_categories.blade.php
@@ -1,0 +1,40 @@
+@extends('world.layout')
+
+@section('world-title')
+    Currency Categories
+@endsection
+
+@section('content')
+    {!! breadcrumbs(['World' => 'world', 'Currency Categories' => 'world/currency-categories']) !!}
+    <h1>Currency Categories</h1>
+
+    <div>
+        {!! Form::open(['method' => 'GET', 'class' => 'form-inline justify-content-end']) !!}
+        <div class="form-group mr-3 mb-3">
+            {!! Form::text('name', Request::get('name'), ['class' => 'form-control']) !!}
+        </div>
+        <div class="form-group mb-3">
+            {!! Form::submit('Search', ['class' => 'btn btn-primary']) !!}
+        </div>
+        {!! Form::close() !!}
+    </div>
+
+    {!! $categories->render() !!}
+    @foreach ($categories as $category)
+        <div class="card mb-3">
+            <div class="card-body">
+                @include('world._entry', [
+                    'imageUrl' => $category->categoryImageUrl,
+                    'name' => $category->displayName,
+                    'description' => $category->parsed_description,
+                    'searchUrl' => $category->searchUrl,
+                    'category' => $category,
+                    'visible' => $category->is_visible,
+                ])
+            </div>
+        </div>
+    @endforeach
+    {!! $categories->render() !!}
+
+    <div class="text-center mt-4 small text-muted">{{ $categories->total() }} result{{ $categories->total() == 1 ? '' : 's' }} found.</div>
+@endsection

--- a/routes/lorekeeper/admin.php
+++ b/routes/lorekeeper/admin.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Facades\Route;
+
 /*
 |--------------------------------------------------------------------------
 | Admin Routes
@@ -105,7 +107,16 @@ Route::group(['prefix' => 'data', 'namespace' => 'Data', 'middleware' => 'power:
     Route::post('galleries/sort', 'GalleryController@postSortGallery');
 
     // CURRENCIES
-    Route::get('currencies', 'CurrencyController@getIndex');
+    Route::get('currency-categories', 'CurrencyController@getIndex');
+    Route::get('currency-categories/create', 'CurrencyController@getCreateCurrencyCategory');
+    Route::get('currency-categories/edit/{id}', 'CurrencyController@getEditCurrencyCategory');
+    Route::get('currency-categories/delete/{id}', 'CurrencyController@getDeleteCurrencyCategory');
+    Route::post('currency-categories/create', 'CurrencyController@postCreateEditCurrencyCategory');
+    Route::post('currency-categories/edit/{id?}', 'CurrencyController@postCreateEditCurrencyCategory');
+    Route::post('currency-categories/delete/{id}', 'CurrencyController@postDeleteCurrencyCategory');
+    Route::post('currency-categories/sort', 'CurrencyController@postSortCurrencyCategory');
+
+    Route::get('currencies', 'CurrencyController@getCurrencyIndex');
     Route::get('currencies/sort', 'CurrencyController@getSort');
     Route::get('currencies/create', 'CurrencyController@getCreateCurrency');
     Route::get('currencies/edit/{id}', 'CurrencyController@getEditCurrency');

--- a/routes/lorekeeper/browse.php
+++ b/routes/lorekeeper/browse.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Facades\Route;
+
 /*
 |--------------------------------------------------------------------------
 | Browse Routes
@@ -101,6 +103,7 @@ Route::group(['prefix' => 'myo', 'namespace' => 'Characters'], function () {
 Route::group(['prefix' => 'world'], function () {
     Route::get('/', 'WorldController@getIndex');
 
+    Route::get('currency-categories', 'WorldController@getCurrencyCategories');
     Route::get('currencies', 'WorldController@getCurrencies');
     Route::get('rarities', 'WorldController@getRarities');
     Route::get('species', 'WorldController@getSpecieses');

--- a/routes/lorekeeper/members.php
+++ b/routes/lorekeeper/members.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Facades\Route;
+
 /*
 |--------------------------------------------------------------------------
 | Member Routes


### PR DESCRIPTION
- add sort, category search to world currencies index
- group home/user bank pages by currency

Currencies grouped by category display a small header on the home/user bank pages; however, unlike items, uncategorized currencies do not display a header so as to match the existing look and feel. Currency display on the profile itself is unimpacted.