### PR TITLE
feat: allow head section

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -80,6 +80,8 @@
     @endif
 
     @include('feed::links')
+
+    @yield('head')
 </head>
 
 <body>


### PR DESCRIPTION
Why?
- Allows extensions to add javascript links etc in JUST their location, this is useful since it will prevent cross-site slowdown if multiple JS files are added to the primary view
- (ex for example, dailies has a JS script that is in the app.blade instead of on the dailies page)