### PR TITLE
feat: clarify and make easier for users to understand the effects of …

### DIFF
--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -450,17 +450,6 @@ function prettyProfileName($url) {
 }
 
 /**
- * Returns the given objects limits, if any.
- *
- * @param mixed $object
- *
- * @return bool
- */
-function getLimits($object) {
-    return App\Models\Limit\Limit::where('object_model', get_class($object))->where('object_id', $object->id)->get();
-}
-
-/**
  * Checks the site setting and returns the appropriate FontAwesome version.
  *
  * @return string
@@ -482,4 +471,35 @@ function faVersion() {
     }
 
     return asset($directory.'/'.$version.'.min.css');
+}
+
+/**
+ * Returns the given objects limits, if any.
+ *
+ * @param mixed $object
+ *
+ * @return bool
+ */
+function getLimits($object) {
+    return App\Models\Limit\Limit::where('object_model', get_class($object))->where('object_id', $object->id)->get();
+}
+
+/**
+ * checks if a certain object has any limits.
+ *
+ * @param mixed $object
+ */
+function hasLimits($object) {
+    return App\Models\Limit\Limit::where('object_model', get_class($object))->where('object_id', $object->id)->exists();
+}
+
+/**
+ * Checks if a user has a limit unlocked.
+ *
+ * @param mixed $object
+ */
+function hasUnlockedLimits($object) {
+    $service = new App\Services\LimitManager;
+
+    return $service->checkLimits($object);
 }

--- a/resources/views/admin/prompts/create_edit_prompt.blade.php
+++ b/resources/views/admin/prompts/create_edit_prompt.blade.php
@@ -107,7 +107,10 @@
     @include('widgets._loot_select_row', ['showLootTables' => true, 'showRaffles' => true])
 
     @if ($prompt->id)
-        @include('widgets._add_limits', ['object' => $prompt])
+        @include('widgets._add_limits', [
+            'object' => $prompt,
+            'hideAutoUnlock' => true
+        ])
 
         <h3>Preview</h3>
         <div class="card mb-3">

--- a/resources/views/admin/prompts/create_edit_prompt.blade.php
+++ b/resources/views/admin/prompts/create_edit_prompt.blade.php
@@ -109,7 +109,7 @@
     @if ($prompt->id)
         @include('widgets._add_limits', [
             'object' => $prompt,
-            'hideAutoUnlock' => true
+            'hideAutoUnlock' => true,
         ])
 
         <h3>Preview</h3>

--- a/resources/views/admin/submissions/submission.blade.php
+++ b/resources/views/admin/submissions/submission.blade.php
@@ -254,7 +254,22 @@
                         <button type="button" class="close" data-dismiss="modal">&times;</button>
                     </div>
                     <div class="modal-body">
-                        <p>This will cancel the {{ $submission->prompt_id ? 'submission' : 'claim' }} and send it back to drafts. Make sure to include a staff comment if you do this!</p>
+                        <p>
+                            This will cancel the {{ $submission->prompt_id ? 'submission' : 'claim' }} and send it back to drafts.
+                            Make sure to include a staff comment if you do this!
+                        </p>
+                        @if ($submission->prompt_id && hasLimits($submission->prompt))
+                            <div class="alert alert-secondary">
+                                The user will not have to meet the prompt's requirements to submit again.
+                                <div class="text-center mb-0">
+                                    @include('widgets._limits', [
+                                        'object' => $submission->prompt,
+                                        'compact' => true,
+                                        'hideUnlock' => true,
+                                    ])
+                                </div>
+                            </div>
+                        @endif
                         <div class="text-right">
                             <a href="#" id="cancelSubmit" class="btn btn-secondary">Cancel</a>
                         </div>

--- a/resources/views/widgets/_add_limits.blade.php
+++ b/resources/views/widgets/_add_limits.blade.php
@@ -11,6 +11,17 @@
     $items = \App\Models\Item\Item::orderBy('name')->pluck('name', 'id')->toArray();
     $currencies = \App\Models\Currency\Currency::orderBy('name')->pluck('name', 'id')->toArray();
     $dynamics = \App\Models\Limit\DynamicLimit::orderBy('name')->pluck('name', 'id')->toArray();
