### PR TITLE
fix(world): Item page mistakes

### DIFF
--- a/resources/views/world/_item_entry.blade.php
+++ b/resources/views/world/_item_entry.blade.php
@@ -1,6 +1,6 @@
 <div class="row world-entry">
     @if ($item->imageUrl)
-        <div class="col-md-3 world-entry-image"><a href="{{ $item->imageUrl }}" data-lightbox="entry" data-title="{{ $item->displayName }}"><img src="{{ $item->imageUrl }}" class="world-entry-image" alt="{{ $item->displayName }}" /></a></div>
+        <div class="col-md-3 world-entry-image"><a href="{{ $item->imageUrl }}" data-lightbox="entry" data-title="{{ $item->name }}"><img src="{{ $item->imageUrl }}" class="world-entry-image" alt="{{ $item->name }}" /></a></div>
     @endif
     <div class="{{ $item->imageUrl ? 'col-md-9' : 'col-12' }}">
         <x-admin-edit title="Item" :object="$item" />
@@ -10,7 +10,7 @@
                     <i class="fas fa-eye-slash mr-1"></i>
                 @endif
                 <a href="{{ $item->idUrl }}">
-                    {!! $item->displayName !!}
+                    {!! $item->name !!}
                 </a>
             </h1>
         @else
@@ -19,11 +19,9 @@
                     <i class="fas fa-eye-slash mr-1"></i>
                 @endif
                 {!! $item->displayName !!}
-                @if (isset($idUrl) && $idUrl)
-                    <a href="{{ $idUrl }}" class="world-entry-search text-muted">
-                        <i class="fas fa-search"></i>
-                    </a>
-                @endif
+                 <a href="{{ $item->idUrl }}" class="world-entry-search text-muted">
+                    <i class="fas fa-search"></i>
+                </a>
             </h3>
         @endif
         <div class="row">

--- a/resources/views/world/_item_entry.blade.php
+++ b/resources/views/world/_item_entry.blade.php
@@ -19,7 +19,7 @@
                     <i class="fas fa-eye-slash mr-1"></i>
                 @endif
                 {!! $item->displayName !!}
-                 <a href="{{ $item->idUrl }}" class="world-entry-search text-muted">
+                <a href="{{ $item->idUrl }}" class="world-entry-search text-muted">
                     <i class="fas fa-search"></i>
                 </a>
             </h3>

--- a/resources/views/world/item_page.blade.php
+++ b/resources/views/world/item_page.blade.php
@@ -24,8 +24,8 @@
                     @if (config('lorekeeper.extensions.unmerge_item_page_and_entry'))
                         <div class="row world-entry">
                             @if ($item->imageUrl)
-                                <div class="col-md-3 world-entry-image"><a href="{{ $item->imageUrl }}" data-lightbox="entry" data-title="{{ $item->displayName }}"><img src="{{ $item->imageUrl }}" class="world-entry-image"
-                                            alt="{{ $item->displayName }}" /></a></div>
+                                <div class="col-md-3 world-entry-image"><a href="{{ $item->imageUrl }}" data-lightbox="entry" data-title="{{ $item->name }}"><img src="{{ $item->imageUrl }}" class="world-entry-image"
+                                            alt="{{ $item->name }}" /></a></div>
                             @endif
                             <div class="{{ $item->imageUrl ? 'col-md-9' : 'col-12' }}">
                                 <x-admin-edit title="Item" :object="$item" />
@@ -34,7 +34,7 @@
                                         <i class="fas fa-eye-slash mr-1"></i>
                                     @endif
                                     <a href="{{ $item->idUrl }}">
-                                        {!! $item->displayName !!}
+                                        {!! $item->name !!}
                                     </a>
                                 </h1>
                                 <div class="row">

--- a/resources/views/world/item_page.blade.php
+++ b/resources/views/world/item_page.blade.php
@@ -24,8 +24,7 @@
                     @if (config('lorekeeper.extensions.unmerge_item_page_and_entry'))
                         <div class="row world-entry">
                             @if ($item->imageUrl)
-                                <div class="col-md-3 world-entry-image"><a href="{{ $item->imageUrl }}" data-lightbox="entry" data-title="{{ $item->name }}"><img src="{{ $item->imageUrl }}" class="world-entry-image"
-                                            alt="{{ $item->name }}" /></a></div>
+                                <div class="col-md-3 world-entry-image"><a href="{{ $item->imageUrl }}" data-lightbox="entry" data-title="{{ $item->name }}"><img src="{{ $item->imageUrl }}" class="world-entry-image" alt="{{ $item->name }}" /></a></div>
                             @endif
                             <div class="{{ $item->imageUrl ? 'col-md-9' : 'col-12' }}">
                                 <x-admin-edit title="Item" :object="$item" />


### PR DESCRIPTION
This is a few fixes in one go:
1. Removed redundant idUrl check- it's always there on items.
2. _Fixed_ usage of idUrl in that instance, supposed to be `$item->idUrl` not just `$idUrl`.
3. Discovered the lightbox and image using `displayName` (meaning an entire html a href string was in there for no reason) - swapped to `name` instead.
4. While at it, also fixed `displayName` instance in `<a href="` sections for same reason- the model has `displayName` with the entire a href string, completely redundant, basically wrapping an entire <a> section in another.

Basically: It's a bunch of tiny quick fixes, with one problem fixed which admittedly I may have mistakenly caused myself in the previous PR. Whoops.