### PR TITLE
fix(ranks & gallery submissions): parsed rank description on setup + gallery character notifications

### DIFF
--- a/app/Console/Commands/SetupAdminUser.php
+++ b/app/Console/Commands/SetupAdminUser.php
@@ -46,16 +46,16 @@ class SetupAdminUser extends Command {
         if (!Rank::count()) {
             // These need to be created even if the seeder isn't run for the site to work correctly.
             $adminRank = Rank::create([
-                'name'        => 'Admin',
-                'description' => 'The site admin. Has the ability to view/edit any data on the site.',
+                'name'               => 'Admin',
+                'description'        => 'The site admin. Has the ability to view/edit any data on the site.',
                 'parsed_description' => parse('The site admin. Has the ability to view/edit any data on the site.'),
-                'sort'        => 1,
+                'sort'               => 1,
             ]);
             Rank::create([
-                'name'        => 'Member',
-                'description' => 'A regular member of the site.',
+                'name'               => 'Member',
+                'description'        => 'A regular member of the site.',
                 'parsed_description' => parse('A regular member of the site.'),
-                'sort'        => 0,
+                'sort'               => 0,
             ]);
 
             $this->line('User ranks not found. Default user ranks (admin and basic member) created.');

--- a/app/Console/Commands/SetupAdminUser.php
+++ b/app/Console/Commands/SetupAdminUser.php
@@ -48,11 +48,13 @@ class SetupAdminUser extends Command {
             $adminRank = Rank::create([
                 'name'        => 'Admin',
                 'description' => 'The site admin. Has the ability to view/edit any data on the site.',
+                'parsed_description' => parse('The site admin. Has the ability to view/edit any data on the site.'),
                 'sort'        => 1,
             ]);
             Rank::create([
                 'name'        => 'Member',
                 'description' => 'A regular member of the site.',
+                'parsed_description' => parse('A regular member of the site.'),
                 'sort'        => 0,
             ]);
 

--- a/app/Services/GalleryManager.php
+++ b/app/Services/GalleryManager.php
@@ -878,7 +878,7 @@ class GalleryManager extends Service {
                 // Send a notification to included characters' owners now that the submission is accepted
                 // but not for the submitting user's own characters
                 foreach ($submission->characters as $character) {
-                    if ($character->user && $character->character->user->id != $submission->user->id) {
+                    if ($character->character->user && $character->character->user->id != $submission->user->id) {
                         Notifications::create('GALLERY_SUBMISSION_CHARACTER', $character->character->user, [
                             'sender'        => $submission->user->name,
                             'sender_url'    => $submission->user->url,


### PR DESCRIPTION
Two tiny fixes...

1. Setting a parsed rank description when the Admin and Member roles are created upon initial setup and running the setup command for the admin user. I noticed that for sites setting up for the first time, the help icon on user profiles does not actually display a tooltip when hovered over; the tooltip uses the contents of `parsed_description` but when doing initial setup commands that value is null and only `description` is set...which now that I look at commit history on the main branch as I type this I think this might be the case for v2/main as well. (Main branch went from using `description` to `parsed_description` way back in April of 2019, so...) This just sets a value for it during setup so the tooltip works from the get-go. <sub>(The parse function the string is wrapped in can just be removed though...if that's more ideal I can edit that real quick.)</sub>
2. Was realizing that users & myself weren't reliably getting notifications for owned characters being included in other users' gallery submissions. Taking a peek at the code chunk I noticed it checks `$character->user` when the GalleryCharacter model does not have a user relation. Like other instances in that code chunk it should be going `$character->character->user` instead.