### PR TITLE
fix: server error if a site image is missing

### DIFF
--- a/resources/views/admin/files/images.blade.php
+++ b/resources/views/admin/files/images.blade.php
@@ -15,7 +15,13 @@
         <div class="card mb-3">
             <div class="card-body">
                 <div class="d-flex flex-column flex-sm-row">
-                    <div class="mr-2" style="width: 200px;"><img src="{{ asset('images/' . $image['filename'] . '?v=' . filemtime(public_path('images/' . $image['filename']))) }}" class="mw-100" alt="Site image: {{ $image['name'] }}" /></div>
+                        @if(file_exists(public_path('images/' . $image['filename'])))
+                            <img src="{{ asset('images/' . $image['filename'] . '?v=' . filemtime(public_path('images/' . $image['filename']))) }}" class="mw-100" alt="Site image: {{ $image['name'] }}" />
+                        @else
+                            No image found.
+                            <br>
+                            Please upload an image.
+                        @endif
                     <div style="width: 100%;">
                         <h3 class="card-heading">{{ $image['name'] }} <a href="{{ asset('images/' . $image['filename']) }}" class="btn btn-info btn-sm float-right">View Current</a></h3>
                         <p>{{ $image['description'] }}</p>

--- a/resources/views/admin/files/images.blade.php
+++ b/resources/views/admin/files/images.blade.php
@@ -15,13 +15,13 @@
         <div class="card mb-3">
             <div class="card-body">
                 <div class="d-flex flex-column flex-sm-row">
-                        @if(file_exists(public_path('images/' . $image['filename'])))
-                            <img src="{{ asset('images/' . $image['filename'] . '?v=' . filemtime(public_path('images/' . $image['filename']))) }}" class="mw-100" alt="Site image: {{ $image['name'] }}" />
-                        @else
-                            No image found.
-                            <br>
-                            Please upload an image.
-                        @endif
+                    @if (file_exists(public_path('images/' . $image['filename'])))
+                        <img src="{{ asset('images/' . $image['filename'] . '?v=' . filemtime(public_path('images/' . $image['filename']))) }}" class="mw-100" alt="Site image: {{ $image['name'] }}" />
+                    @else
+                        No image found.
+                        <br>
+                        Please upload an image.
+                    @endif
                     <div style="width: 100%;">
                         <h3 class="card-heading">{{ $image['name'] }} <a href="{{ asset('images/' . $image['filename']) }}" class="btn btn-info btn-sm float-right">View Current</a></h3>
                         <p>{{ $image['description'] }}</p>


### PR DESCRIPTION
If something goofy happens and a site image goes missing, allows a site owner to fix it themselves rather than needing to call copy-default-images fresh on the backend (and potentially overwrite existing site images).