### PR TITLE
fix: change "prompt rewards" to "rewards" in check when attempting to delete item or currency

### DIFF
--- a/app/Services/CurrencyService.php
+++ b/app/Services/CurrencyService.php
@@ -320,8 +320,8 @@ class CurrencyService extends Service {
             if (DB::table('loots')->where('rewardable_type', 'Currency')->where('rewardable_id', $currency->id)->exists()) {
                 throw new \Exception('A loot table currently distributes this currency as a potential reward. Please remove the currency before deleting it.');
             }
-            if (DB::table('prompt_rewards')->where('rewardable_type', 'Currency')->where('rewardable_id', $currency->id)->exists()) {
-                throw new \Exception('A prompt currently distributes this currency as a reward. Please remove the currency before deleting it.');
+            if (DB::table('rewards')->where('rewardable_type', 'Currency')->where('rewardable_id', $currency->id)->exists()) {
+                throw new \Exception('An object currently distributes this currency as a reward. Please remove the currency before deleting it.');
             }
             if (DB::table('shop_stock_costs')->where('cost_type', 'Currency')->where('cost_id', $currency->id)->exists()) {
                 throw new \Exception('A shop currently requires this currency to purchase an currency. Please change the currency before deleting it.');

--- a/app/Services/ItemService.php
+++ b/app/Services/ItemService.php
@@ -321,8 +321,8 @@ class ItemService extends Service {
             if (DB::table('loots')->where('rewardable_type', 'Item')->where('rewardable_id', $item->id)->exists()) {
                 throw new \Exception('A loot table currently distributes this item as a potential reward. Please remove the item before deleting it.');
             }
-            if (DB::table('prompt_rewards')->where('rewardable_type', 'Item')->where('rewardable_id', $item->id)->exists()) {
-                throw new \Exception('A prompt currently distributes this item as a reward. Please remove the item before deleting it.');
+            if (DB::table('rewards')->where('rewardable_type', 'Item')->where('rewardable_id', $item->id)->exists()) {
+                throw new \Exception('An object currently distributes this item as a reward. Please remove the item before deleting it.');
             }
             if (DB::table('shop_stock')->where('item_id', $item->id)->exists()) {
                 throw new \Exception('A shop currently stocks this item. Please remove the item before deleting it.');


### PR DESCRIPTION
Fixes remnants left from prior to prompt_rewards deletion. Otherwise, it'll cause a SQL error where it can't find the prompt_rewards table.