### PR TITLE
fix: update socialiteproviders/deviantart to ^4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "laravel/tinker": "^2.0",
         "laravel/ui": "^3.1.0",
         "laravelcollective/html": "^6.0",
-        "socialiteproviders/deviantart": "4.2",
+        "socialiteproviders/deviantart": "^4.2",
         "socialiteproviders/imgur": "^4.1",
         "socialiteproviders/instagram": "^4.1",
         "socialiteproviders/tumblr": "^4.1",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "laravel/tinker": "^2.0",
         "laravel/ui": "^3.1.0",
         "laravelcollective/html": "^6.0",
-        "socialiteproviders/deviantart": "^4.1",
+        "socialiteproviders/deviantart": "4.2",
         "socialiteproviders/imgur": "^4.1",
         "socialiteproviders/instagram": "^4.1",
         "socialiteproviders/tumblr": "^4.1",


### PR DESCRIPTION
deviantART recently changed to [using OAuth 2.1 for newly registered applications](https://www.deviantart.com/developers/authentication#:~:text=OAuth%202.1%20and%20OAuth%202.0) and now requires the use of PKCE. 

Existing sites are not required to update. However, _new_ LK sites of _any_ version set up with dA authentication will not work whatsoever, as the version 4.1 of socialiteproviders/deviantart does not have PKCE enabled. Hence, this PR is on main.

This PR updates socialiteproviders/deviantart to 4.2 -- which _does_ have PKCE enabled -- so that dA auth will continue to work for new sites.

Thanks!