### PR TITLE
fix(trait-indexes): 500 error due to 'subtype' missing

### DIFF
--- a/app/Http/Controllers/WorldController.php
+++ b/app/Http/Controllers/WorldController.php
@@ -477,7 +477,7 @@ class WorldController extends Controller {
      * @return \Illuminate\Contracts\Support\Renderable
      */
     public function getFeatureDetail($id) {
-        $feature = Feature::visible(Auth::user() ?? null)->where('id', $id)->with('species', 'subtype', 'rarity')->first();
+        $feature = Feature::visible(Auth::user() ?? null)->where('id', $id)->first();
 
         if (!$feature) {
             abort(404);

--- a/app/Http/Controllers/WorldController.php
+++ b/app/Http/Controllers/WorldController.php
@@ -477,7 +477,7 @@ class WorldController extends Controller {
      * @return \Illuminate\Contracts\Support\Renderable
      */
     public function getFeatureDetail($id) {
-        $feature = Feature::visible(Auth::user() ?? null)->where('id', $id)->first();
+        $feature = Feature::visible(Auth::user() ?? null)->where('id', $id)->with('species', 'subtypes', 'rarity')->first();
 
         if (!$feature) {
             abort(404);


### PR DESCRIPTION
Fixes a 500 error on opening modals from any of the trait indexes.

I'm not entirely sure why eager loading is required here when all it does is indirectly load a trait page? Maybe I'm missing something. Would love an explanation and would not mind fixing if required.