### PR TITLE
fix: prev/next character buttons not wrapping on mobile

### DIFF
--- a/public/css/lorekeeper.css
+++ b/public/css/lorekeeper.css
@@ -456,6 +456,9 @@ main > .row {
     height: 2rem;
     padding-right: .5rem;
 }
+.text-wrap {
+    text-wrap: auto;
+}
 
 /* NOTIFICATIONS *********************************************************************************/
 

--- a/resources/views/character/_header.blade.php
+++ b/resources/views/character/_header.blade.php
@@ -2,16 +2,16 @@
     @if ($extPrevAndNextBtns['prevCharName'] || $extPrevAndNextBtns['nextCharName'])
         <div class="row mb-4">
             @if ($extPrevAndNextBtns['prevCharName'])
-                <div class="col text-left float-left">
+                <div class="col text-left mb-2 mb-md-0">
                     <a class="btn btn-outline-success text-success" href="{{ $extPrevAndNextBtns['prevCharUrl'] }}{!! $extPrevAndNextBtnsUrl !!}">
-                        <i class="fas fa-angle-double-left"></i> Previous Character ・ <span class="text-primary">{!! $extPrevAndNextBtns['prevCharName'] !!}</span>
+                        <i class="fas fa-angle-double-left"></i> Previous Character ・ <span class="text-primary text-break text-wrap">{!! $extPrevAndNextBtns['prevCharName'] !!}</span>
                     </a>
                 </div>
             @endif
             @if ($extPrevAndNextBtns['nextCharName'])
-                <div class="col text-right float-right">
+                <div class="col text-right">
                     <a class="btn btn-outline-success text-success" href="{{ $extPrevAndNextBtns['nextCharUrl'] }}{!! $extPrevAndNextBtnsUrl !!}">
-                        <span class="text-primary">{!! $extPrevAndNextBtns['nextCharName'] !!}</span> ・ Next Character <i class="fas fa-angle-double-right"></i><br />
+                        <span class="text-primary text-break text-wrap">{!! $extPrevAndNextBtns['nextCharName'] !!}</span> ・ Next Character <i class="fas fa-angle-double-right"></i><br />
                     </a>
                 </div>
             @endif


### PR DESCRIPTION
fixes this:
<img width="1069" height="855" alt="vivaldi_egMUKidaYk" src="https://github.com/user-attachments/assets/be05df19-748f-48d2-b941-6e07477e3165" />

into this:
<img width="994" height="860" alt="image" src="https://github.com/user-attachments/assets/5f9e8cd7-d111-4689-9b7a-66f605904115" />

note: when this gets merged forward, text-wrap should be included in dev's 4.6 bootstrap already (but I don't think leaving it in will hurt)