### PR TITLE
feat(staff): add secondary admin power

### DIFF
--- a/app/Models/Rank/Rank.php
+++ b/app/Models/Rank/Rank.php
@@ -13,7 +13,7 @@ class Rank extends Model {
      */
     protected $fillable = [
         'name', 'description', 'parsed_description', 'sort', 'color', 'icon',
-        'is_admin',
+        'is_admin', 'is_secondary_admin',
     ];
 
     /**
@@ -22,6 +22,15 @@ class Rank extends Model {
      * @var string
      */
     protected $table = 'ranks';
+
+    /**
+     * The relationships that should always be loaded.
+     *
+     * @var array
+     */
+    protected $with = [
+        'powers',
+    ];
 
     /**
      * Validation rules for ranks.
@@ -73,7 +82,7 @@ class Rank extends Model {
      * @return bool
      */
     public function getIsAdminAttribute() {
-        return $this->attributes['is_admin'];
+        return $this->attributes['is_admin'] || $this->attributes['is_secondary_admin'];
     }
 
     /**********************************************************************************************
@@ -95,6 +104,15 @@ class Rank extends Model {
         }
         if ($this->hasPower('edit_ranks')) {
             if ($this->isAdmin) {
+                // editing a false admin rank
+                if ($rank->powers()->where('power', 'admin')->exists()) {
+                    if ($this->attributes['is_admin']) {
+                        return 3; // must remove admin power to edit more granularly
+                    } else {
+                        return 4; // false admin rank, cannot edit
+                    }
+                }
+
                 if ($rank->id != $this->id) {
                     return 1;
                 } // can edit everything

--- a/app/Services/RankService.php
+++ b/app/Services/RankService.php
@@ -39,6 +39,10 @@ class RankService extends Service {
                     if (!config('lorekeeper.powers.'.$power)) {
                         throw new \Exception('Invalid power selected.');
                     }
+
+                    if ($power == 'admin') {
+                        $data['is_secondary_admin'] = true;
+                    }
                 }
 
                 $powers = array_unique($data['powers']);
@@ -98,6 +102,10 @@ class RankService extends Service {
                 foreach ($data['powers'] as $power) {
                     if (!config('lorekeeper.powers.'.$power)) {
                         throw new \Exception('Invalid power selected.');
+                    }
+
+                    if ($power == 'admin') {
+                        $data['is_secondary_admin'] = true;
                     }
                 }
 

--- a/app/Services/RankService.php
+++ b/app/Services/RankService.php
@@ -113,6 +113,10 @@ class RankService extends Service {
                 unset($data['powers']);
             }
 
+            if (!isset($data['is_secondary_admin']) || !in_array('admin', $powers)) {
+                $data['is_secondary_admin'] = false;
+            }
+
             $data['color'] = isset($data['color']) ? str_replace('#', '', $data['color']) : null;
             if (isset($data['description']) && $data['description']) {
                 $data['parsed_description'] = parse($data['description']);

--- a/config/lorekeeper/powers.php
+++ b/config/lorekeeper/powers.php
@@ -11,6 +11,10 @@ return [
     |
     */
 
+    'admin' => [
+        'name'        => 'Administrator Access',
+        'description' => 'Grants all powers automatically. Grant this power wisely.',
+    ],
     'edit_site_settings' => [
         'name'        => 'Edit Site Settings',
         'description' => 'Allow rank to modify site settings and upload new images to replace the site layout images.',

--- a/database/migrations/2026_05_04_111717_add_is_secondary_admin_column_to_rank_table.php
+++ b/database/migrations/2026_05_04_111717_add_is_secondary_admin_column_to_rank_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void {
+        Schema::table('ranks', function (Blueprint $table) {
+            $table->boolean('is_secondary_admin')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void {
+        Schema::table('ranks', function (Blueprint $table) {
+            $table->dropColumn('is_secondary_admin');
+        });
+    }
+};

--- a/resources/views/admin/users/_create_edit_rank.blade.php
+++ b/resources/views/admin/users/_create_edit_rank.blade.php
@@ -33,12 +33,19 @@
         </div>
     </div>
 
-    @if ($editable != 2)
-        {{-- Powers --}}
-        <div class="form-group">
-            <div class="row">
+    @if ($editable == 2)
+        <div class="card bg-light mb-3">
+            <div class="card-body">Powers for the admin rank cannot be edited. {!! add_help('The admin rank has the ability to edit any editable information on the site, and is always highest-ranked (cannot be edited by any other user).') !!}</div>
+        </div>
+    @elseif ($editable == 3)
+        <div class="card bg-light mb-3">
+            <div class="card-body">
+                This rank has the "Admin" power granted to it, meaning it has all powers. If you want to edit this rank, you must remove the "Admin" power first.
                 @foreach ($powers as $key => $power)
-                    <div class="col-md-6 form-check">
+                    @if ($key != 'admin')
+                        @continue
+                    @endif
+                    <div class="col-md-6 form-group ml-1 mt-2 mb-0">
                         {!! Form::checkbox('powers[' . $key . ']', $key, $rankPowers ? isset($rankPowers[$key]) : false, ['class' => 'form-check-input', 'id' => 'powers[' . $key . ']']) !!}
                         {!! Form::label('powers[' . $key . ']', $power['name'], ['class' => 'form-check-label']) !!}
                         {!! add_help($power['description']) !!}
@@ -46,9 +53,24 @@
                 @endforeach
             </div>
         </div>
-    @else
+    @elseif ($editable == 4)
         <div class="card bg-light mb-3">
-            <div class="card-body">Powers for the admin rank cannot be edited. {!! add_help('The admin rank has the ability to edit any editable information on the site, and is always highest-ranked (cannot be edited by any other user).') !!}</div>
+            <div class="card-body">
+                You cannot edit this rank's powers.
+            </div>
+        </div>
+    @else
+        {{-- Powers --}}
+        <div class="row">
+            @foreach ($powers as $key => $power)
+                <div class="col-md-6">
+                    <div class="form-check">
+                        {!! Form::checkbox('powers[' . $key . ']', $key, $rankPowers ? isset($rankPowers[$key]) : false, ['class' => 'form-check-input', 'id' => 'powers[' . $key . ']']) !!}
+                        {!! Form::label('powers[' . $key . ']', $power['name'], ['class' => 'form-check-label']) !!}
+                        {!! add_help($power['description']) !!}
+                    </div>
+                </div>
+            @endforeach
         </div>
     @endif
 


### PR DESCRIPTION
broken up from original pr https://github.com/lk-arpg/lorekeeper/pull/1409
- Allow non admin ranks to do admin things
   - nice if you don't want to have to give everyone admin to do admin things, especially since you need to remove the role in the DB

secondary admins can't edit their own powers
<img width="1123" height="794" alt="image" src="https://github.com/user-attachments/assets/f7bab015-f90e-439f-9244-cf95f942ff93" />
