### PR TITLE
fix(style): remove thead-light to uniformize tables

### DIFF
--- a/resources/views/admin/submissions/submission.blade.php
+++ b/resources/views/admin/submissions/submission.blade.php
@@ -101,7 +101,7 @@
             <h2>Add-Ons</h2>
             <p>These items have been removed from the {{ $submission->prompt_id ? 'submitter' : 'claimant' }}'s inventory and will be refunded if the request is rejected or consumed if it is approved.</p>
             <table class="table table-sm">
-                <thead class="thead-light">
+                <thead>
                     <tr class="d-flex">
                         <th class="col-2">Item</th>
                         <th class="col-4">Source</th>

--- a/resources/views/character/design/addons.blade.php
+++ b/resources/views/character/design/addons.blade.php
@@ -33,7 +33,7 @@
             <div class="card mb-3">
                 <div class="card-body">
                     <table class="table table-sm">
-                        <thead class="thead-light">
+                        <thead>
                             <tr class="d-flex">
                                 <th class="col-2">Item</th>
                                 <th class="col-4">Source</th>

--- a/resources/views/home/_submission_content.blade.php
+++ b/resources/views/home/_submission_content.blade.php
@@ -74,7 +74,7 @@
         <div class="card-header h2">Rewards</div>
         <div class="card-body">
             <table class="table table-sm">
-                <thead class="thead-light">
+                <thead>
                     <tr>
                         <th width="70%">Reward</th>
                         <th width="30%">Amount</th>
@@ -116,7 +116,7 @@
                             <div class="submission-character-info-body">
                                 @if (array_filter(parseAssetData($character->data)))
                                     <table class="table table-sm mb-0">
-                                        <thead class="thead-light">
+                                        <thead>
                                             <tr>
                                                 <th width="70%">Reward</th>
                                                 <th width="30%">Amount</th>
@@ -171,7 +171,7 @@
         <div class="card-body">
             <p>These items have been removed from the {{ $submission->prompt_id ? 'submitter' : 'claimant' }}'s inventory and will be refunded if the request is rejected or consumed if it is approved.</p>
             <table class="table table-sm">
-                <thead class="thead-light">
+                <thead>
                     <tr class="d-flex">
                         <th class="col-2">Item</th>
                         <th class="col-4">Source</th>
@@ -202,7 +202,7 @@
         <div class="card-header h2">{!! $submission->user->displayName !!}'s Bank</div>
         <div class="card-body">
             <table class="table table-sm mb-3">
-                <thead class="thead-light">
+                <thead>
                     <tr>
                         <th width="70%">Currency</th>
                         <th width="30%">Quantity</th>

--- a/resources/views/home/trades/_offer.blade.php
+++ b/resources/views/home/trades/_offer.blade.php
@@ -35,7 +35,7 @@
             </div>
             <div class="card-body user-items">
                 <table class="table table-sm">
-                    <thead class="thead-light">
+                    <thead>
                         <tr class="d-flex">
                             <th class="col-2">Item</th>
                             <th class="col-4">Source</th>

--- a/resources/views/widgets/_inventory_select.blade.php
+++ b/resources/views/widgets/_inventory_select.blade.php
@@ -37,7 +37,7 @@
             </div>
             <div id="userItems" class="user-items">
                 <table class="table table-sm">
-                    <thead class="thead-light">
+                    <thead>
                         <tr class="d-flex">
                             <th class="col-1"><input id="toggle-checks" type="checkbox"></th>
                             <th class="col-2">Item</th>


### PR DESCRIPTION
This is mostly an aesthetic fix for tables as there were some tables with thead-light when it's not the case for most tables anymore. I believe develop has some additional ones with trade listing added. 
My reasoning is that it doesn't change that much for the visual and helps being more consistent accross theme as *-light can be inconsistent in darker themes + people will generally style the head with a color. This is basically just to uniformize tables accross the site.

I do know some might like the darker shade *-light gives for light mode bootstrap so feel free to give other suggestions or more cross-theme friendly options!