### PR TITLE
Fix: Lack of alias set as primary causing error 500

### DIFF
--- a/app/Models/User/User.php
+++ b/app/Models/User/User.php
@@ -398,7 +398,7 @@ class User extends Authenticatable implements MustVerifyEmail {
             return '(Unverified)';
         }
 
-        return $this->primaryAlias->displayAlias;
+        return $this->primaryAlias?->displayAlias ?? '(No Alias)';
     }
 
     /**


### PR DESCRIPTION
I noticed this earlier trying to add social auth to another LK, if someone sets one alias and doesn't change it to their primary and the "require alias" setting isn't on it will error out on all pages involving the display alias. The fix should paliate that issue (and display "No alias" instead).