### PR TITLE
chore: update contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ For support and general questions and discussions, please visit the [support Dis
 
 The following are accepted uses for the [issue tracker](https://github.com/corowne/Lorekeeper/issues):
 - Bug reports
-- Feature or enhancement requests (within reason)-- note that these may be denied if they are deemed out of scope of the project and/or are not feasible to implement for any reason.
+- Feature or enhancement requests *or* discussion of potential new features (within reason)-- note that these may be denied if they are deemed out of scope of the project and/or are not feasible to implement for any reason.
 
 ## Opening an Issue
 ### Reporting a bug
@@ -24,7 +24,7 @@ Avoid listing multiple requests in one issue. One issue per request makes it eas
 
 ## Contributing Code
 
-Please see the full [Contribution Guide](http://wiki.lorekeeper.me/index.php?title=Contributing_to_Lorekeeper) for more information!
+Please see the full [Contribution Guide](https://lk-arpg.github.io/lk-docs/prerelease/contributing/) for more information!
 
 ### About abandoned pull requests
 


### PR DESCRIPTION
Not much of note, just making a couple small tweaks to contribution info-- mainly switching the link to point to the new docs.

I figure it's most reasonable to point at the prerelease version, since that'll always be the most up-to-date contribution info.