### PR TITLE
Fix(footer): Lorekeeper Github link

### DIFF
--- a/resources/views/layouts/_footer.blade.php
+++ b/resources/views/layouts/_footer.blade.php
@@ -6,7 +6,7 @@
         <li class="nav-item"><a href="{{ url('reports/bug-reports') }}" class="nav-link">Bug Reports</a></li>
         <li class="nav-item"><a href="mailto:{{ env('CONTACT_ADDRESS') }}" class="nav-link">Contact</a></li>
         <li class="nav-item"><a href="http://deviantart.com/{{ env('DEVIANTART_ACCOUNT') }}" class="nav-link">deviantART</a></li>
-        <li class="nav-item"><a href="https://github.com/corowne/lorekeeper" class="nav-link">Lorekeeper</a></li>
+        <li class="nav-item"><a href="https://github.com/lk-arpg/lorekeeper" class="nav-link">Lorekeeper</a></li>
         <li class="nav-item"><a href="{{ url('credits') }}" class="nav-link">Credits</a></li>
         <li class="nav-item"><a href="{{ url('feeds/news') }}" class="nav-link"><i class="fas fa-rss-square"></i> News</a></li>
         <li class="nav-item"><a href="{{ url('feeds/sales') }}" class="nav-link"><i class="fas fa-rss-square"></i> Sales</a></li>


### PR DESCRIPTION
Should technically be done on main as well, but since the old url redirects just fine, I don't think it's that important to rush out a fix.