### PR TITLE
fix(css): custom.css using lorekeeper.css filemtime

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -79,7 +79,7 @@
     <link href="{{ asset('css/selectize.bootstrap4.css') }}" rel="stylesheet">
 
     @if (file_exists(public_path() . '/css/custom.css'))
-        <link href="{{ asset('css/custom.css') . '?v=' . filemtime(public_path('css/lorekeeper.css')) }}" rel="stylesheet">
+        <link href="{{ asset('css/custom.css') . '?v=' . filemtime(public_path('css/custom.css')) }}" rel="stylesheet">
     @endif
 
     @include('feed::links')


### PR DESCRIPTION
Simple bugfix, means the custom.css variable actually changes if the file is, rather than waiting for lorekeeper.css for some reason. :)