### PR TITLE
fix: tinymce sub modals

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -146,6 +146,12 @@
         @yield('scripts')
         @include('layouts._pagination_js')
         <script>
+            $(document).on('focusin', function(e) {
+                if ($(e.target).closest(".tox-tinymce, .tox-tinymce-aux, .moxman-window, .tam-assetmanager-root").length) {
+                    e.stopImmediatePropagation();
+                }
+            });
+        
             $(function() {
                 $('[data-toggle="tooltip"]').tooltip({
                     html: true

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -151,7 +151,7 @@
                     e.stopImmediatePropagation();
                 }
             });
-        
+
             $(function() {
                 $('[data-toggle="tooltip"]').tooltip({
                     html: true


### PR DESCRIPTION
Based on code used by Newt in #1215. Tested and functional.

Originally found in the  [TinyMCE Documentation](https://www.tiny.cloud/docs/tinymce/latest/bootstrap-cloud/#usingtinymceinabootstrapdialog).