### PR TITLE
fix(admin): Rarity edit object not filled in admin section

### DIFF
--- a/resources/views/admin/rarities/create_edit_rarity.blade.php
+++ b/resources/views/admin/rarities/create_edit_rarity.blade.php
@@ -68,6 +68,10 @@
                     'description' => $rarity->parsed_description,
                     'searchFeaturesUrl' => $rarity->searchFeaturesUrl,
                     'searchCharactersUrl' => $rarity->searchCharactersUrl,
+                    'edit' => [
+                        'title' => 'Edit Rarity',
+                        'object' => $rarity,
+                    ],
                 ])
             </div>
         </div>


### PR DESCRIPTION
Curiously enough, this was missed and I only just saw an error related to this.