+
+    // Hiding auto unlock options are good for cases where the user should not know the option exists for that object
+    // Prompts are a good example--users shouldn't know they can auto-unlock prompts, as that would be confusing, since
+    // the UI for the prompt interactions occurs on submission...
+    // ex the limits are checked as part of submitting a prompt,
+    // requiring the user to manually unlock the prompt prior, especially if the limits are needed for every prompt submission, would be problematic.
+    // also as currently implemented having manual unlocking required would effectively prevent users from submitting the prompt
+    // as a refinement, this could be changed to allow for manual unlocking under certain conditions
+    if (!isset($hideAutoUnlock)) {
+        $hideAutoUnlock = false;
+    }
 @endphp
 
 <div class="card p-4 mb-3 mt-3" id="limit-card">
@@ -37,23 +48,35 @@
                 <div class="col-md form-group">
                     {!! Form::label('is_unlocked', 'Is Unlocked?', ['class' => 'form-label font-weight-bold']) !!}
                     <p>
-                        If this is set to "No", the object will continue to be locked until all requirements are met, every time the user attempts to interact with it.
+                        If this is set to "No", the object will continue to be locked until all requirements are met, every time the user attempts to use or interact with it.
                         <br />
-                        If this is set to "Yes", the object will be unlocked for the user to interact with indefinitely after the requirements are met once. This option is good for one-time unlocks such as shops, locations, certain prompts, etc.
+                        If this is set to "Yes", the object will be unlocked for the user to interact with indefinitely after the requirements are met once.
+                        <br />
+                        The "Yes" option is good for one-time unlocks such as shops, locations, certain prompts, etc.
                     </p>
                     {!! Form::select('is_unlocked', ['yes' => 'Yes', 'no' => 'No'], $limits?->first()->is_unlocked ? 'yes' : 'no', ['class' => 'form-control']) !!}
                 </div>
-                <div class="col-md form-group border-left">
-                    {!! Form::label('is_auto_unlocked', 'Automatically Unlock?', ['class' => 'form-label font-weight-bold']) !!} {!! add_help("This only affects objects with 'Is Unlocked?' set to 'Yes'.") !!}
-                    <p>
-                        If this is set to "No", the user must manually unlock the object by interacting with it - ex. clicking on the "Unlock" button.
-                        <br />
-                        If this is set to "Yes", the object will be automatically unlocked when the user attempts to access them - ex. when a user enters a shop.
-                        <br />
-                        This setting is good for preventing users from being debited before being certain they want to interact with the object.
-                    </p>
-                    {!! Form::select('is_auto_unlocked', ['yes' => 'Yes', 'no' => 'No'], $limits?->first()->is_auto_unlocked ? 'yes' : 'no', ['class' => 'form-control']) !!}
-                </div>
+                @if (!$hideAutoUnlock)
+                    <div class="col-md form-group border-left">
+                        {!! Form::label('is_auto_unlocked', 'Automatically Unlock?', ['class' => 'form-label font-weight-bold']) !!} {!! add_help("This only affects objects with 'Is Unlocked?' set to 'Yes'.") !!}
+                        <p>
+                            If this is set to "No", the user must manually unlock the object by interacting with it - ex. clicking on the "Unlock" button. 
+                            <div class="text-warning">
+                                This will prevent the limits from being used as part of a series of actions, ex. prompt submissions.
+                            </div>
+                            <br />
+                            If this is set to "Yes", the object will be automatically unlocked when the user attempts to access them - ex. when a user enters a shop.
+                            <br />
+                            This setting is good for preventing users from being debited before being certain they want to interact with the object.
+                            <div class="text-danger">
+                                This option is not suitable for objects that should have limits as part of an action workflow, ex. prompt submissions.
+                            </div>
+                        </p>
+                        {!! Form::select('is_auto_unlocked', ['yes' => 'Yes', 'no' => 'No'], $limits?->first()->is_auto_unlocked ? 'yes' : 'no', ['class' => 'form-control']) !!}
+                    </div>
+                @else
+                    {!! Form::hidden('is_auto_unlocked', 'yes') !!}
+                @endif
             </div>
             @if ($limits)
                 @foreach ($limits as $limit)

--- a/resources/views/widgets/_add_limits.blade.php
+++ b/resources/views/widgets/_add_limits.blade.php
@@ -60,17 +60,17 @@
                     <div class="col-md form-group border-left">
                         {!! Form::label('is_auto_unlocked', 'Automatically Unlock?', ['class' => 'form-label font-weight-bold']) !!} {!! add_help("This only affects objects with 'Is Unlocked?' set to 'Yes'.") !!}
                         <p>
