### PR TITLE
fix(character): Minor button renaming

### DIFF
--- a/resources/views/character/_image_info.blade.php
+++ b/resources/views/character/_image_info.blade.php
@@ -120,7 +120,7 @@
 
                 @if (Auth::check() && Auth::user()->hasPower('manage_characters'))
                     <div class="mt-3">
-                        <a href="#" class="btn btn-outline-info btn-sm edit-features" data-id="{{ $image->id }}"><i class="fas fa-cog"></i> Edit Features</a>
+                        <a href="#" class="btn btn-outline-info btn-sm edit-features" data-id="{{ $image->id }}"><i class="fas fa-cog"></i> Edit Traits</a>
                     </div>
                 @endif
             </div>

--- a/resources/views/character/_image_info.blade.php
+++ b/resources/views/character/_image_info.blade.php
@@ -120,7 +120,7 @@
 
                 @if (Auth::check() && Auth::user()->hasPower('manage_characters'))
                     <div class="mt-3">
-                        <a href="#" class="btn btn-outline-info btn-sm edit-features" data-id="{{ $image->id }}"><i class="fas fa-cog"></i> Edit</a>
+                        <a href="#" class="btn btn-outline-info btn-sm edit-features" data-id="{{ $image->id }}"><i class="fas fa-cog"></i> Edit Features</a>
                     </div>
                 @endif
             </div>
@@ -134,7 +134,7 @@
                 @endif
                 @if (Auth::check() && Auth::user()->hasPower('manage_characters'))
                     <div class="mt-3">
-                        <a href="#" class="btn btn-outline-info btn-sm edit-notes" data-id="{{ $image->id }}"><i class="fas fa-cog"></i> Edit</a>
+                        <a href="#" class="btn btn-outline-info btn-sm edit-notes" data-id="{{ $image->id }}"><i class="fas fa-cog"></i> Edit Notes</a>
                     </div>
                 @endif
             </div>
@@ -165,7 +165,7 @@
 
                 @if (Auth::check() && Auth::user()->hasPower('manage_characters'))
                     <div class="mt-3">
-                        <a href="#" class="btn btn-outline-info btn-sm edit-credits" data-id="{{ $image->id }}"><i class="fas fa-cog"></i> Edit</a>
+                        <a href="#" class="btn btn-outline-info btn-sm edit-credits" data-id="{{ $image->id }}"><i class="fas fa-cog"></i> Edit Credits</a>
                     </div>
                 @endif
             </div>

--- a/resources/views/character/_tab_notes.blade.php
+++ b/resources/views/character/_tab_notes.blade.php
@@ -5,6 +5,6 @@
 @endif
 @if (Auth::check() && Auth::user()->hasPower('manage_characters'))
     <div class="mt-3">
-        <a href="#" class="btn btn-outline-info btn-sm edit-description" data-{{ $character->is_myo_slot ? 'id' : 'slug' }}="{{ $character->is_myo_slot ? $character->id : $character->slug }}"><i class="fas fa-cog"></i> Edit Notes</a>
+        <a href="#" class="btn btn-outline-info btn-sm edit-description" data-{{ $character->is_myo_slot ? 'id' : 'slug' }}="{{ $character->is_myo_slot ? $character->id : $character->slug }}"><i class="fas fa-cog"></i> Edit Description</a>
     </div>
 @endif

--- a/resources/views/character/_tab_notes.blade.php
+++ b/resources/views/character/_tab_notes.blade.php
@@ -5,6 +5,6 @@
 @endif
 @if (Auth::check() && Auth::user()->hasPower('manage_characters'))
     <div class="mt-3">
-        <a href="#" class="btn btn-outline-info btn-sm edit-description" data-{{ $character->is_myo_slot ? 'id' : 'slug' }}="{{ $character->is_myo_slot ? $character->id : $character->slug }}"><i class="fas fa-cog"></i> Edit</a>
+        <a href="#" class="btn btn-outline-info btn-sm edit-description" data-{{ $character->is_myo_slot ? 'id' : 'slug' }}="{{ $character->is_myo_slot ? $character->id : $character->slug }}"><i class="fas fa-cog"></i> Edit Notes</a>
     </div>
 @endif

--- a/resources/views/character/_tab_stats.blade.php
+++ b/resources/views/character/_tab_stats.blade.php
@@ -51,6 +51,6 @@
 @endif
 @if (Auth::check() && Auth::user()->hasPower('manage_characters'))
     <div class="mt-3">
-        <a href="#" class="btn btn-outline-info btn-sm edit-stats" data-{{ $character->is_myo_slot ? 'id' : 'slug' }}="{{ $character->is_myo_slot ? $character->id : $character->slug }}"><i class="fas fa-cog"></i> Edit</a>
+        <a href="#" class="btn btn-outline-info btn-sm edit-stats" data-{{ $character->is_myo_slot ? 'id' : 'slug' }}="{{ $character->is_myo_slot ? $character->id : $character->slug }}"><i class="fas fa-cog"></i> Edit Stats</a>
     </div>
 @endif

--- a/resources/views/character/character.blade.php
+++ b/resources/views/character/character.blade.php
@@ -74,7 +74,7 @@
                     {!! Form::close() !!}
                     <hr />
                     <div class="text-right">
-                        <a href="#" class="btn btn-outline-danger btn-sm delete-character" data-slug="{{ $character->slug }}">Delete</a>
+                        <a href="#" class="btn btn-outline-danger btn-sm delete-character" data-slug="{{ $character->slug }}">Delete Character</a>
                     </div>
                 </div>
             @endif


### PR DESCRIPTION
This is admittedly a nitpick, but I've changed this on some sites ages ago. Having a bunch of buttons all just be 'edit' when they're strictly for specific purposes seems a bit odd.

I did keep 'Edit' for the visibility update button, because that one directly updates. It does not open a modal, and as such it's actually more consistent with other administrative Edit buttons.