### PR TITLE
feat(world): Add sorting to subtype and species

### DIFF
--- a/app/Http/Controllers/WorldController.php
+++ b/app/Http/Controllers/WorldController.php
@@ -217,8 +217,9 @@ class WorldController extends Controller {
         } else {
             $query->sortStandard();
         }
+
         return view('world.subtypes', [
-            'subtypes' => $query->visible(Auth::user() ?? null)->paginate(20)->appends($request->query()),
+            'subtypes'   => $query->visible(Auth::user() ?? null)->paginate(20)->appends($request->query()),
             'specieses'  => ['none' => 'Any Species'] + Species::visible(Auth::user() ?? null)->orderBy('sort', 'DESC')->pluck('name', 'id')->toArray(),
         ]);
     }

--- a/app/Http/Controllers/WorldController.php
+++ b/app/Http/Controllers/WorldController.php
@@ -137,15 +137,40 @@ class WorldController extends Controller {
             $query->withCount('features');
         }
 
-        $name = $request->get('name');
-        if ($name) {
-            $query->where('name', 'LIKE', '%'.$name.'%');
+        $data = $request->only(['name', 'sort']);
+
+        if (isset($data['name'])) {
+            $query->where('name', 'LIKE', '%'.$data['name'].'%');
+        }
+        if (isset($data['sort'])) {
+            switch ($data['sort']) {
+                case 'standard':
+                    $query->sortStandard();
+                    break;
+                case 'standard-reverse':
+                    $query->sortStandard(true);
+                    break;
+                case 'alpha':
+                    $query->sortAlphabetical();
+                    break;
+                case 'alpha-reverse':
+                    $query->sortAlphabetical(true);
+                    break;
+                case 'newest':
+                    $query->sortNewest();
+                    break;
+                case 'oldest':
+                    $query->sortNewest(true);
+                    break;
+            }
+        } else {
+            $query->sortStandard();
         }
 
         return view('world.specieses', [
             'specieses' => $query->with(['subtypes' => function ($query) {
-                $query->visible(Auth::user() ?? null)->orderBy('sort', 'DESC');
-            }])->visible(Auth::user() ?? null)->orderBy('sort', 'DESC')->orderBy('id')->paginate(20)->appends($request->query()),
+                $query->visible(Auth::user() ?? null)->sortStandard();
+            }])->visible(Auth::user() ?? null)->paginate(20)->appends($request->query()),
         ]);
     }
 
