### PR TITLE
feat(comments): add class definition in css for 'btn-faded' 

### DIFF
--- a/public/css/lorekeeper.css
+++ b/public/css/lorekeeper.css
@@ -1,3 +1,7 @@
+:root {
+    --btn-faded : transparent;
+}
+
 /**************************************************************************************************
 
     Font definitions
@@ -376,6 +380,35 @@ main > .row {
 .btn.disabled {
     opacity: 0.5;
     cursor: not-allowed;
+}
+
+.btn-faded,
+.btn-faded.disabled,
+.btn-faded:disabled {
+    color: inherit;
+	background-color: var(--btn-faded);
+	border-color: color-mix(in srgb,var(--btn-faded),#000 15%);
+}
+
+.btn-faded:hover,
+.btn-faded:not(:disabled):not(.disabled):active,
+.btn-faded:not(:disabled):not(.disabled).active,
+.show>.btn-faded.dropdown-toggle  {
+	background-color: color-mix(in srgb,var(--btn-faded),#000 10%);
+	border-color: color-mix(in srgb,var(--btn-faded),#000 10%);
+}
+
+.btn-faded:focus,
+.btn-faded.focus {
+	border-color: color-mix(in srgb,var(--btn-faded),#000 20%);
+}
+
+.btn-faded:not(:disabled):not(.disabled):active:focus,
+.btn-faded:not(:disabled):not(.disabled).active:focus,
+.show>.btn-faded.dropdown-toggle:focus,
+.btn-faded:focus,
+.btn-faded.focus  {
+	box-shadow: 0 0 0 0.2rem color-mix(in srgb,var(--btn-faded),#000 10%);
 }
 
 .pagination {

--- a/resources/views/comments/_actions.blade.php
+++ b/resources/views/comments/_actions.blade.php
@@ -3,16 +3,16 @@
     <div class="my-1 row justify-content-between no-gutters">
         <div class="col-auto">
             @can('reply-to-comment', $comment)
-                <button data-toggle="modal" data-target="#reply-modal-{{ $comment->getKey() }}" class="btn btn-sm px-3 py-2 px-sm-2 py-sm-1 btn-faded text-uppercase"><i class="fas fa-comment"></i><span
-                        class="ml-2 d-none d-sm-inline-block">Reply</span></button>
+                <a data-toggle="modal" href="#reply-modal-{{ $comment->getKey() }}" class=" text-secondary px-3 py-2 px-sm-2 py-sm-1 text-uppercase"><i class="fas fa-comment"></i><span
+                        class="ml-2 d-none d-sm-inline-block">Reply</span></a>
             @endcan
             @can('edit-comment', $comment)
-                <button data-toggle="modal" data-target="#comment-modal-{{ $comment->getKey() }}" class="btn btn-sm px-3 py-2 px-sm-2 py-sm-1 btn-faded text-uppercase"><i class="fas fa-edit"></i><span
-                        class="ml-2 d-none d-sm-inline-block">Edit</span></button>
+                <a data-toggle="modal" href="#comment-modal-{{ $comment->getKey() }}" class="text-secondary px-3 py-2 px-sm-2 py-sm-1 text-uppercase"><i class="fas fa-edit"></i><span
+                        class="ml-2 d-none d-sm-inline-block">Edit</span></a>
             @endcan
             @if (((Auth::user()->id == $comment->commentable_id && $comment->commentable_type == 'App\Models\User\UserProfile') || Auth::user()->isStaff) && (isset($compact) && !$compact))
-                <button data-toggle="modal" data-target="#feature-modal-{{ $comment->getKey() }}" class="btn btn-sm px-3 py-2 px-sm-2 py-sm-1 btn-faded text-success text-uppercase"><i class="fas fa-star"></i><span
-                        class="ml-2 d-none d-sm-inline-block">{{ $comment->is_featured ? 'Unf' : 'F' }}eature Comment</span></button>
+                <a data-toggle="modal" href="#feature-modal-{{ $comment->getKey() }}" class="text-success px-3 py-2 px-sm-2 py-sm-1 text-uppercase"><i class="fas fa-star"></i><span
+                        class="ml-2 d-none d-sm-inline-block">{{ $comment->is_featured ? 'Unf' : 'F' }}eature Comment</span></a>
             @endif
             @can('delete-comment', $comment)
                 <button data-toggle="modal" data-target="#delete-modal-{{ $comment->getKey() }}" class="btn btn-sm px-3 py-2 px-sm-2 py-sm-1 btn-outline-danger text-uppercase"><i class="fas fa-minus-circle"></i><span
@@ -22,10 +22,10 @@
         <div class="col-auto text-right">
             {{-- Likes Section --}}
             <a href="#" data-toggle="modal" data-target="#show-likes-{{ $comment->id }}">
-                <button href="#" data-toggle="tooltip" title="Click to View" class="btn btn-sm px-3 py-2 px-sm-2 py-sm-1 btn-faded">
+                <a href="#" data-toggle="tooltip" title="Click to View" class="px-3 py-2 px-sm-2 py-sm-1">
                     {{ $comment->likes()->where('is_like', 1)->count() -$comment->likes()->where('is_like', 0)->count() }}
                     {{ $comment->likes()->where('is_like', 1)->count() -$comment->likes()->where('is_like', 0)->count() !=1? 'Likes': 'Like' }}
-                </button>
+                </a>
             </a>
             {!! Form::open(['url' => 'comments/' . $comment->id . '/like/1', 'class' => 'd-inline-block']) !!}
             {!! Form::button('<i class="fas fa-thumbs-up"></i>', [


### PR DESCRIPTION
This is a proposition to remove an unused class (`btn-faded`) in a blade file pertaining to comments - I am unsure as to why or how that class wriggled its way in, but it's not used elsewhere nor referenced in the css files. (Best guess being ToyHouse code being referenced and forgotten at some point)

Given it's not an "official" bootstrap color either, I replaced it by the secondary color and added back the outline to all buttons (reply, edit & feature). If it feels too crowded we could just make them links instead of buttons and tie text colors to them. Either way just a small fix from me yelling at clouds again.