### PR TITLE
fix(shops): shop being displayed as inactive when is_timed_shop is false but date data still exists

### DIFF
--- a/app/Models/Shop/Shop.php
+++ b/app/Models/Shop/Shop.php
@@ -200,7 +200,6 @@ class Shop extends Model {
      * We dont account for is_visible here, as this is used for checking both visible and invisible shop.
      */
     public function getIsActiveCheckAttribute() {
-
         if ($this->is_timed_shop) {
             if ($this->start_at && $this->start_at > Carbon::now()) {
                 return false;

--- a/app/Models/Shop/Shop.php
+++ b/app/Models/Shop/Shop.php
@@ -200,20 +200,23 @@ class Shop extends Model {
      * We dont account for is_visible here, as this is used for checking both visible and invisible shop.
      */
     public function getIsActiveCheckAttribute() {
-        if ($this->start_at && $this->start_at > Carbon::now()) {
-            return false;
-        }
 
-        if ($this->end_at && $this->end_at < Carbon::now()) {
-            return false;
-        }
+        if ($this->is_timed_shop) {
+            if ($this->start_at && $this->start_at > Carbon::now()) {
+                return false;
+            }
 
-        if ($this->days && !in_array(Carbon::now()->format('l'), $this->days)) {
-            return false;
-        }
+            if ($this->end_at && $this->end_at < Carbon::now()) {
+                return false;
+            }
 
-        if ($this->months && !in_array(Carbon::now()->format('F'), $this->months)) {
-            return false;
+            if ($this->days && !in_array(Carbon::now()->format('l'), $this->days)) {
+                return false;
+            }
+
+            if ($this->months && !in_array(Carbon::now()->format('F'), $this->months)) {
+                return false;
+            }
         }
 
         if (!$this->is_timed_shop && !$this->is_active) {


### PR DESCRIPTION
Exactly what it says on the tin. If date data is set, but the shop is marked as inactive, it will still display like this:
<img width="291" height="55" alt="image" src="https://github.com/user-attachments/assets/e762095f-22f4-49d0-ab34-8e11735ec1fe" />
...and this PR fixes that by just wrapping the date checker stuff in an `if ($this->is_timed_shop)`.