### PR TITLE
refactor: remove $appends from subtype

### DIFF
--- a/app/Models/Species/Subtype.php
+++ b/app/Models/Species/Subtype.php
@@ -22,15 +22,6 @@ class Subtype extends Model {
     protected $table = 'subtypes';
 
     /**
-     * Accessors to append to the model.
-     *
-     * @var array
-     */
-    protected $appends = [
-        'name_with_species',
-    ];
-
-    /**
      * Validation rules for creation.
      *
      * @var array


### PR DESCRIPTION
Similar to thing to the develop PR, just removes $appends entirely because it's not used anywhere, so it's just making a call to the species model for every subtype in a query for no reason.