### PR TITLE
fix(user profiles): Rank info help does not appear if description empty

### DIFF
--- a/resources/views/user/_profile_content.blade.php
+++ b/resources/views/user/_profile_content.blade.php
@@ -56,7 +56,7 @@
                 <div class="col-lg-3 col-md-3 col-4">
                     <h5>Rank</h5>
                 </div>
-                <div class="col-lg-9 col-md-9 col-8">{!! $user->rank->displayName !!} {!! !$user->rank->parsed_description ? '' : add_help($user->rank->parsed_description) !!}</div>
+                <div class="col-lg-9 col-md-9 col-8">{!! $user->rank->displayName !!} {!! $user->rank->parsed_description ? add_help($user->rank->parsed_description) : '' !!}</div>
             </div>
             @if ($user->birthdayDisplay && isset($user->birthday))
                 <div class="row no-gutters col-sm-7">

--- a/resources/views/user/_profile_content.blade.php
+++ b/resources/views/user/_profile_content.blade.php
@@ -56,7 +56,7 @@
                 <div class="col-lg-3 col-md-3 col-4">
                     <h5>Rank</h5>
                 </div>
-                <div class="col-lg-9 col-md-9 col-8">{!! $user->rank->displayName !!} {!! add_help($user->rank->parsed_description) !!}</div>
+                <div class="col-lg-9 col-md-9 col-8">{!! $user->rank->displayName !!} {!! $user->rank->parsed_description != '' ?? add_help($user->rank->parsed_description) !!}</div>
             </div>
             @if ($user->birthdayDisplay && isset($user->birthday))
                 <div class="row no-gutters col-sm-7">

--- a/resources/views/user/_profile_content.blade.php
+++ b/resources/views/user/_profile_content.blade.php
@@ -56,7 +56,7 @@
                 <div class="col-lg-3 col-md-3 col-4">
                     <h5>Rank</h5>
                 </div>
-                <div class="col-lg-9 col-md-9 col-8">{!! $user->rank->displayName !!} {!! $user->rank->parsed_description != '' ? add_help($user->rank->parsed_description) : '' !!}</div>
+                <div class="col-lg-9 col-md-9 col-8">{!! $user->rank->displayName !!} {!! !$user->rank->parsed_description ? '' : add_help($user->rank->parsed_description) !!}</div>
             </div>
             @if ($user->birthdayDisplay && isset($user->birthday))
                 <div class="row no-gutters col-sm-7">

--- a/resources/views/user/_profile_content.blade.php
+++ b/resources/views/user/_profile_content.blade.php
@@ -56,7 +56,7 @@
                 <div class="col-lg-3 col-md-3 col-4">
                     <h5>Rank</h5>
                 </div>
-                <div class="col-lg-9 col-md-9 col-8">{!! $user->rank->displayName !!} {!! $user->rank->parsed_description != '' ?? add_help($user->rank->parsed_description) !!}</div>
+                <div class="col-lg-9 col-md-9 col-8">{!! $user->rank->displayName !!} {!! $user->rank->parsed_description != '' ? add_help($user->rank->parsed_description) : '' !!}</div>
             </div>
             @if ($user->birthdayDisplay && isset($user->birthday))
                 <div class="row no-gutters col-sm-7">


### PR DESCRIPTION
Noticed the little ? just.. does nothing if there's no text. Might as well remove it so that it doesn't confuse users. :)