### PR TITLE
fix(aliases): Enable 'remember me' option on user login

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -68,7 +68,7 @@ class LoginController extends Controller {
             return redirect('/register/'.$provider)->with(['userData' => $result]);
         }
 
-        Auth::login($user->user);
+        Auth::login($user->user, true);
 
         return redirect($this->redirectTo);
     }


### PR DESCRIPTION
prevent alias login from expiring after the default cache expiration

made a v3 pr at request from toko