### PR TITLE
Fix: Unselected rarity / species causing error 500 in feature modal

### DIFF
--- a/app/Services/CharacterManager.php
+++ b/app/Services/CharacterManager.php
@@ -625,6 +625,15 @@ class CharacterManager extends Service {
                 }
             }
 
+            //Check that species & rarity are selected
+            if (!(isset($data['species_id']) && $data['species_id'])) {
+                    throw new \Exception('Characters require a species.');
+            }
+
+            if (!(isset($data['rarity_id']) && $data['rarity_id'])) {
+                    throw new \Exception('Characters require a rarity.');
+            }
+
             if (!$this->logAdminAction($user, 'Updated Image', 'Updated character image features on <a href="'.$image->character->url.'">#'.$image->id.'</a>')) {
                 throw new \Exception('Failed to log admin action.');
             }


### PR DESCRIPTION
What title says, referencing to #906 where the trait modal allowed for species & rarity to be unselected which caused the error to pop. This simply adds two checks to see if the user has selected them and will error out if not.