### PR TITLE
fix(nav): renaming Dropdown ids

### DIFF
--- a/resources/views/layouts/_nav.blade.php
+++ b/resources/views/layouts/_nav.blade.php
@@ -148,11 +148,11 @@
                     @endif
 
                     <li class="nav-item dropdown">
-                        <a id="browseDropdown" class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" v-pre>
+                        <a id="submitDropdown" class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" v-pre>
                             Submit
                         </a>
 
-                        <div class="dropdown-menu" aria-labelledby="browseDropdown">
+                        <div class="dropdown-menu" aria-labelledby="submitDropdown">
                             <a class="dropdown-item" href="{{ url('submissions/new') }}">
                                 Submit Prompt
                             </a>
@@ -166,11 +166,11 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a id="navbarDropdown" class="nav-link dropdown-toggle" href="{{ Auth::user()->url }}" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" v-pre>
+                        <a id="userDropdown" class="nav-link dropdown-toggle" href="{{ Auth::user()->url }}" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" v-pre>
                             {{ Auth::user()->name }} <span class="caret"></span>
                         </a>
 
-                        <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
+                        <div class="dropdown-menu dropdown-menu-right" aria-labelledby="userDropdown">
                             <a class="dropdown-item" href="{{ Auth::user()->url }}">
                                 Profile
                             </a>


### PR DESCRIPTION
Just noticed that the SUBMIT menu is _also_ labelled `browseDropdown`.

I'm aware that, due to the fact it's in _another_ navbar section, it shouldn't have any odd effects, but it seems better to me to avoid issues duplication may or may not cause. It's now `submitDropdown`.

While at it, also id'd the usermenu as `userDropdown`, as it used a generic `navbarDropdown`.