### PR TITLE
fix: dynamic rewards rewardable_id and item_id error

### DIFF
--- a/app/Models/Reward/Reward.php
+++ b/app/Models/Reward/Reward.php
@@ -30,6 +30,36 @@ class Reward extends Model {
         'data' => 'array',
     ];
 
+    /**
+     * Validation rules for reward creation.
+     *
+     * @var array
+     */
+    public static $createRules = [
+        'object_id'            => 'required',
+        'object_model'         => 'required',
+        'rewardable_recipient' => 'required',
+        'rewardable_id'        => 'nullable',
+        'rewardable_type'      => 'required',
+        'quantity'             => 'required',
+        'data'                 => 'nullable',
+    ];
+
+    /**
+     * Validation rules for reward updating.
+     *
+     * @var array
+     */
+    public static $updateRules = [
+        'object_id'            => 'required',
+        'object_model'         => 'required',
+        'rewardable_recipient' => 'required',
+        'rewardable_id'        => 'nullable',
+        'rewardable_type'      => 'required',
+        'quantity'             => 'required',
+        'data'                 => 'nullable',
+    ];
+
     /**********************************************************************************************
 
         RELATIONS

--- a/app/Models/Reward/Reward.php
+++ b/app/Models/Reward/Reward.php
@@ -51,7 +51,7 @@ class Reward extends Model {
 
         if (!class_exists($model)) {
             // Laravel requires a relationship instance to be returned (cannot return null), so returning one that doesn't exist here.
-            return $this->belongsTo(self::class, 'id', 'item_id')->whereNull('item_id');
+            return $this->belongsTo(self::class, 'id', 'object_id')->whereNull('object_id');
         }
 
         return $this->belongsTo($model, 'rewardable_id');

--- a/app/Services/PromptService.php
+++ b/app/Services/PromptService.php
@@ -207,12 +207,18 @@ class PromptService extends Service {
                 $this->handleImage($image, $prompt->imagePath, $prompt->imageFileName);
             }
 
-            (new RewardService)->populateRewards(
+            $rewardService = new RewardService;
+            if (!$rewardService->populateRewards(
                 get_class($prompt),
                 $prompt->id,
                 Arr::only($data, ['rewardable_type', 'rewardable_id', 'quantity', 'rewardable_recipient']),
                 false
-            );
+            )) {
+                foreach ($rewardService->errors()->getMessages()['error'] as $error) {
+                    flash($error)->error();
+                }
+                throw new \Exception('Failed to create rewards.');
+            }
 
             return $this->commitReturn($prompt);
         } catch (\Exception $e) {
@@ -270,12 +276,18 @@ class PromptService extends Service {
                 $this->handleImage($image, $prompt->imagePath, $prompt->imageFileName);
             }
 
-            (new RewardService)->populateRewards(
+            $rewardService = new RewardService;
+            if (!$rewardService->populateRewards(
                 get_class($prompt),
                 $prompt->id,
                 Arr::only($data, ['rewardable_type', 'rewardable_id', 'quantity', 'rewardable_recipient']),
                 false
-            );
+            )) {
+                foreach ($rewardService->errors()->getMessages()['error'] as $error) {
+                    flash($error)->error();
+                }
+                throw new \Exception('Failed to create rewards.');
+            }
 
             return $this->commitReturn($prompt);
         } catch (\Exception $e) {

--- a/app/Services/RewardService.php
+++ b/app/Services/RewardService.php
@@ -5,6 +5,8 @@ namespace App\Services;
 use App\Models\Reward\Reward;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Session;
+use Illuminate\Support\Facades\Validator;
 
 class RewardService extends Service {
     /*
@@ -64,7 +66,7 @@ class RewardService extends Service {
 
             if (isset($data['rewardable_type'])) {
                 foreach ($data['rewardable_type'] as $key => $type) {
-                    $reward = new Reward([
+                    $rewardData = [
                         'object_model'         => $object_model,
                         'object_id'            => $object_id,
                         'rewardable_recipient' => $data['rewardable_recipient'][$key] ?? 'User',
@@ -72,7 +74,19 @@ class RewardService extends Service {
                         'rewardable_id'        => $data['rewardable_id'][$key],
                         'quantity'             => $data['quantity'][$key],
                         'data'                 => $rewardableData[$key] ?? (count($rewardableData) > 0 ? $rewardableData : null),
-                    ]);
+                    ];
+
+                    $validator = Validator::make($rewardData, Reward::$createRules);
+
+                    if ($validator->fails()) {
+                        // Unfortunately $validator->errors() gets eaten here if we try to save it to the session/flash them
+                        // so we just have to return a generic error message
+                        // However, uncommenting the below will send the validator errors to the logs
+                        // \Log::debug($validator->errors());
+                        throw new \Exception ('Reward data validation failed.');
+                    }
+
+                    $reward = Reward::create($rewardData);
 
                     if (!$reward->save()) {
                         throw new \Exception('Failed to save reward.');

--- a/app/Services/RewardService.php
+++ b/app/Services/RewardService.php
@@ -83,7 +83,7 @@ class RewardService extends Service {
                         // so we just have to return a generic error message
                         // However, uncommenting the below will send the validator errors to the logs
                         // \Log::debug($validator->errors());
-                        throw new \Exception ('Reward data validation failed.');
+                        throw new \Exception('Reward data validation failed.');
                     }
 
                     $reward = Reward::create($rewardData);

--- a/database/migrations/2025_11_29_120810_allow_null_id_for_dynamic_rewards.php
+++ b/database/migrations/2025_11_29_120810_allow_null_id_for_dynamic_rewards.php
@@ -4,13 +4,11 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     /**
      * Run the migrations.
      */
-    public function up(): void
-    {
+    public function up(): void {
         Schema::table('rewards', function (Blueprint $table) {
             $table->integer('rewardable_id')->nullable(true)->change();
         });
@@ -19,9 +17,8 @@ return new class extends Migration
     /**
      * Reverse the migrations.
      */
-    public function down(): void
-    {
-        //i don't recommend you reverse this, but...
+    public function down(): void {
+        // i don't recommend you reverse this, but...
         Schema::table('rewards', function (Blueprint $table) {
             $table->integer('rewardable_id')->nullable(false)->change();
         });

--- a/database/migrations/2025_11_29_120810_allow_null_id_for_dynamic_rewards.php
+++ b/database/migrations/2025_11_29_120810_allow_null_id_for_dynamic_rewards.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('rewards', function (Blueprint $table) {
+            $table->integer('rewardable_id')->nullable(true)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //i don't recommend you reverse this, but...
+        Schema::table('rewards', function (Blueprint $table) {
+            $table->integer('rewardable_id')->nullable(false)->change();
+        });
+    }
+};


### PR DESCRIPTION
- Certain very popular extensions and other custom coded features have asset types that do not actually exist as a model (things such as EXP or points), and therefore do not have a rewardable_id. This migration changes the rewardable_id column to be nullable. Otherwise, it will cause the rewards to silently fail to save, because it can't create a null value in that column. I figured it was better to handle this in core than rely on various slightly different extensions or custom code solutions.
- The item_id column does not exist and throws a SQL error if you tried to refer to it, so I changed it to object_id instead (this should serve the same purpose of creating a "null" relationship).

Edit:
- Also now actually shows errors from RewardService, instead of just silently eating them.