### PR TITLE
QoL(prompts): Make displayName link to the idUrl instead

### DIFF
--- a/app/Models/Prompt/Prompt.php
+++ b/app/Models/Prompt/Prompt.php
@@ -237,7 +237,7 @@ class Prompt extends Model {
      * @return string
      */
     public function getDisplayNameAttribute() {
-        return '<a href="'.$this->url.'" class="display-prompt">'.$this->name.'</a>';
+        return '<a href="'.$this->idUrl.'" class="display-prompt">'.$this->name.'</a>';
     }
 
     /**


### PR DESCRIPTION
I'm not sure why it still refers to the Search function, rather than directly to the prompt. We have id pages for a reason, don't we?