### PR TITLE
fix(shops): fix error for 100% off coupons

### DIFF
--- a/app/Services/ShopManager.php
+++ b/app/Services/ShopManager.php
@@ -217,9 +217,9 @@ class ShopManager extends Service {
                 addAsset($baseStockCost, $cost->item, $cost->quantity);
             }
 
-            if(countAssets($userCostAssets) == 0) {
-                //the coupon made it free
-                //we will manually make the array empty to prevent trying to credit 0 currency
+            if (countAssets($userCostAssets) == 0) {
+                // the coupon made it free
+                // we will manually make the array empty to prevent trying to credit 0 currency
                 $userCostAssets = createAssetsArray();
             }
 

--- a/app/Services/ShopManager.php
+++ b/app/Services/ShopManager.php
@@ -217,6 +217,12 @@ class ShopManager extends Service {
                 addAsset($baseStockCost, $cost->item, $cost->quantity);
             }
 
+            if(countAssets($userCostAssets) == 0) {
+                //the coupon made it free
+                //we will manually make the array empty to prevent trying to credit 0 currency
+                $userCostAssets = createAssetsArray();
+            }
+
             if ($character) {
                 if (!fillCharacterAssets($characterCostAssets, $character, null, 'Shop Purchase', [
                     'data' => 'Purchased '.$shopStock->item->name.' x'.$quantity.' from '.$shop->name.


### PR DESCRIPTION
Real simple virtually one-liner that resolves an issue where, if a coupon was 100% off, it would try to credit a quantity of 0 towards null and henceforth explode.

I settled on this solution because coupons reduce _all_ costs, so if a coupon was 100% off, then the item should just be straight up free. Utilizing countAssets() and setting the $userCostAssets to an empty asset array (that will then subtract nothing) seemed like the least intrusive solution.