### PR TITLE
fix(loot): use default $recipient value when $loot->rewardable_recipient is nonexistent

### DIFF
--- a/resources/views/widgets/_loot_select.blade.php
+++ b/resources/views/widgets/_loot_select.blade.php
@@ -77,7 +77,7 @@
                 <tr class="loot-row">
                     @if ($showRecipient)
                         <td>
-                            {!! Form::select($prefix . 'rewardable_recipient[]', $rewardableRecipients, $loot->rewardable_recipient, [
+                            {!! Form::select($prefix . 'rewardable_recipient[]', $rewardableRecipients, $loot->rewardable_recipient ?? $recipient, [
                                 'class' => 'form-control recipient-type',
                                 'placeholder' => 'Select Recipient Type',
                             ]) !!}
@@ -86,14 +86,14 @@
 
                     <td class="{{ $prefix }}loot-row-type">
                         {{-- The long array of key value pairs is now defined in getRewardTypes and data should be moved there --}}
-                        {!! Form::select($prefix . 'rewardable_type[]', getRewardTypes($showData, $loot->rewardable_recipient), $loot->rewardable_type, [
+                        {!! Form::select($prefix . 'rewardable_type[]', getRewardTypes($showData, $loot->rewardable_recipient ?? $recipient), $loot->rewardable_type, [
                             'class' => 'form-control reward-type',
                             'placeholder' => 'Select ' . $type . ' Type',
                         ]) !!}
                     </td>
                     <td class="{{ $prefix }}loot-row-select">
                         {{-- If statements here can be removed and replaced with the below code. They are now defined programmatically --}}
-                        {!! Form::select($prefix . 'rewardable_id[]', $showRecipient ? $rewardLootData[$loot->rewardable_recipient][$loot->rewardable_type] : $rewardLootData[$loot->rewardable_type], $loot->rewardable_id, [
+                        {!! Form::select($prefix . 'rewardable_id[]', $showRecipient ? $rewardLootData[$loot->rewardable_recipient ?? $recipient][$loot->rewardable_type] : $rewardLootData[$loot->rewardable_type], $loot->rewardable_id, [
                             'class' => 'form-control ' . strtolower($loot->rewardable_type) . '-select',
                             'placeholder' => 'Select ' . $rewardTypes[$loot->rewardable_type],
                         ]) !!}


### PR DESCRIPTION
A more permanent fix than what was done [here](https://github.com/lk-arpg/lorekeeper/pull/1388), since this fix will also apply to extensions like Choice Box and other extensions that are experiencing a similar error.

If $loot->rewardable_recipient is null, it just defaults to referencing $recipient (which will never be null and defaults to 'User').