### PR TITLE
fix(submissions): add eager loading for submission characters

### DIFF
--- a/resources/views/home/_submission_content.blade.php
+++ b/resources/views/home/_submission_content.blade.php
@@ -104,7 +104,7 @@
                 Some characters have been deleted since this submission was created.
             </div>
         @endif
-        @foreach ($submission->characters()->whereRelation('character', 'deleted_at', null)->get() as $character)
+        @foreach ($submission->characters()->with('character', 'character.image')->whereRelation('character', 'deleted_at', null)->get() as $character)
             <div class="submission-character-row mb-2">
                 <div class="submission-character-thumbnail">
                     <a href="{{ $character->character->url }}"><img src="{{ $character->character->image->thumbnailUrl }}" class="img-thumbnail" alt="Thumbnail for {{ $character->character->fullName }}" /></a>


### PR DESCRIPTION
Just eager loads submission characters and their images in submission content... with rewards this could probably add up further, but this at least streamlines things a little for submissions with many characters associated.