### PR TITLE
fix(prompts) consolidate all count arrays for prompt limits into one

### DIFF
--- a/app/Http/Controllers/Admin/SubmissionController.php
+++ b/app/Http/Controllers/Admin/SubmissionController.php
@@ -86,7 +86,7 @@ class SubmissionController extends Controller {
             'currencies'          => Currency::where('is_user_owned', 1)->orderBy('name')->pluck('name', 'id'),
             'tables'              => LootTable::orderBy('name')->pluck('name', 'id'),
             'raffles'             => Raffle::where('rolled_at', null)->where('is_active', 1)->orderBy('name')->pluck('name', 'id'),
-            'count'               => $prompt->filterCount($submission->user),
+            'count'               => $prompt->getCount($submission->user),
             'limit'               => $limit,
         ] : []));
     }

--- a/app/Http/Controllers/Admin/SubmissionController.php
+++ b/app/Http/Controllers/Admin/SubmissionController.php
@@ -65,12 +65,6 @@ class SubmissionController extends Controller {
         }
 
         $prompt = $submission->prompt;
-        $count['all'] = Submission::submitted($prompt->id, $submission->user_id)->count();
-        $count['Hour'] = Submission::submitted($prompt->id, $submission->user_id)->where('created_at', '>=', now()->startOfHour())->count();
-        $count['Day'] = Submission::submitted($prompt->id, $submission->user_id)->where('created_at', '>=', now()->startOfDay())->count();
-        $count['Week'] = Submission::submitted($prompt->id, $submission->user_id)->where('created_at', '>=', now()->startOfWeek())->count();
-        $count['Month'] = Submission::submitted($prompt->id, $submission->user_id)->where('created_at', '>=', now()->startOfMonth())->count();
-        $count['Year'] = Submission::submitted($prompt->id, $submission->user_id)->where('created_at', '>=', now()->startOfYear())->count();
 
         if ($prompt->limit_character) {
             $limit = $prompt->limit * Character::visible()->where('is_myo_slot', 0)->where('user_id', $submission->user_id)->count();
@@ -92,7 +86,7 @@ class SubmissionController extends Controller {
             'currencies'          => Currency::where('is_user_owned', 1)->orderBy('name')->pluck('name', 'id'),
             'tables'              => LootTable::orderBy('name')->pluck('name', 'id'),
             'raffles'             => Raffle::where('rolled_at', null)->where('is_active', 1)->orderBy('name')->pluck('name', 'id'),
-            'count'               => $count,
+            'count'               => $prompt->filterCount($submission->user),
             'limit'               => $limit,
         ] : []));
     }

--- a/app/Http/Controllers/Users/SubmissionController.php
+++ b/app/Http/Controllers/Users/SubmissionController.php
@@ -218,7 +218,7 @@ class SubmissionController extends Controller {
 
         return view('home._prompt', [
             'prompt' => $prompt,
-            'count'  => $prompt->filterCount(Auth::user()),
+            'count'  => $prompt->getCount(Auth::user()),
             'limit'  => $limit,
         ]);
     }

--- a/app/Http/Controllers/Users/SubmissionController.php
+++ b/app/Http/Controllers/Users/SubmissionController.php
@@ -210,13 +210,6 @@ class SubmissionController extends Controller {
             return response(404);
         }
 
