### PR TITLE
fix(shops): fix shop stock costs not being deleted alongside stock

### DIFF
--- a/app/Console/Commands/FixDeletedShopCosts.php
+++ b/app/Console/Commands/FixDeletedShopCosts.php
@@ -3,7 +3,6 @@
 namespace App\Console\Commands;
 
 use App\Models\Shop\ShopStockCost;
-use App\Models\User\User;
 use Illuminate\Console\Command;
 
 class FixDeletedShopCosts extends Command {
@@ -34,13 +33,12 @@ class FixDeletedShopCosts extends Command {
      * @return mixed
      */
     public function handle() {
-
         $costs = ShopStockCost::doesntHave('stock');
 
-        $this->info("Deleting " . $costs->count() . " orphaned shop costs...");
+        $this->info('Deleting '.$costs->count().' orphaned shop costs...');
 
         $costs->delete();
 
-        $this->info("Success!");
+        $this->info('Success!');
     }
 }

--- a/app/Console/Commands/FixDeletedShopCosts.php
+++ b/app/Console/Commands/FixDeletedShopCosts.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Shop\ShopStockCost;
+use App\Models\User\User;
+use Illuminate\Console\Command;
+
+class FixDeletedShopCosts extends Command {
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'fix-deleted-shop-costs';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Fixes shop costs in the database orphaned by deleted stock.';
+
+    /**
+     * Create a new command instance.
+     */
+    public function __construct() {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle() {
+
+        $costs = ShopStockCost::doesntHave('stock');
+
+        $this->info("Deleting " . $costs->count() . " orphaned shop costs...");
+
+        $costs->delete();
+
+        $this->info("Success!");
+    }
+}

--- a/app/Services/ShopService.php
+++ b/app/Services/ShopService.php
@@ -325,6 +325,7 @@ class ShopService extends Service {
         DB::beginTransaction();
 
         try {
+            $stock->costs()->delete();
             $stock->delete();
 
             return $this->commitReturn(true);


### PR DESCRIPTION
This bug is a bit gnarly. Shop stock costs do not get deleted alongside their stock, leaving them orphaned in the DB. I discovered it when I went to delete an old currency and it told me a stock cost was still using it.

Alongside the fix, I also included a console command (`fix-deleted-shop-costs`) that will also clean up the orphaned shop rows, so that we aren't just leaving them in the DB forever.