### PR TITLE
fix(assethelpers): Makes Raffle Tickets and Loot Tables show up properly again

### DIFF
--- a/app/Helpers/AssetHelpers.php
+++ b/app/Helpers/AssetHelpers.php
@@ -105,7 +105,7 @@ function getAssetModelString($type, $namespaced = true) {
             }
             break;
 
-        case 'raffle_tickets':
+        case 'raffle_tickets': case 'raffle':
             if ($namespaced) {
                 return '\App\Models\Raffle\Raffle';
             } else {
@@ -113,7 +113,7 @@ function getAssetModelString($type, $namespaced = true) {
             }
             break;
 
-        case 'loot_tables':
+        case 'loot_tables': case 'loottable':
             if ($namespaced) {
                 return '\App\Models\Loot\LootTable';
             } else {


### PR DESCRIPTION
..on that note, do we still need the distinction between user_items and character_items? It seems like the naming is picked up by general items now..

I honestly don't know where all this is being used, only saw it in prompt and submission rewards.. 😅 