### PR TITLE
add docker and docker-compose for easy setup

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,251 @@
+# Running Lorekeeper with Docker
+
+This guide will help you set up and run Lorekeeper using Docker and Docker Compose, making it easy to get started without manual installation steps.
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
+
+## Quick Start
+
+1. Clone the repository:
+   ```
+   git clone https://github.com/corowne/lorekeeper.git
+   cd lorekeeper
+   ```
+
+2. Start the Docker containers:
+   ```
+   docker-compose up -d --build
+   ```
+
+   Note: The `--build` flag is important for the first run to ensure Docker builds the images locally instead of trying to pull them from a remote registry.
+
+3. Wait for the setup to complete. The first time you run this, it will:
+   - Set up the database
+   - Install PHP dependencies
+   - Generate application key
+   - Run database migrations
+   - Add basic site data
+   - Compile frontend assets
+
+4. Access the application:
+   - Open your browser and go to `http://localhost:8080`
+
+## Setting Up Social Media Authentication
+
+For social media authentication to work, you need to update the `.env` file with your client ID and secret for at least one supported platform.
+
+1. Stop the containers:
+   ```
+   docker-compose down
+   ```
+
+2. Edit the `.env` file in the project root and add your social media credentials.
+   See [the Wiki](http://wiki.lorekeeper.me/index.php?title=Category:Social_Media_Authentication) for platform-specific instructions.
+
+3. Restart the containers:
+   ```
+   docker-compose up -d
+   ```
+
+## Setting Up Admin Account
+
+To set up the admin account:
+
+1. Access the app container:
+   ```
+   docker-compose exec app bash
+   ```
+
+2. Run the admin setup command:
+   ```
+   php artisan setup-admin-user
+   ```
+
+3. Follow the prompts to create your admin account.
+
+4. You will need to send yourself the verification email and then link your social media account as prompted.
+
+## Customizing the Setup
+
+### Database Configuration
+
+The default database configuration is:
+- Database: `lorekeeper`
+- Username: `lorekeeper`
+- Password: `secret`
+- Root Password: `root`
+
+If you want to change these values, edit the `docker-compose.yml` file before starting the containers.
+
+### PHP Configuration
+
+PHP configuration can be modified in the `php/local.ini` file.
+
+### Nginx Configuration
+
+Nginx configuration can be modified in the `nginx/conf.d/app.conf` file.
+
+### MySQL Configuration
+
+MySQL configuration can be modified in the `mysql/my.cnf` file.
+
+## Troubleshooting
+
+### Platform Compatibility Issues
+
+If you encounter an error like `no matching manifest for linux/arm64/v8 in the manifest list entries`, it means Docker is trying to use an image that doesn't support your system's architecture (typically ARM64 for Apple Silicon Macs).
+
+To resolve this:
+
+1. Make sure you're using the latest version of the repository with ARM64 compatibility updates
+2. Run with the explicit platform setting:
+   ```
+   TARGETPLATFORM=linux/arm64 docker-compose up -d --build
+   ```
+3. If the issue persists with a specific service, you can try forcing emulation for that service by setting its platform to linux/amd64 in docker-compose.yml
+
+### Container Logs
+
+To view logs for a specific container:
+```
+docker-compose logs app    # For PHP/Laravel logs
+docker-compose logs webserver  # For Nginx logs
+docker-compose logs db     # For MySQL logs
+```
+
+### Restarting Containers
+
+If you need to restart the containers:
+```
+docker-compose restart
+```
+
+### Rebuilding Containers
+
+If you make changes to the Dockerfile or need to rebuild the containers:
+```
+docker-compose up -d --build
+```
+
+This ensures that Docker rebuilds the images locally rather than trying to pull them from a remote registry.
+
+### Running on ARM64 Systems (Apple Silicon Macs)
+
+If you're using an ARM64-based system like an Apple Silicon Mac (M1, M2, etc.), you might encounter platform compatibility issues. The Docker setup has been configured to handle this automatically by:
+
+1. Using MySQL 5.7 with platform set to linux/amd64 (runs via emulation)
+2. Using platform-specific builds for the PHP and Nginx containers
+
+To explicitly set the target platform for all services, you can use:
+
+```
+TARGETPLATFORM=linux/arm64 docker-compose up -d --build
+```
+
+For optimal performance on ARM64 systems, you can also try:
+
+```
+TARGETPLATFORM=linux/arm64 COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose up -d --build
+```
+
+This enables BuildKit which can improve build performance.
+
+### Port Conflicts
+
+If you encounter an error like `Error response from daemon: Ports are not available: exposing port TCP 0.0.0.0:8080 -> 127.0.0.1:0: listen tcp 0.0.0.0:8080: bind: address already in use`, it means that port 8080 is already in use on your host machine.
+
+To resolve this, you can either:
+
+1. Stop the service that's using port 8080 on your host machine
+2. Change the port mapping in `docker-compose.yml` to use a different port:
+   ```
+   ports:
+     - "8081:80"  # Change 8080 to another port like 8081
+     - "8443:443"
+   ```
+   Then update the access URL to match your new port (e.g., `http://localhost:8081`)
+
+### MySQL Database Issues
+
+If you encounter MySQL database issues, such as:
+
+- `Failed to initialize DD Storage Engine`
+- `No space left on device`
+- `Cannot resize redo log file`
+- `unknown variable 'innodb_redo_log_capacity'`
+- Connection refused errors
+
+These are typically caused by MySQL requiring more disk space than is available or configuration incompatibilities. To resolve these issues:
+
+1. The Docker setup now uses MySQL 5.7 instead of 8.0, which has lower resource requirements
+2. The MySQL configuration in `mysql/my.cnf` has been optimized for low resource usage:
+   - Using smaller log file sizes
+   - Reducing buffer pool size
+   - Limiting connections
+   - Using compatible configuration parameters for MySQL 5.7
+3. The MySQL data directory is now stored in memory using tmpfs instead of on disk:
+   ```yaml
+   tmpfs:
+     - /var/lib/mysql:rw,noexec,nosuid,size=500m
+   ```
+   This significantly reduces disk space requirements and improves performance, but note that data will not persist if the container is stopped.
+
+4. If you still encounter issues, you can try:
+   - Increasing the tmpfs size in `docker-compose.yml` if you need more space
+   - Clearing the database volume: `docker-compose down -v` (warning: this will delete all your data)
+   - Increasing the disk space available to Docker
+   - Checking if your Docker environment has disk space limits
+
+If MySQL starts but the application can't connect to it, check:
+- MySQL logs: `docker-compose logs db`
+- Application logs: `docker-compose logs app`
+- Try restarting just the database: `docker-compose restart db`
+
+### Using Docker Compose Bake for Better Performance
+
+Docker Compose now supports delegating builds to Bake for better performance. To enable this feature:
+
+```
+COMPOSE_BAKE=true docker-compose up -d --build
+```
+
+If you encounter a permission error like `stat /Users/username/.docker/buildx/instances: permission denied`, you need to fix the permissions for your Docker Buildx directory:
+
+1. Check the ownership of your Docker directory:
+   ```
+   ls -la ~/.docker
+   ```
+
+2. Fix the permissions:
+   ```
+   sudo chown -R $USER:$USER ~/.docker
+   ```
+
+3. If the buildx directory doesn't exist, you may need to create it:
+   ```
+   mkdir -p ~/.docker/buildx
+   ```
+
+4. Try running the command again:
+   ```
+   COMPOSE_BAKE=true docker-compose up -d --build
+   ```
+
+### Accessing the Database
+
+To access the MySQL database directly:
+```
+docker-compose exec db mysql -u lorekeeper -p lorekeeper
+```
+When prompted, enter the password (`secret` by default).
+
+## Data Persistence
+
+All data is persisted in Docker volumes:
+- Database data is stored in the `dbdata` volume
+- Application files are mounted from your local directory
+
+This means your data will persist even if you stop or remove the containers.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,57 @@
+ARG TARGETPLATFORM=linux/amd64
+FROM --platform=${TARGETPLATFORM} php:8.1-fpm
+
+# Set working directory
+WORKDIR /var/www
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    libpng-dev \
+    libjpeg62-turbo-dev \
+    libfreetype6-dev \
+    locales \
+    zip \
+    jpegoptim optipng pngquant gifsicle \
+    vim \
+    unzip \
+    git \
+    curl \
+    libzip-dev \
+    libonig-dev \
+    libxml2-dev \
+    netcat-openbsd
+
+# Clear cache
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install extensions
+RUN docker-php-ext-install pdo_mysql mbstring zip exif pcntl bcmath gd
+
+# Install composer
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+# Install node and npm
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
+RUN apt-get install -y nodejs
+
+# Add user for laravel application
+RUN groupadd -g 1000 www
+RUN useradd -u 1000 -ms /bin/bash -g www www
+
+# Copy existing application directory contents
+COPY . /var/www
+
+# Copy existing application directory permissions
+COPY --chown=www:www . /var/www
+
+# Copy the entrypoint script
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# Change current user to www
+USER www
+
+# Expose port 9000 and start php-fpm server
+EXPOSE 9000
+CMD ["/usr/local/bin/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Lorekeeper is a framework for managing deviantART-based ARPGs/closed species mas
 
 Important: For those who are not familiar with web dev, please refer to the [Wiki](http://wiki.lorekeeper.me/index.php?title=Tutorial:_Setting_Up) for a much more detailed set of instructions!!
 
+## Docker Setup (Recommended)
+
+For the easiest setup experience, you can use Docker and Docker Compose to run Lorekeeper without manual installation steps. See [DOCKER.md](DOCKER.md) for instructions.
+
+## Manual Setup
+
 ## Obtain a copy of the code
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,70 @@
+services:
+  # PHP Service
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}  # Default to amd64 but use host platform if specified
+    image: lorekeeper-app:local
+    container_name: lorekeeper-app
+    restart: unless-stopped
+    tty: true
+    environment:
+      SERVICE_NAME: app
+      SERVICE_TAGS: dev
+    working_dir: /var/www
+    volumes:
+      - ./:/var/www
+      - ./php/local.ini:/usr/local/etc/php/conf.d/local.ini
+    networks:
+      - lorekeeper-network
+
+  # Nginx Service
+  webserver:
+    image: nginx:alpine
+    platform: ${TARGETPLATFORM:-linux/amd64}  # Use the same platform as the app service
+    container_name: lorekeeper-webserver
+    restart: unless-stopped
+    tty: true
+    ports:
+      - "8080:80"
+      - "8443:443"
+    volumes:
+      - ./:/var/www
+      - ./nginx/conf.d:/etc/nginx/conf.d
+    networks:
+      - lorekeeper-network
+
+  # MySQL Service
+  db:
+    image: mysql:5.7
+    platform: linux/amd64  # Specify platform for compatibility
+    container_name: lorekeeper-db
+    restart: unless-stopped
+    tty: true
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_DATABASE: lorekeeper
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_PASSWORD: secret
+      MYSQL_USER: lorekeeper
+      SERVICE_TAGS: dev
+      SERVICE_NAME: mysql
+    volumes:
+      - ./mysql/my.cnf:/etc/mysql/my.cnf
+    tmpfs:
+      - /var/lib/mysql:rw,noexec,nosuid,size=500m
+    networks:
+      - lorekeeper-network
+
+# Networks
+networks:
+  lorekeeper-network:
+    driver: bridge
+
+# Volumes
+volumes:
+  dbdata:
+    driver: local

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# Wait for MySQL to be ready
+echo "Waiting for MySQL to be ready..."
+MAX_RETRIES=30
+RETRY_COUNT=0
+
+while ! nc -z db 3306; do
+  RETRY_COUNT=$((RETRY_COUNT+1))
+  if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
+    echo "Error: Maximum retry count reached. MySQL is not available. Check MySQL logs for errors."
+    echo "Continuing anyway, but database operations may fail..."
+    break
+  fi
+  echo "Waiting for database connection... (Attempt $RETRY_COUNT/$MAX_RETRIES)"
+  sleep 5
+done
+
+if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
+  echo "MySQL is up and running!"
+  # Additional check to verify MySQL is accepting connections
+  sleep 2
+  if ! mysql -h db -u lorekeeper -psecret -e "SELECT 1" >/dev/null 2>&1; then
+    echo "Warning: MySQL is running but not accepting connections. Some database operations may fail."
+  else
+    echo "MySQL connection verified successfully!"
+  fi
+fi
+
+cd /var/www
+
+# Copy .env.example to .env if .env doesn't exist
+if [ ! -f .env ]; then
+    echo "Creating .env file..."
+    cp .env.example .env
+
+    # Update database connection settings
+    sed -i 's/DB_HOST=127.0.0.1/DB_HOST=db/g' .env
+    sed -i 's/DB_DATABASE=homestead/DB_DATABASE=lorekeeper/g' .env
+    sed -i 's/DB_USERNAME=homestead/DB_USERNAME=lorekeeper/g' .env
+    sed -i 's/DB_PASSWORD=secret/DB_PASSWORD=secret/g' .env
+
+    # Add required settings from README
+    echo "CONTACT_ADDRESS=example@example.com" >> .env
+    echo "DEVIANTART_ACCOUNT=example" >> .env
+fi
+
+# Install dependencies
+echo "Installing dependencies..."
+composer install --no-interaction --no-dev --optimize-autoloader
+
+# Generate key if not already generated
+if grep -q "APP_KEY=base64:" .env; then
+    echo "Application key already exists."
+else
+    echo "Generating application key..."
+    php artisan key:generate
+fi
+
+# Run migrations
+echo "Running migrations..."
+php artisan migrate --force
+
+# Add basic site data
+echo "Adding basic site data..."
+php artisan add-site-settings
+php artisan add-text-pages
+php artisan copy-default-images
+
+# Set permissions
+echo "Setting permissions..."
+chmod -R 777 storage bootstrap/cache
+
+# Compile assets
+echo "Compiling assets..."
+npm install
+npm run prod
+
+echo "Setup completed!"
+
+# Start PHP-FPM
+php-fpm

--- a/mysql/my.cnf
+++ b/mysql/my.cnf
@@ -1,0 +1,15 @@
+[mysqld]
+general_log = 1
+general_log_file = /var/lib/mysql/general.log
+sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
+character-set-server = utf8mb4
+collation-server = utf8mb4_unicode_ci
+
+# Reduce disk space requirements
+innodb_log_file_size=1M
+innodb_flush_log_at_trx_commit=0
+innodb_log_buffer_size=256K
+innodb_buffer_pool_size=5M
+innodb_file_per_table=1
+max_connections=10
+innodb_data_file_path=ibdata1:10M:autoextend:max:50M

--- a/nginx/conf.d/app.conf
+++ b/nginx/conf.d/app.conf
@@ -1,0 +1,24 @@
+server {
+    listen 80 default_server;
+    server_name _;
+
+    index index.php index.html;
+    error_log  /var/log/nginx/error.log;
+    access_log /var/log/nginx/access.log;
+    root /var/www/public;
+
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass app:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+        gzip_static on;
+    }
+}

--- a/php/local.ini
+++ b/php/local.ini
@@ -1,0 +1,3 @@
+upload_max_filesize=40M
+post_max_size=40M
+memory_limit=512M


### PR DESCRIPTION
as the title says i have added framework and implementation for an easy local deployment of lorekeeper entirely in docker-compose along with readme updates to describe how to make it work for anyone easily.

implementation was tested on my macbook air with the current commited dockerfile and compose yaml i would expect this to work for others on any OS with docker and compose.