### PR TITLE
fix(ranks): Parsed_description would not get set to null if description left empty

### DIFF
--- a/app/Services/RankService.php
+++ b/app/Services/RankService.php
@@ -54,6 +54,8 @@ class RankService extends Service {
             $data['color'] = isset($data['color']) ? str_replace('#', '', $data['color']) : null;
             if (isset($data['description']) && $data['description']) {
                 $data['parsed_description'] = parse($data['description']);
+            } else {
+                $data['parsed_description'] = null;
             }
 
             $data['icon'] ??= 'fas fa-user';
@@ -106,6 +108,8 @@ class RankService extends Service {
             $data['color'] = isset($data['color']) ? str_replace('#', '', $data['color']) : null;
             if (isset($data['description']) && $data['description']) {
                 $data['parsed_description'] = parse($data['description']);
+            } else {
+                $data['parsed_description'] = null;
             }
 
             $data['icon'] ??= 'fas fa-user';


### PR DESCRIPTION
And now the fun part- realizing I couldn't empty a rank description. How did this bug get overlooked for SO LONG?