### PR TITLE
fix: show hidden character ownership logs to staff

### DIFF
--- a/app/Models/User/UserCharacterLog.php
+++ b/app/Models/User/UserCharacterLog.php
@@ -4,6 +4,8 @@ namespace App\Models\User;
 
 use App\Models\Character\Character;
 use App\Models\Model;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
 
 class UserCharacterLog extends Model {
     /**
@@ -28,6 +30,18 @@ class UserCharacterLog extends Model {
      * @var string
      */
     public $timestamps = true;
+
+    /**
+     * The "booted" method of the model.
+     */
+    protected static function booted(): void
+    {
+        static::addGlobalScope('visible', function (Builder $builder) {
+            if(!(Auth::check()) || !(Auth::user()->hasPower('manage_characters'))) {
+                $builder->whereRelation('character', 'is_visible', 1);
+            }
+        });
+    }
 
     /**********************************************************************************************
 

--- a/app/Models/User/UserCharacterLog.php
+++ b/app/Models/User/UserCharacterLog.php
@@ -31,18 +31,6 @@ class UserCharacterLog extends Model {
      */
     public $timestamps = true;
 
-    /**
-     * The "booted" method of the model.
-     */
-    protected static function booted(): void
-    {
-        static::addGlobalScope('visible', function (Builder $builder) {
-            if(!(Auth::check()) || !(Auth::user()->hasPower('manage_characters'))) {
-                $builder->whereRelation('character', 'is_visible', 1);
-            }
-        });
-    }
-
     /**********************************************************************************************
 
         RELATIONS
@@ -92,5 +80,16 @@ class UserCharacterLog extends Model {
      */
     public function getDisplayRecipientAliasAttribute() {
         return prettyProfileLink($this->recipient_url);
+    }
+
+    /**
+     * The "booted" method of the model.
+     */
+    protected static function booted(): void {
+        static::addGlobalScope('visible', function (Builder $builder) {
+            if (!(Auth::check()) || !(Auth::user()->hasPower('manage_characters'))) {
+                $builder->whereRelation('character', 'is_visible', 1);
+            }
+        });
     }
 }

--- a/resources/views/user/_ownership_log_row.blade.php
+++ b/resources/views/user/_ownership_log_row.blade.php
@@ -1,4 +1,4 @@
-@if ($log->character && $log->character->is_visible == 1)
+@if ($log->character)
     <div class="row flex-wrap">
         <div class="col-6 col-md">
             <div class="logs-table-cell">
@@ -15,7 +15,10 @@
         @if (isset($showCharacter))
             <div class="col-6 col-md">
                 <div class="logs-table-cell">
-                    {!! $log->character ? $log->character->displayName : '---' !!}
+                    @if (!$log->character->is_visible)
+                        <i class="fas fa-eye-slash"></i>
+                    @endif
+                    {!! $log->character->displayName !!}
                 </div>
             </div>
         @endif


### PR DESCRIPTION
Went about it this way because it prevents having to either a) use `Auth::user()->hasPower()` on every single character row or b) fix something across multiple locations. (I love global scopes and whereRelation...) 

Also removed some checks that weren't needed given we already check for if character is deleted (aka null).