### PR TITLE
feat: add description to item in inventory

### DIFF
--- a/resources/views/home/_inventory_stack.blade.php
+++ b/resources/views/home/_inventory_stack.blade.php
@@ -18,6 +18,17 @@
         @endif
     </div>
 
+    @if ($item->parsed_description)
+        <div class="mb-2">
+            <a data-toggle="collapse" href="#itemDescription" class="h5">Description <i class="fas fa-caret-down"></i></a>
+            <div class="card collapse mt-1" id="itemDescription">
+                <div class="card-body">
+                    {!! $item->parsed_description !!}
+                </div>
+            </div>
+        </div>
+    @endif
+
     <h5>Item Variations</h5>
     @if ($user && $user->hasPower('edit_inventories'))
         <p class="alert alert-warning my-2">Note: Your rank allows you to transfer account-bound items to another user.</p>


### PR DESCRIPTION
Drove me a bit insane that shop has the item description but not inventory (which means you can't quick check the item desc from your inventory) so I added it back o7