### PR TITLE
fix(traits): Typo and missing folders

### DIFF
--- a/app/Models/Feature/Feature.php
+++ b/app/Models/Feature/Feature.php
@@ -327,7 +327,7 @@ class Feature extends Model {
         if (config('lorekeeper.extensions.organised_traits_dropdown.enable')) {
             $sorted_feature_categories = collect(FeatureCategory::all()->where('is_visible', '>=', $visibleOnly)->sortBy('sort')->pluck('name')->toArray());
 
-            if (config('show_exlusively_species_traits_in_dropdown') && $withSpecies) {
+            if (config('lorekeeper.extensions.show_exclusively_species_traits_in_dropdown') && $withSpecies) {
                 $grouped = self::where('is_visible', '>=', $visibleOnly)
                     ->when($withSpecies, function (Builder $query, int $withSpecies) {
                         $query->where('species_id', '=', $withSpecies)
@@ -401,7 +401,7 @@ class Feature extends Model {
 
             return $features_by_category;
         } else {
-            if (config('show_exlusively_species_traits_in_dropdown') && $withSpecies) {
+            if (config('lorekeeper.extensions.show_exclusively_species_traits_in_dropdown') && $withSpecies) {
                 return self::where('is_visible', '>=', $visibleOnly)
                     ->when($withSpecies, function (Builder $query, int $withSpecies) {
                         $query->where('species_id', '=', $withSpecies)

--- a/config/lorekeeper/extensions.php
+++ b/config/lorekeeper/extensions.php
@@ -142,5 +142,5 @@ return [
     'unmerge_item_page_and_entry' => 0, // If enabled, uses the html on world/item_page.blade.php instead of the include that links to world/_item_entry.blade.php
 
     // Show Species-only traits in dropdown - Speedy
-    'show_exlusively_species_traits_in_dropdown' => 0, // If enabled, will only show traits from the associated species as well as traits that aren't species-limited in the dropdown menus.
+    'show_exclusively_species_traits_in_dropdown' => 0, // If enabled, will only show traits from the associated species as well as traits that aren't species-limited in the dropdown menus.
 ];


### PR DESCRIPTION
Noticed I typo'd 'exclusively' as 'exlusively'...

Oh, and more importantly, forgot the `lorekeeper.extensions` folder line. Oops.