-        $count['all'] = Submission::submitted($id, Auth::user()->id)->count();
-        $count['Hour'] = Submission::submitted($id, Auth::user()->id)->where('created_at', '>=', now()->startOfHour())->count();
-        $count['Day'] = Submission::submitted($id, Auth::user()->id)->where('created_at', '>=', now()->startOfDay())->count();
-        $count['Week'] = Submission::submitted($id, Auth::user()->id)->where('created_at', '>=', now()->startOfWeek())->count();
-        $count['Month'] = Submission::submitted($id, Auth::user()->id)->where('created_at', '>=', now()->startOfMonth())->count();
-        $count['Year'] = Submission::submitted($id, Auth::user()->id)->where('created_at', '>=', now()->startOfYear())->count();
-
         if ($prompt->limit_character) {
             $limit = $prompt->limit * Character::visible()->where('is_myo_slot', 0)->where('user_id', Auth::user()->id)->count();
         } else {
@@ -225,7 +218,7 @@ class SubmissionController extends Controller {
 
         return view('home._prompt', [
             'prompt' => $prompt,
-            'count'  => $count,
+            'count'  => $prompt->filterCount(Auth::user()),
             'limit'  => $limit,
         ]);
     }

--- a/app/Models/Prompt/Prompt.php
+++ b/app/Models/Prompt/Prompt.php
@@ -6,7 +6,6 @@ use App\Models\Model;
 use App\Models\Reward\Reward;
 use App\Models\Submission\Submission;
 use Carbon\Carbon;
-use Illuminate\Support\Facades\Auth;
 
 class Prompt extends Model {
     /**
@@ -94,20 +93,16 @@ class Prompt extends Model {
      * @return array
      */
     public function filterCount($user) {
-        if (Auth::check()) {
-            // filter the submissions by hour/day/week/etc and returns count
-            $count['all'] = Submission::submitted($this->id, $user->id)->count();
-            $count['Hour'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->startOfHour())->count();
-            $count['Day'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->startOfDay())->count();
-            $count['Week'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->startOfWeek())->count();
-            $count['BiWeekly'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->subWeeks(2))->count();
-            $count['Month'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->startOfMonth())->count();
-            $count['BiMonthly'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->subMonths(2))->count();
-            $count['Quarter'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->subMonths(3))->count();
-            $count['Year'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->startOfYear())->count();
-        } else {
-            $count = null;
-        }
+        // filter the submissions by hour/day/week/etc and returns count
+        $count['all'] = Submission::submitted($this->id, $user->id)->count();
+        $count['Hour'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->startOfHour())->count();
+        $count['Day'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->startOfDay())->count();
+        $count['Week'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->startOfWeek())->count();
+        $count['BiWeekly'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->subWeeks(2))->count();
+        $count['Month'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->startOfMonth())->count();
+        $count['BiMonthly'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->subMonths(2))->count();
+        $count['Quarter'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->subMonths(3))->count();
+        $count['Year'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->startOfYear())->count();
 
         return $count;
     }

--- a/app/Models/Prompt/Prompt.php
+++ b/app/Models/Prompt/Prompt.php
@@ -4,7 +4,9 @@ namespace App\Models\Prompt;
 
 use App\Models\Model;
 use App\Models\Reward\Reward;
+use App\Models\Submission\Submission;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Auth;
 
 class Prompt extends Model {
     /**
@@ -84,6 +86,31 @@ class Prompt extends Model {
         return $this->morphMany(Reward::class, 'object', 'object_model', 'object_id');
     }
 
+    /**
+     * Get an array of how many prompts the user has completed in general.
+     *
+     * @param mixed $user
+     *
+     * @return array
+     */
+    public function filterCount($user) {
+        if (Auth::check()) {
+            // filter the submissions by hour/day/week/etc and returns count
+            $count['all'] = Submission::submitted($this->id, $user->id)->count();
+            $count['Hour'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->startOfHour())->count();
+            $count['Day'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->startOfDay())->count();
+            $count['Week'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->startOfWeek())->count();
+            $count['BiWeekly'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->subWeeks(2))->count();
+            $count['Month'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->startOfMonth())->count();
+            $count['BiMonthly'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->subMonths(2))->count();
+            $count['Quarter'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->subMonths(3))->count();
+            $count['Year'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->startOfYear())->count();
+        } else {
+            $count = null;
+        }
+
+        return $count;
+    }
     /**********************************************************************************************
 
         SCOPES

--- a/app/Models/Prompt/Prompt.php
+++ b/app/Models/Prompt/Prompt.php
@@ -92,7 +92,7 @@ class Prompt extends Model {
      *
      * @return array
      */
-    public function filterCount($user) {
+    public function getCount($user) {
         // filter the submissions by hour/day/week/etc and returns count
         $count['all'] = Submission::submitted($this->id, $user->id)->count();
         $count['Hour'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->startOfHour())->count();

--- a/app/Services/SubmissionManager.php
+++ b/app/Services/SubmissionManager.php
@@ -66,7 +66,7 @@ class SubmissionManager extends Service {
                 if ($prompt->limit) {
                     // check that the user hasn't hit the prompt submission limit
                     // filter the submissions by hour/day/week/etc and count
-                    $count = $prompt->filterCount($user);
+                    $count = $prompt->getCount($user);
 
                     // if limit by character is on... multiply by # of chars. otherwise, don't
                     if ($prompt->limit_character) {
@@ -165,7 +165,7 @@ class SubmissionManager extends Service {
                 if ($prompt->limit && !($submission->status == 'Draft' && $submission->prompt_id && $submission->staff_comments)) {
                     // check that the user hasn't hit the prompt submission limit
                     // filter the submissions by hour/day/week/etc and count
-                    $count = $prompt->filterCount($user);
+                    $count = $prompt->getCount($user);
 
                     // if limit by character is on... multiply by # of chars. otherwise, don't
                     if ($prompt->limit_character) {

--- a/app/Services/SubmissionManager.php
+++ b/app/Services/SubmissionManager.php
@@ -66,15 +66,7 @@ class SubmissionManager extends Service {
                 if ($prompt->limit) {
                     // check that the user hasn't hit the prompt submission limit
                     // filter the submissions by hour/day/week/etc and count
-                    $count['all'] = Submission::submitted($prompt->id, $user->id)->count();
-                    $count['Hour'] = Submission::submitted($prompt->id, $user->id)->where('created_at', '>=', now()->startOfHour())->count();
-                    $count['Day'] = Submission::submitted($prompt->id, $user->id)->where('created_at', '>=', now()->startOfDay())->count();
-                    $count['Week'] = Submission::submitted($prompt->id, $user->id)->where('created_at', '>=', now()->startOfWeek())->count();
-                    $count['BiWeekly'] = Submission::submitted($prompt->id, $user->id)->where('created_at', '>=', now()->subWeeks(2))->count();
-                    $count['Month'] = Submission::submitted($prompt->id, $user->id)->where('created_at', '>=', now()->startOfMonth())->count();
-                    $count['BiMonthly'] = Submission::submitted($prompt->id, $user->id)->where('created_at', '>=', now()->subMonths(2))->count();
-                    $count['Quarter'] = Submission::submitted($prompt->id, $user->id)->where('created_at', '>=', now()->subMonths(3))->count();
-                    $count['Year'] = Submission::submitted($prompt->id, $user->id)->where('created_at', '>=', now()->startOfYear())->count();
+                    $count = $prompt->filterCount($user);
 
                     // if limit by character is on... multiply by # of chars. otherwise, don't
                     if ($prompt->limit_character) {
@@ -173,15 +165,7 @@ class SubmissionManager extends Service {
                 if ($prompt->limit && !($submission->status == 'Draft' && $submission->prompt_id && $submission->staff_comments)) {
                     // check that the user hasn't hit the prompt submission limit
                     // filter the submissions by hour/day/week/etc and count
-                    $count['all'] = Submission::submitted($prompt->id, $user->id)->count();
-                    $count['Hour'] = Submission::submitted($prompt->id, $user->id)->where('created_at', '>=', now()->startOfHour())->count();
-                    $count['Day'] = Submission::submitted($prompt->id, $user->id)->where('created_at', '>=', now()->startOfDay())->count();
-                    $count['Week'] = Submission::submitted($prompt->id, $user->id)->where('created_at', '>=', now()->startOfWeek())->count();
-                    $count['BiWeekly'] = Submission::submitted($prompt->id, $user->id)->where('created_at', '>=', now()->subWeeks(2))->count();
-                    $count['Month'] = Submission::submitted($prompt->id, $user->id)->where('created_at', '>=', now()->startOfMonth())->count();
-                    $count['BiMonthly'] = Submission::submitted($prompt->id, $user->id)->where('created_at', '>=', now()->subMonths(2))->count();
-                    $count['Quarter'] = Submission::submitted($prompt->id, $user->id)->where('created_at', '>=', now()->subMonths(3))->count();
-                    $count['Year'] = Submission::submitted($prompt->id, $user->id)->where('created_at', '>=', now()->startOfYear())->count();
+                    $count = $prompt->filterCount($user);
 
                     // if limit by character is on... multiply by # of chars. otherwise, don't
                     if ($prompt->limit_character) {


### PR DESCRIPTION
Just moves a few of the repeating count arrays into the prompt model to cut down on code/easier editing. There's potential for consolidating the limit count even further but I'm not sure what the best way would be so this is something simple!