### PR TITLE
style(site settings): make settings description column 6 units

### DIFF
--- a/resources/views/admin/settings/settings.blade.php
+++ b/resources/views/admin/settings/settings.blade.php
@@ -22,10 +22,10 @@
                     <div class="col-6 col-md-3">
                         <div class="logs-table-cell">Key</div>
                     </div>
-                    <div class="col-6 col-md-3">
+                    <div class="col-6">
                         <div class="logs-table-cell">Description</div>
                     </div>
-                    <div class="col-md-6">
+                    <div class="col-md-3">
                         <div class="logs-table-cell">Value</div>
                     </div>
                 </div>
@@ -37,10 +37,10 @@
                             <div class="col-6 col-md-3">
                                 <div class="logs-table-cell">{{ $setting->key }}</div>
                             </div>
-                            <div class="col-6 col-md-3">
+                            <div class="col-6">
                                 <div class="logs-table-cell">{{ $setting->description }}</div>
                             </div>
-                            <div class="col-6 col-md-3">
+                            <div class="col-md-3">
                                 <div class="logs-table-cell">
                                     {!! Form::open(['url' => 'admin/settings/' . $setting->key, 'class' => 'd-flex justify-content-end']) !!}
                                     <div class="form-group mr-3 mb-3">


### PR DESCRIPTION
Very small edit. In the site settings page in the admin panel, the value column was set to 6 units on the heading and 3 for the body while the description was set to 3 thus making a chunk of empty space on the right. This is an adjustment to instead make the description 6 units instead so each setting takes up the full row. 

This also gives more room for settings with lengthier descriptions, and with the value column not being restricted until the md breakpoint it makes the page friendlier on extra small mobile screens as well.

**Before:**
![The original site settings page.](https://i.imgur.com/dcd1k0c.png)

**After:**
![The updated site settings page.](https://i.imgur.com/WRs6VIW.png)