-                            If this is set to "No", the user must manually unlock the object by interacting with it - ex. clicking on the "Unlock" button. 
-                            <div class="text-warning">
-                                This will prevent the limits from being used as part of a series of actions, ex. prompt submissions.
-                            </div>
-                            <br />
-                            If this is set to "Yes", the object will be automatically unlocked when the user attempts to access them - ex. when a user enters a shop.
-                            <br />
-                            This setting is good for preventing users from being debited before being certain they want to interact with the object.
-                            <div class="text-danger">
-                                This option is not suitable for objects that should have limits as part of an action workflow, ex. prompt submissions.
-                            </div>
+                            If this is set to "No", the user must manually unlock the object by interacting with it - ex. clicking on the "Unlock" button.
+                        <div class="text-warning">
+                            This will prevent the limits from being used as part of a series of actions, ex. prompt submissions.
+                        </div>
+                        <br />
+                        If this is set to "Yes", the object will be automatically unlocked when the user attempts to access them - ex. when a user enters a shop.
+                        <br />
+                        This setting is good for preventing users from being debited before being certain they want to interact with the object.
+                        <div class="text-danger">
+                            This option is not suitable for objects that should have limits as part of an action workflow, ex. prompt submissions.
+                        </div>
                         </p>
                         {!! Form::select('is_auto_unlocked', ['yes' => 'Yes', 'no' => 'No'], $limits?->first()->is_auto_unlocked ? 'yes' : 'no', ['class' => 'form-control']) !!}
                     </div>

--- a/resources/views/widgets/_limits.blade.php
+++ b/resources/views/widgets/_limits.blade.php
@@ -14,10 +14,14 @@
 @if ($limits)
     @if (!isset($compact) || !$compact)
         <h4 class="my-3">{!! $object->displayName !!}'s Requirements</h4>
-
         <p>
             You must obtain or complete all of the following in order to access this {{ $object->assetType ? (substr($object->assetType, -1) === 's' ? substr($object->assetType, 0, -1) : $object->assetType) : '' }}.
         </p>
+        @if ($limits->first()->is_unlocked && $limits->first()->isUnlocked(Auth::user() ?? null))
+            <div class="alert alert-success">
+                You previously have met these requirements and have unlocked access to this {{ $object->assetType ? (substr($object->assetType, -1) === 's' ? substr($object->assetType, 0, -1) : $object->assetType) : '' }}.
+            </div>
+        @endif
         <div class="mb-2 logs-table">
             <div class="logs-table-header">
                 <div class="row no-gutters">
@@ -87,7 +91,7 @@
             @endif
         @endif
     @else