@@ -156,13 +181,45 @@ class WorldController extends Controller {
      */
     public function getSubtypes(Request $request) {
         $query = Subtype::query()->with('species');
-        $name = $request->get('name');
-        if ($name) {
-            $query->where('name', 'LIKE', '%'.$name.'%');
+        $data = $request->only(['species_id', 'name', 'sort']);
+
+        if (isset($data['species_id']) && $data['species_id'] != 'none') {
+            $query->where('species_id', $data['species_id']);
+        }
+        if (isset($data['name'])) {
+            $query->where('name', 'LIKE', '%'.$data['name'].'%');
         }
 
+        if (isset($data['sort'])) {
+            switch ($data['sort']) {
+                case 'standard':
+                    $query->sortStandard();
+                    break;
+                case 'standard-reverse':
+                    $query->sortStandard(true);
+                    break;
+                case 'alpha':
+                    $query->sortAlphabetical();
+                    break;
+                case 'alpha-reverse':
+                    $query->sortAlphabetical(true);
+                    break;
+                case 'species':
+                    $query->sortSpecies();
+                    break;
+                case 'newest':
+                    $query->sortNewest();
+                    break;
+                case 'oldest':
+                    $query->sortNewest(true);
+                    break;
+            }
+        } else {
+            $query->sortStandard();
+        }
         return view('world.subtypes', [
-            'subtypes' => $query->visible(Auth::user() ?? null)->orderBy('sort', 'DESC')->orderBy('id')->paginate(20)->appends($request->query()),
+            'subtypes' => $query->visible(Auth::user() ?? null)->paginate(20)->appends($request->query()),
+            'specieses'  => ['none' => 'Any Species'] + Species::visible(Auth::user() ?? null)->orderBy('sort', 'DESC')->pluck('name', 'id')->toArray(),
         ]);
     }
 

--- a/app/Models/Species/Species.php
+++ b/app/Models/Species/Species.php
@@ -78,6 +78,41 @@ class Species extends Model {
     **********************************************************************************************/
 
     /**
+     * Scope a query to sort species in default order.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param bool                                  $reverse
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeSortStandard($query, $reverse = false) {
+        return $query->orderBy('sort', $reverse ? 'ASC' : 'DESC')->orderBy('id');
+    }
+
+    /**
+     * Scope a query to sort species in alphabetical order.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param bool                                  $reverse
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeSortAlphabetical($query, $reverse = false) {
+        return $query->orderBy('name', $reverse ? 'DESC' : 'ASC');
+    }
+
+    /**
+     * Scope a query to sort species by newest first.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeSortNewest($query, $reverse = false) {
+        return $query->orderBy('id', $reverse ? 'ASC' : 'DESC');
+    }
+
+    /**
      * Scope a query to show only visible species.
      *
      * @param \Illuminate\Database\Eloquent\Builder $query

--- a/app/Models/Species/Species.php
+++ b/app/Models/Species/Species.php
@@ -105,6 +105,7 @@ class Species extends Model {
      * Scope a query to sort species by newest first.
      *
      * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param mixed                                 $reverse
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */

--- a/app/Models/Species/Subtype.php
+++ b/app/Models/Species/Subtype.php
@@ -82,6 +82,54 @@ class Subtype extends Model {
     **********************************************************************************************/
 
     /**
+     * Scope a query to sort species in default order.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param bool                                  $reverse
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeSortStandard($query, $reverse = false) {
+        return $query->orderBy('sort', $reverse ? 'ASC' : 'DESC')->orderBy('id');
+    }
+
+    /**
+     * Scope a query to sort subtypes in alphabetical order.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param bool                                  $reverse
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeSortAlphabetical($query, $reverse = false) {
+        return $query->orderBy('name', $reverse ? 'DESC' : 'ASC');
+    }
+
+    /**
+     * Scope a query to sort subtypes in species order.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeSortSpecies($query) {
+        $ids = Species::orderBy('sort', 'DESC')->pluck('id')->toArray();
+
+        return count($ids) ? $query->orderBy(DB::raw('FIELD(species_id, '.implode(',', $ids).')')) : $query;
+    }
+
+    /**
+     * Scope a query to sort subtypes by newest first.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeSortNewest($query, $reverse = false) {
+        return $query->orderBy('id', $reverse ? 'ASC' : 'DESC');
+    }
+
+    /**
      * Scope a query to show only visible subtypes.
      *
      * @param \Illuminate\Database\Eloquent\Builder $query

--- a/app/Models/Species/Subtype.php
+++ b/app/Models/Species/Subtype.php
@@ -122,6 +122,7 @@ class Subtype extends Model {
      * Scope a query to sort subtypes by newest first.
      *
      * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param mixed                                 $reverse
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */

--- a/resources/views/world/specieses.blade.php
+++ b/resources/views/world/specieses.blade.php
@@ -9,12 +9,29 @@
     <h1>Species</h1>
 
     <div>
-        {!! Form::open(['method' => 'GET', 'class' => 'form-inline justify-content-end']) !!}
-        <div class="form-group mr-3 mb-3">
-            {!! Form::text('name', Request::get('name'), ['class' => 'form-control']) !!}
-        </div>
-        <div class="form-group mb-3">
-            {!! Form::submit('Search', ['class' => 'btn btn-primary']) !!}
+        {!! Form::open(['method' => 'GET', 'class' => '']) !!}
+        <div class="form-inline justify-content-end">
+            <div class="form-group ml-3 mb-3">
+                {!! Form::text('name', Request::get('name'), ['class' => 'form-control']) !!}
+            </div>
+            <div class="form-group ml-3 mb-3">
+                {!! Form::select(
+                    'sort',
+                    [
+                        'standard' => 'Default Sorting',
+                        'standard-reverse' => 'Default Sorting (Reverse)',
+                        'alpha' => 'Sort Alphabetically (A-Z)',
+                        'alpha-reverse' => 'Sort Alphabetically (Z-A)',
+                        'newest' => 'Newest First',
+                        'oldest' => 'Oldest First',
+                    ],
+                    Request::get('sort') ?: 'standard',
+                    ['class' => 'form-control'],
+                ) !!}
+            </div>
+            <div class="form-group ml-3 mb-3">
+                {!! Form::submit('Search', ['class' => 'btn btn-primary']) !!}
+            </div>
         </div>
         {!! Form::close() !!}
     </div>

--- a/resources/views/world/subtypes.blade.php
+++ b/resources/views/world/subtypes.blade.php
@@ -9,12 +9,33 @@
     <h1>Subtypes</h1>
 
     <div>
-        {!! Form::open(['method' => 'GET', 'class' => 'form-inline justify-content-end']) !!}
-        <div class="form-group mr-3 mb-3">
-            {!! Form::text('name', Request::get('name'), ['class' => 'form-control']) !!}
-        </div>
-        <div class="form-group mb-3">
-            {!! Form::submit('Search', ['class' => 'btn btn-primary']) !!}
+        {!! Form::open(['method' => 'GET', 'class' => '']) !!}
+        <div class="form-inline justify-content-end">
+            <div class="form-group ml-3 mb-3">
+                {!! Form::text('name', Request::get('name'), ['class' => 'form-control']) !!}
+            </div>
+            <div class="form-group ml-3 mb-3">
+                {!! Form::select('species_id', $specieses, Request::get('species_id'), ['class' => 'form-control']) !!}
+            </div>
+            <div class="form-group ml-3 mb-3">
+                {!! Form::select(
+                    'sort',
+                    [
+                        'standard' => 'Default Sorting',
+                        'standard-reverse' => 'Default Sorting (Reverse)',
+                        'alpha' => 'Sort Alphabetically (A-Z)',
+                        'alpha-reverse' => 'Sort Alphabetically (Z-A)',
+                        'species' => 'Sort by Species',
+                        'newest' => 'Newest First',
+                        'oldest' => 'Oldest First',
+                    ],
+                    Request::get('sort') ?: 'standard',
+                    ['class' => 'form-control'],
+                ) !!}
+            </div>
+            <div class="form-group ml-3 mb-3">
+                {!! Form::submit('Search', ['class' => 'btn btn-primary']) !!}
+            </div>
         </div>
         {!! Form::close() !!}
     </div>


### PR DESCRIPTION
Adds the following sorting methods to the Subtypes and Species world pages:
- Default Sorting
(Sorting per administration choice)
- Default Sorting (Reverse)
- Sort Alphabetically (A-Z)
- Sort Alphabetically (Z-A)
- Sort by Species `*`
- Newest First
- Oldest First

`*` Sort by Species is _obviously_ limited to the Subtypes only.