### PR TITLE
fix: patch for CRLF injection vulnerability in email inputs

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -20,6 +20,7 @@ class Kernel extends HttpKernel
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         \App\Http\Middleware\TrustProxies::class,
         \App\Http\Middleware\ParsePostRequestFields::class,
+        \App\Http\Middleware\SanitizeEmails::class,
     ];
 
     /**

--- a/app/Http/Middleware/SanitizeEmails.php
+++ b/app/Http/Middleware/SanitizeEmails.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class SanitizeEmails
+{
+    /**
+     * Hotfix for security advisory GHSA-5vg9-5847-vvmq
+     * https://github.com/laravel/framework/security/advisories/GHSA-5vg9-5847-vvmq
+     * Will no longer be necessary on laravel/framework ^12.60.0 or ^13.10.0
+     *
+     * FILTER_SANITIZE_EMAIL will remove vulnerable \ and / characters
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        if ($request->has('email')) {
+            $request->merge([
+                'email' => filter_var($request->email, FILTER_SANITIZE_EMAIL)
+            ]);
+        }
+
+        return $next($request);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,14 @@
     "config": {
         "optimize-autoloader": true,
         "preferred-install": "dist",
-        "sort-packages": true
+        "sort-packages": true,
+        "policy": {
+            "advisories": {
+                "ignore-id": {
+                    "PKSA-mdq4-51ck-6kdq": "Hotfixed using custom sanitization middleware."
+                }
+            }
+        }
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,8 @@
         "policy": {
             "advisories": {
                 "ignore-id": {
-                    "PKSA-mdq4-51ck-6kdq": "Hotfixed using custom sanitization middleware."
+                    "PKSA-mdq4-51ck-6kdq": "Hotfixed using custom sanitization middleware.",
+                    "PKSA-8qx3-n5y5-vvnd": "Resolved in laravel/framework 10.48.23. Do not use wildcard validation with files in Laravel v8/Lorekeeper v2."
                 }
             }
         }


### PR DESCRIPTION
Patch for laravel/framework security advisory https://github.com/laravel/framework/security/advisories/GHSA-5vg9-5847-vvmq

Adds middleware that runs `filter_var($val, FILTER_SANITIZE_EMAIL)` against any form request field labeled "email".

Notably:
- The malicious string `victim@example.com\r\nBcc: attacker@evil.com` is already blocked by frontend validation (had to remove that when testing this!).
- I saw an article indicating that if you use the native validate() with your form data then you're safe, so technically we may already be fine? It did seem to be getting blocked by just the normal 'email' validation rule when I was testing this (and as far as I can tell, we never accept an email without validating it first). Still, sanitization != validation -- this will sanitize it before it even hits the validation rule.

**Also, important note:** Because I ran into this... people should run `composer self-update` when they upgrade, because I noticed I had an older version of composer that didn't recognize the newer `policy.advisories.ignore-id` config.