-        <div class="alert alert-{{ $limits->first()->isUnlocked(Auth::user() ?? null) ? 'info' : 'danger' }} p-0 mt-2">
+        <div class="alert alert-{{ ($limits->first()->is_unlocked && $limits->first()->isUnlocked(Auth::user() ?? null)) ? 'info' : 'danger' }} p-0 mt-2">
             <small>
                 (Requires {!! implode(
                     ', ',

--- a/resources/views/widgets/_limits.blade.php
+++ b/resources/views/widgets/_limits.blade.php
@@ -91,7 +91,7 @@
             @endif
         @endif
     @else
-        <div class="alert alert-{{ ($limits->first()->is_unlocked && $limits->first()->isUnlocked(Auth::user() ?? null)) ? 'info' : 'danger' }} p-0 mt-2">
+        <div class="alert alert-{{ $limits->first()->is_unlocked && $limits->first()->isUnlocked(Auth::user() ?? null) ? 'info' : 'danger' }} p-0 mt-2">
             <small>
                 (Requires {!! implode(
                     ', ',

--- a/resources/views/widgets/_limits.blade.php
+++ b/resources/views/widgets/_limits.blade.php
@@ -23,7 +23,7 @@
             </div>
         @else
             <div class="alert alert-warning">
-                You must meet the following requirements to access this {{ $object->assetType ? (substr($object->assetType, -1) === 's' ? substr($object->assetType, 0, -1) : $object->assetType) : '' }} 
+                You must meet the following requirements to access this {{ $object->assetType ? (substr($object->assetType, -1) === 's' ? substr($object->assetType, 0, -1) : $object->assetType) : '' }}
                 {{ $limits->first()->is_unlocked ? 'once.' : 'every time you interact with it.' }}
             </div>
         @endif

--- a/resources/views/widgets/_limits.blade.php
+++ b/resources/views/widgets/_limits.blade.php
@@ -21,6 +21,11 @@
             <div class="alert alert-success">
                 You previously have met these requirements and have unlocked access to this {{ $object->assetType ? (substr($object->assetType, -1) === 's' ? substr($object->assetType, 0, -1) : $object->assetType) : '' }}.
             </div>
+        @else
+            <div class="alert alert-warning">
+                You must meet the following requirements to access this {{ $object->assetType ? (substr($object->assetType, -1) === 's' ? substr($object->assetType, 0, -1) : $object->assetType) : '' }} 
+                {{ $limits->first()->is_unlocked ? 'once.' : 'every time you interact with it.' }}
+            </div>
         @endif
         <div class="mb-2 logs-table">
             <div class="logs-table-header">
@@ -79,13 +84,13 @@
         </div>
         @if (!$hideUnlock)
             @if (Auth::check() && !$limits->first()->isUnlocked(Auth::user() ?? null) && !$limits->first()->is_auto_unlocked)
-                <div class="alert alert-secondary p-0 mt-2 mb-0">
+                <div class="alert alert-secondary text-center px-0 py-1 mb-0">
                     {!! Form::open(['url' => 'limits/unlock/' . $limits->first()->id]) !!}
                     {!! Form::submit('Unlock', ['class' => 'btn btn-sm btn-secondary']) !!}
                     {!! Form::close() !!}
                 </div>
             @else
-                <div class="alert alert-secondary p-0 mt-2 mb-0">
+                <div class="alert alert-secondary text-center px-0 p-1 mb-0 font-weight-bold">
                     You must be logged in to unlock this limit.
                 </div>
             @endif
@@ -98,9 +103,10 @@
                     $limits->map(function ($limit) use ($limitTypes) {
                             return ($limit->quantity ? $limit->quantity . ' ' : '') . $limit->limit->displayName;
                         })->toArray(),
-                ) !!})
+                ) !!}
+                {{ $limits->first()->is_unlocked ? 'once' : 'every time you interact with it' }}.)
                 @if (!$hideUnlock && !$limits->first()->isUnlocked(Auth::user() ?? null) && !$limits->first()->is_auto_unlocked)
-                    <div class="alert alert-secondary p-0 mt-2 mb-0">
+                    <div class="alert alert-secondary text-center p-0 mb-0">
                         <small>
                             {!! Form::open(['url' => 'limits/unlock/' . $limits->first()->id]) !!}
                             {!! Form::submit('Unlock', ['class' => 'btn btn-sm btn-secondary']) !!}
@@ -112,8 +118,16 @@
         </div>
     @endif
 @elseif ($showNoLimits)
-    <h4 class="my-3">{!! $object->displayName !!}'s Requirements</h4>
-    <div class="alert alert-info">
-        No requirements to access this {{ $object->assetType ? (substr($object->assetType, -1) === 's' ? substr($object->assetType, 0, -1) : $object->assetType) : '' }}.
-    </div>
+    @if (!isset($compact) || !$compact)
+        <h4 class="my-3">{!! $object->displayName !!}'s Requirements</h4>
+        <div class="alert alert-info">
+            No requirements to access this {{ $object->assetType ? (substr($object->assetType, -1) === 's' ? substr($object->assetType, 0, -1) : $object->assetType) : '' }}.
+        </div>
+    @else
+        <div class="alert alert-info p-0 mb-0">
+            <small>
+                No requirements to access this {{ $object->assetType ? (substr($object->assetType, -1) === 's' ? substr($object->assetType, 0, -1) : str_replace('_', ' ', $object->assetType)) : '' }}.
+            </small>
+        </div>
+    @endif
 @endif


### PR DESCRIPTION
…manual unlocking and reducing user error in action workflows that expect certain unlock types

currently prompts expect `is_auto_unlocked` to be set to true so that the submission workflow can process correctly.
current workflow is:
user fills out submission -> acknowledges they cannot return to draft prior to staff cancelling -> limits are processed -> submitted

with `is_auto_unlocked` set to false, the limits could not be processed since the user has not "manually" unlocked. Manually unlocking is good for one time debits (ex unlocking a shop to enter it, so that a user accidentally clicking on it doesn't debit them) or debits that aren't implicitly part of a workflow

would love some comments on this in regards to making clear to users how these options interact or if it is already clear, what should default behaviours be, etc. considering it's part of dev now and should be documented according to the knowledge of the average user