### PR TITLE
fix(shops): Inactive shop refreshes as Active

### DIFF
--- a/app/Console/Commands/UpdateTimedStock.php
+++ b/app/Console/Commands/UpdateTimedStock.php
@@ -54,10 +54,10 @@ class UpdateTimedStock extends Command {
 
         // also activate or deactivate the shops
         $hideshop = Shop::where('is_timed_shop', 1)->where('is_active', 1)->get()->filter(function ($shop) {
-            return !$shop->isActive;
+            return !$shop->isActiveCheck;
         });
         $showshop = Shop::where('is_timed_shop', 1)->where('is_active', 0)->get()->filter(function ($shop) {
-            return $shop->isActive;
+            return $shop->isActiveCheck;
         });
 
         // set shop that should be active to active

--- a/app/Models/Shop/Shop.php
+++ b/app/Models/Shop/Shop.php
@@ -111,7 +111,7 @@ class Shop extends Model {
      * @return string
      */
     public function getDisplayNameAttribute() {
-        return '<a href="'.$this->url.'" class="display-shop">'.(!$this->isActive ? '<i class="fas fa-eye-slash"></i> ' : '').$this->name.'</a>';
+        return '<a href="'.$this->url.'" class="display-shop">'.(!$this->isActiveCheck ? '<i class="fas fa-eye-slash"></i> ' : '').$this->name.'</a>';
     }
 
     /**
@@ -199,7 +199,7 @@ class Shop extends Model {
      * Returns if this shop should be active or not.
      * We dont account for is_visible here, as this is used for checking both visible and invisible shop.
      */
-    public function getIsActiveAttribute() {
+    public function getIsActiveCheckAttribute() {
         if ($this->start_at && $this->start_at > Carbon::now()) {
             return false;
         }
@@ -213,6 +213,10 @@ class Shop extends Model {
         }
 
         if ($this->months && !in_array(Carbon::now()->format('F'), $this->months)) {
+            return false;
+        }
+
+        if (!$this->is_timed_shop && !$this->is_active) {
             return false;
         }
 

--- a/resources/views/admin/shops/create_edit_shop.blade.php
+++ b/resources/views/admin/shops/create_edit_shop.blade.php
@@ -46,7 +46,7 @@
     <div class="row">
         <div class="col-md form-group">
             {!! Form::checkbox('is_active', 1, $shop->id ? $shop->is_active : 1, ['class' => 'form-check-input', 'data-toggle' => 'toggle']) !!}
-            {!! Form::label('is_active', 'Set Active', ['class' => 'form-check-label ml-3']) !!} {!! add_help('If turned off, the shop will not be accessible to anyone.') !!}
+            {!! Form::label('is_active', 'Set Active', ['class' => 'form-check-label ml-3']) !!} {!! add_help('If turned off, the shop will not be accessible to anyone. Please note that this option is overridden if this is set as a Timed Shop.') !!}
         </div>
         <div class="col-md form-group">
             {!! Form::checkbox('is_hidden', 0, $shop->id ? $shop->is_hidden : 1, ['class' => 'form-check-input', 'data-toggle' => 'toggle']) !!}


### PR DESCRIPTION
When editing a shop that was previously set as Inactive, the shop would mysteriously be toggled to Active (even if still Inactive). This causes admins undue stress from having to recheck every single time they edit an inactive shop.

Turns out the `isActive` check bounces against `is_active`. So to fix this, all references to `isActive` have been renamed to `isActiveCheck` for shops, and an additional line was added for actual inactive shops to also show as inactive.

Additionally, a minor text change was added as Timed Shop settings override the is_active option.