### PR TITLE
fix: erroneous query generation on currency log search

### DIFF
--- a/app/Http/Controllers/Users/UserController.php
+++ b/app/Http/Controllers/Users/UserController.php
@@ -288,7 +288,11 @@ class UserController extends Controller {
         }
         if ($request->get('user_id')) {
             $query->where(function ($query) use ($request) {
-                $query->where('sender_id', $request->get('user_id'))->orWhere('recipient_id', $request->get('user_id'));
+                $query->where(function ($query) use ($request) {
+                    $query->where('sender_id', intval($request->get('user_id')));
+                })->orWhere(function ($query) use ($request) {
+                    $query->where('recipient_id', intval($request->get('user_id')));
+                });
             });
         }
         if ($request->get('sort')) {

--- a/app/Models/Character/Character.php
+++ b/app/Models/Character/Character.php
@@ -470,9 +470,9 @@ class Character extends Model {
         $character = $this;
         $query = CurrencyLog::with('currency')->where(function ($query) use ($character) {
             $query->where(function ($query) use ($character) {
-                $query->with('sender')->where('sender_type', 'Character')->where('sender_id', $character->id)->where('log_type', '!=', 'Staff Grant');
+                $query->with('sender.rank')->where('sender_type', 'Character')->where('sender_id', $character->id)->where('log_type', '!=', 'Staff Grant');
             })->orWhere(function ($query) use ($character) {
-                $query->with('recipient')->where('recipient_type', 'Character')->where('recipient_id', $character->id)->where('log_type', '!=', 'Staff Removal');
+                $query->with('recipient.rank')->where('recipient_type', 'Character')->where('recipient_id', $character->id)->where('log_type', '!=', 'Staff Removal');
             });
         })->orderBy('id', 'DESC');
 

--- a/app/Models/Character/Character.php
+++ b/app/Models/Character/Character.php
@@ -469,9 +469,11 @@ class Character extends Model {
     public function getCurrencyLogs($limit = 10) {
         $character = $this;
         $query = CurrencyLog::with('currency')->where(function ($query) use ($character) {
-            $query->with('sender.rank')->where('sender_type', 'Character')->where('sender_id', $character->id)->where('log_type', '!=', 'Staff Grant');
-        })->orWhere(function ($query) use ($character) {
-            $query->with('recipient.rank')->where('recipient_type', 'Character')->where('recipient_id', $character->id)->where('log_type', '!=', 'Staff Removal');
+            $query->where(function ($query) use ($character) {
+                $query->with('sender')->where('sender_type', 'Character')->where('sender_id', $character->id)->where('log_type', '!=', 'Staff Grant');
+            })->orWhere(function ($query) use ($character) {
+                $query->with('recipient')->where('recipient_type', 'Character')->where('recipient_id', $character->id)->where('log_type', '!=', 'Staff Removal');
+            });
         })->orderBy('id', 'DESC');
 
         if ($limit) {

--- a/app/Models/User/User.php
+++ b/app/Models/User/User.php
@@ -583,9 +583,11 @@ class User extends Authenticatable implements MustVerifyEmail {
     public function getCurrencyLogs() {
         $user = $this;
         $query = CurrencyLog::with('currency')->where(function ($query) use ($user) {
-            $query->with('sender')->where('sender_type', 'User')->where('sender_id', $user->id)->whereNotIn('log_type', ['Staff Grant', 'Prompt Rewards', 'Claim Rewards', 'Gallery Submission Reward']);
-        })->orWhere(function ($query) use ($user) {
-            $query->with('recipient')->where('recipient_type', 'User')->where('recipient_id', $user->id)->where('log_type', '!=', 'Staff Removal');
+            $query->where(function ($query) use ($user) {
+                $query->with('sender')->where('sender_type', 'User')->where('sender_id', $user->id)->whereNotIn('log_type', ['Staff Grant', 'Prompt Rewards', 'Claim Rewards', 'Gallery Submission Reward']);
+            })->orWhere(function ($query) use ($user) {
+                $query->with('recipient')->where('recipient_type', 'User')->where('recipient_id', $user->id)->where('log_type', '!=', 'Staff Removal');
+            });
         })->orderBy('id', 'DESC');
 
         return $query;


### PR DESCRIPTION
When calling getCurrencyLogs(), the way the SQL generates currently is:

```
select * from `currencies_log` where (`sender_type` = ? and `sender_id` = ? and `log_type` not in (?, ?, ?, ?)) or (`recipient_type` = ? and `recipient_id` = ? and `log_type` != ?) order by `id` desc
```

...which, when chained with additional where clauses in the search function, causes some odd display behavior at times (users reported some currencies not showing at all, not showing logs where users transferred them currency, strange ordering, etc). You can see it when searching for a specific user within someone's currency logs here:

```
select * from `currencies_log` where ((`sender_type` = ? and `sender_id` = ? and `log_type` not in (?, ?, ?, ?)) or (`recipient_type` = ? and `recipient_id` = ? and `log_type` != ?)) and (`sender_id` = ? or `recipient_id` = ?) order by `id` desc
```

This PR creates additional parentheses in the SQL so chained where()'s are properly handled:

```
select * from `currencies_log` where ((`sender_type` = ? and `sender_id` = ? and `log_type` not in (?, ?, ?, ?)) or (`recipient_type` = ? and `recipient_id` = ? and `log_type` != ?)) order by `id` desc
```

So now, when searching for a user:

```
select * from `currencies_log` where ((`sender_type` = ? and `sender_id` = ? and `log_type` not in (?, ?, ?, ?)) or (`recipient_type` = ? and `recipient_id` = ? and `log_type` != ?)) and ((`sender_id` = ?) or (`recipient_id` = ?)) order by `id` desc
```

I also applied the same fix to characters for consistency's sake (maybe somebody will add search there someday). Also don't ask me why the intval()s were needed, I'm not fully sure either, but it was handling weird without them, lol.

This would _theoretically_ also be an issue on v3, but it never happens because getCurrencyLogs() returns a collection and not a query.