### PR TITLE
fix: flat array by default & extension compatibility

### DIFF
--- a/app/Models/User/User.php
+++ b/app/Models/User/User.php
@@ -486,6 +486,7 @@ class User extends Authenticatable implements MustVerifyEmail {
      *
      * @param bool       $showAll
      * @param mixed|null $user
+     * @param mixed      $showCategories
      *
      * @return \Illuminate\Support\Collection
      */

--- a/resources/views/home/bank.blade.php
+++ b/resources/views/home/bank.blade.php
@@ -12,7 +12,7 @@
     </h1>
 
     <h3>Currencies</h3>
-    @foreach (Auth::user()->getCurrencies(true) as $category => $currencies)
+    @foreach (Auth::user()->getCurrencies(true, true) as $category => $currencies)
         <div class="card mb-2">
             @if ($currencies->first()->category)
                 <div class="card-header">

--- a/resources/views/user/bank.blade.php
+++ b/resources/views/user/bank.blade.php
@@ -12,7 +12,7 @@
     </h1>
 
     <h3>Currencies</h3>
-    @foreach ($user->getCurrencies(true) as $category => $currencies)
+    @foreach ($user->getCurrencies(true, true) as $category => $currencies)
         <div class="card mb-2">
             @if ($currencies->first()->category)
                 <div class="card-header">


### PR DESCRIPTION
described in dms:

> theres an error on shops due to changes on getCurrencies on User.php in the _sidebar
presumably because its wrapped in the categories now instead of just being the currency
there should probably be a bool option to return it as a flat collection

the reason why im making useCategory a default false is because a lot of extensions use the getCurrencies()