### PR TITLE
fix: make fontawesome work in tinyMCE editor

### DIFF
--- a/resources/views/character/_image_js.blade.php
+++ b/resources/views/character/_image_js.blade.php
@@ -21,8 +21,10 @@
                     content_css: [
                         '{{ asset('css/app.css') }}',
                         '{{ asset('css/lorekeeper.css') }}'
+                        '{{ asset('css/all.min.css') }}', //fontawesome
                     ],
                     spoiler_caption: 'Toggle Spoiler',
+                    extended_valid_elements: '#i[class],#em[class]',
                     target_list: false
                 });
 			});
@@ -69,8 +71,10 @@
                     content_css: [
                         '{{ asset('css/app.css') }}',
                         '{{ asset('css/lorekeeper.css') }}'
+                        '{{ asset('css/all.min.css') }}', //fontawesome
                     ],
                     spoiler_caption: 'Toggle Spoiler',
+                    extended_valid_elements: '#i[class],#em[class]',
                     target_list: false
                 });
 			});

--- a/resources/views/js/_modal_wysiwyg.blade.php
+++ b/resources/views/js/_modal_wysiwyg.blade.php
@@ -8,9 +8,11 @@ tinymce.init({
         'insertdatetime media table paste code help wordcount'
     ],
     toolbar: 'undo redo | formatselect | bold italic backcolor | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | removeformat | code',
+    extended_valid_elements: '#i[class],#em[class]',
     content_css: [
         '//www.tiny.cloud/css/codepen.min.css',
         '{{ asset('css/app.css') }}',
         '{{ asset('css/lorekeeper.css') }}'
+        '{{ asset('css/all.min.css') }}', //fontawesome
     ]
 });

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -146,8 +146,10 @@
                     content_css: [
                         '{{ asset('css/app.css') }}',
                         '{{ asset('css/lorekeeper.css') }}'
+                        '{{ asset('css/all.min.css') }}', //fontawesome
                     ],
                     spoiler_caption: 'Toggle Spoiler',
+                    extended_valid_elements: '#i[class],#em[class]',
                     target_list: false
                 });
                 var $mobileMenuButton = $('#mobileMenuButton');


### PR DESCRIPTION
this is a small fix/enhancement to make fontawesome work live within the tinyMCE editor!

**current tinyMCE behavior:**
- fontawesome code (`<i class="fas fa-heart"></i>`) gets automatically stripped in the tinyMCE editor because it's considered an empty element.
- workarounds to get it to persist must be done manually every time (the comment method or typing `&nbsp;`)
- even using workarounds to make sure the code isn't stripped, FA will not display a live preview in the editor (it will render properly on site pages/profiles/comments though)

**testing outcome:**
- FA will now display in tinyMCE's live preview while editing it.
- this will prevent the autoconversion to `<em>` tags when `<i>` is used.
- only `<i class>` and `<em class>` "empty" code will always automatically pad with a `&nbsp;` so it'll never get eaten again by accident (`<i class="fas fa-heart">&nbsp;</i>`)

> **notes:**
> - the fix to make FA show up in tinyMCE was simply adding in the css in the content_css lol
> - the `extended_valid_elements` is set to only target the class attribute when used in `<i>` and `<em>` attributes, so hopefully it shouldn't be affecting anything else. both of these are included to account for the editor's previous behavior with the autoconverting tags to `<em>`, and the autopadding should only target empty elements too (so anyone using the noted workarounds should also be unaffected).
>   - (to be technical, we're not limited to `<i>` to use FA, folks can legalize other elements in the editor if they want, but for the sake of brevity, the average user is most likely not going to know alternatives are possible because of the default copy+paste code the FA website gives.)
> - the autopadding behavior is set with the `#` in front (in `extended_valid_elements: '#i[class]',`); it's set as a default, since this behavior probably won't show up outside the use of FA and accidentally losing tags is more of the unwanted behavior. individuals _can_ remove the `#` if desired though, but they'll be on their own with understanding what doesn't trigger the eating behavior.
>   - while it would be nice for the autopadding to spawn with a comment (`<!-- -->`) so there won't be a visible space, I don't think this is possible without some more complicated code or a plugin at that point. however, users can still manually edit the autopadded `&nbsp;` to a comment if they prefer instead.

just a footnote this is my first pr so I'm not fully sure if I understand what I'm doing haha if I did something out of order let me know 🙏