### PR TITLE
fix(galleries): add missing argument to create submission "can submit" check

### DIFF
--- a/resources/views/galleries/create_edit_submission.blade.php
+++ b/resources/views/galleries/create_edit_submission.blade.php
@@ -23,7 +23,7 @@
         @endif
     </h1>
 
-    @if (!$submission->id && ($closed || !$gallery->canSubmit(Auth::user())))
+    @if (!$submission->id && ($closed || !$gallery->canSubmit(Settings::get('gallery_submissions_open'), Auth::user())))
         <div class="alert alert-danger">
             @if ($closed)
                 Gallery submissions are currently closed.


### PR DESCRIPTION
Looks like I missed updating precisely One instance of this check...