### PR TITLE
Fixes(Ranks): Sorting and Power Changes

### DIFF
--- a/app/Models/Rank/Rank.php
+++ b/app/Models/Rank/Rank.php
@@ -85,6 +85,39 @@ class Rank extends Model {
         return $this->attributes['is_admin'] || $this->attributes['is_secondary_admin'];
     }
 
+    /**
+     * Check if the rank is a secondary admin rank.
+     *
+     * @return bool
+     */
+    public function getIsSecondaryAdminAttribute() {
+        return $this->attributes['is_secondary_admin'];
+    }
+
+    /**
+     * Check if the rank is the default user rank.
+     *
+     * @return bool
+     */
+    public function getIsDefaultRankAttribute() {
+        if ($this->sort == 0) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Check if the rank can be sorted.
+     *
+     * @return bool
+     */
+    public function getIsSortableAttribute() {
+        if ($this->attributes['is_admin'] || $this->isDefaultRank) {
+            return false;
+        }
+        return true;
+    }
+
     /**********************************************************************************************
 
         OTHER FUNCTIONS
@@ -104,23 +137,29 @@ class Rank extends Model {
         }
         if ($this->hasPower('edit_ranks')) {
             if ($this->isAdmin) {
-                // editing a false admin rank
-                if ($rank->powers()->where('power', 'admin')->exists()) {
-                    if ($this->attributes['is_admin']) {
-                        return 3; // must remove admin power to edit more granularly
-                    } else {
-                        return 4; // false admin rank, cannot edit
-                    }
+                if ($rank->attributes['is_admin']) {
+                    return 2; // is admin, cannot edit
                 }
 
                 if ($rank->id != $this->id) {
-                    return 1;
-                } // can edit everything
+                    if ($this->sort > $rank->sort) {
+                        if ($rank->IsSecondaryAdmin) {
+                            return 3; // editing a false admin rank, must remove admin power to edit more granularly
+                        }
+                        else {
+                            return 1; // can edit everything, as admin
+                        }
+                    }
+                    else {
+                        return 4; // cannot edit higher rank
+                    }
+                }
                 else {
-                    return 2;
-                } // limited edit: cannot edit sort order/powers
+                    return 4; // cannot edit own rank
+                }
+
             } elseif ($this->sort > $rank->sort) {
-                return 1;
+                return 1; // can edit everything, rank is higher
             }
         }
 

--- a/app/Models/Rank/Rank.php
+++ b/app/Models/Rank/Rank.php
@@ -103,6 +103,7 @@ class Rank extends Model {
         if ($this->sort == 0) {
             return true;
         }
+
         return false;
     }
 
@@ -115,6 +116,7 @@ class Rank extends Model {
         if ($this->attributes['is_admin'] || $this->isDefaultRank) {
             return false;
         }
+
         return true;
     }
 
@@ -145,19 +147,15 @@ class Rank extends Model {
                     if ($this->sort > $rank->sort) {
                         if ($rank->IsSecondaryAdmin) {
                             return 3; // editing a false admin rank, must remove admin power to edit more granularly
-                        }
-                        else {
+                        } else {
                             return 1; // can edit everything, as admin
                         }
-                    }
-                    else {
+                    } else {
                         return 4; // cannot edit higher rank
                     }
-                }
-                else {
+                } else {
                     return 4; // cannot edit own rank
                 }
-
             } elseif ($this->sort > $rank->sort) {
                 return 1; // can edit everything, rank is higher
             }

--- a/app/Services/RankService.php
+++ b/app/Services/RankService.php
@@ -196,7 +196,7 @@ class RankService extends Service {
                     throw new \Exception('The sort order of the admin rank cannot be changed.');
                 }
 
-                Rank::where('id', $s)->update(['sort' => $key+1]);
+                Rank::where('id', $s)->update(['sort' => $key + 1]);
                 $count++;
             }
             $adminRank->update(['sort'=> $count]);

--- a/app/Services/RankService.php
+++ b/app/Services/RankService.php
@@ -187,17 +187,19 @@ class RankService extends Service {
 
             // Check if the array contains the admin rank, or anything non-numeric
             $adminRank = Rank::where('is_admin', 1)->first();
-            $count = 0;
+            $count = 1;
             foreach ($sort as $key => $s) {
                 if (!is_numeric($s) || !is_numeric($key)) {
                     throw new \Exception('Invalid sort order.');
                 }
-                if ($s == $adminRank->id && $key == 0) {
-                    throw new \Exception('The admin rank cannot be sorted to become the default user rank.');
+                if ($s == $adminRank->id) {
+                    throw new \Exception('The sort order of the admin rank cannot be changed.');
                 }
 
-                Rank::where('id', $s)->update(['sort' => $key]);
+                Rank::where('id', $s)->update(['sort' => $key+1]);
+                $count++;
             }
+            $adminRank->update(['sort'=> $count]);
 
             return $this->commitReturn(true);
         } catch (\Exception $e) {

--- a/app/Services/RankService.php
+++ b/app/Services/RankService.php
@@ -192,14 +192,12 @@ class RankService extends Service {
                 if (!is_numeric($s) || !is_numeric($key)) {
                     throw new \Exception('Invalid sort order.');
                 }
-                if ($s == $adminRank->id) {
-                    throw new \Exception('The sort order of the admin rank cannot be changed.');
+                if ($s == $adminRank->id && $key == 0) {
+                    throw new \Exception('The admin rank cannot be sorted to become the default user rank.');
                 }
 
                 Rank::where('id', $s)->update(['sort' => $key]);
-                $count++;
             }
-            $adminRank->update(['sort'=> $count]);
 
             return $this->commitReturn(true);
         } catch (\Exception $e) {

--- a/resources/views/admin/users/_create_edit_rank.blade.php
+++ b/resources/views/admin/users/_create_edit_rank.blade.php
@@ -35,7 +35,9 @@
 
     @if ($editable == 2)
         <div class="card bg-light mb-3">
-            <div class="card-body">Powers for the admin rank cannot be edited. {!! add_help('The admin rank has the ability to edit any editable information on the site, and is always highest-ranked (cannot be edited by any other user).') !!}</div>
+            <div class="card-body">
+                Powers for the admin rank cannot be edited. {!! add_help('The admin rank has the ability to edit any editable information on the site, and is always highest-ranked (cannot be edited by any other user).') !!}
+            </div>
         </div>
     @elseif ($editable == 3)
         <div class="card bg-light mb-3">

--- a/resources/views/admin/users/_create_edit_rank.blade.php
+++ b/resources/views/admin/users/_create_edit_rank.blade.php
@@ -59,6 +59,12 @@
                 You cannot edit this rank's powers.
             </div>
         </div>
+    @elseif ($rank->isDefaultRank)
+        <div class="card bg-light mb-3">
+            <div class="card-body">
+                Powers for the default user rank cannot be edited. {!! add_help('The default user rank should always be the lowest sorted rank and can not have any specific powers.') !!}
+            </div>
+        </div>
     @else
         {{-- Powers --}}
         <div class="row">

--- a/resources/views/admin/users/ranks.blade.php
+++ b/resources/views/admin/users/ranks.blade.php
@@ -26,22 +26,27 @@
         </thead>
         <tbody id="sortable" class="sortable">
             @foreach ($ranks as $rank)
-                <tr {{ !$rank->isAdmin ? 'class=sort-item' : '' }} data-id="{{ $rank->id }}">
+                <tr class=sort-item data-id="{{ $rank->id }}">
                     <td>
-                        @if (!$rank->isAdmin)
-                            <a class="fas fa-arrows-alt-v handle" href="#"></a>
-                        @endif
+                        <a class="fas fa-arrows-alt-v handle" href="#"></a>
                     </td>
                     <td><i class="{!! $rank->icon ? $rank->icon . ' mr-2' : '' !!} "></i>{!! $rank->displayName !!}</td>
                     <td>{!! $rank->parsed_description !!}</td>
                     <td>
-                        @foreach ($rank->getPowers() as $power)
-                            <div>{{ $power['name'] }}</div>
-                        @endforeach
+                        @if (!$rank->isAdmin)
+                            @foreach ($rank->getPowers() as $power)
+                                <div>{{ $power['name'] }}</div>
+                            @endforeach
+                        @else
+                            <div><em>{{ $rank->getPowers()['admin']['name'] }} {!! add_help('This rank has the &quot;Admin&quot; power granted to it, meaning it has all powers.') !!}</em></div>
+                        @endif
+                        @if ($loop->last)
+                            <div><em>Default user rank {!! add_help('As this is the rank sorted lowest it will be automatically given to new users.') !!}</em></div>
+                        @endif
                     </td>
                     <td>
                         <a href="#" class="btn btn-primary edit-rank-button" data-id="{{ $rank->id }}">Edit</a>
-                        @if (!$rank->isAdmin)
+                        @if (!$rank->isAdmin && !$loop->last)
                             <a href="#" class="btn btn-danger delete-rank-button" data-id="{{ $rank->id }}">Delete</a>
                         @endif
                     </td>

--- a/resources/views/admin/users/ranks.blade.php
+++ b/resources/views/admin/users/ranks.blade.php
@@ -8,7 +8,8 @@
     {!! breadcrumbs(['Admin Panel' => 'admin', 'User Ranks' => 'admin/users/ranks']) !!}
 
     <h1>
-        User Ranks</h1>
+        User Ranks
+    </h1>
 
     <p>You can create and edit ranks to assign to users here. Ranks can have powers attached, which allows users with the rank to view and edit data on certain parts of the site. To assign a rank to a user, find their admin page from the <a
             href="{{ url('admin/users') }}">User Index</a> and change their rank there.</p>
@@ -26,9 +27,11 @@
         </thead>
         <tbody id="sortable" class="sortable">
             @foreach ($ranks as $rank)
-                <tr class=sort-item data-id="{{ $rank->id }}">
+                <tr {{ $rank->isSortable ? 'class=sort-item' : '' }} data-id="{{ $rank->id }}">
                     <td>
-                        <a class="fas fa-arrows-alt-v handle" href="#"></a>
+                        @if ($rank->isSortable)
+                            <a class="fas fa-arrows-alt-v handle" href="#"></a>
+                        @endif
                     </td>
                     <td><i class="{!! $rank->icon ? $rank->icon . ' mr-2' : '' !!} "></i>{!! $rank->displayName !!}</td>
                     <td>{!! $rank->parsed_description !!}</td>
@@ -40,13 +43,13 @@
                         @else
                             <div><em>{{ $rank->getPowers()['admin']['name'] }} {!! add_help('This rank has the &quot;Admin&quot; power granted to it, meaning it has all powers.') !!}</em></div>
                         @endif
-                        @if ($loop->last)
-                            <div><em>Default user rank {!! add_help('As this is the rank sorted lowest it will be automatically given to new users.') !!}</em></div>
+                        @if ($rank->isDefaultRank)
+                            <div><em>Default user rank {!! add_help('This is the default user rank. It can not have any powers. You can not delete this.') !!}</em></div>
                         @endif
                     </td>
                     <td>
                         <a href="#" class="btn btn-primary edit-rank-button" data-id="{{ $rank->id }}">Edit</a>
-                        @if (!$rank->isAdmin && !$loop->last)
+                        @if (!$rank->isAdmin && !$rank->isDefaultRank)
                             <a href="#" class="btn btn-danger delete-rank-button" data-id="{{ $rank->id }}">Delete</a>
                         @endif
                     </td>


### PR DESCRIPTION
I noticed how secondary admin can still not be sorted, and it kinda made me realize that admin ranks cannot be sorted at all.. Despite that some sites may have it differently. Also, the whole.. all of the ranks is a bit much?

Here's the gist:
- Secondary "Admin" power ranks can now be sorted, but it cannot be dead last.
  - As the default user rank is last, I figured it's good to prevent admin ranks to be sorted there.
- Neither main Admin rank nor Default user rank can be sorted or edited.
  - Default user rank can also no longer have powers.
- "Admin" power ranks now have an abbreviated list in the ranks list.
  - With an added help that explains it has all powers.
- The rank sorted last now has an extra mention it's the Default User Rank.
  - With an added help explaining it's the rank that will be given automatically to users.
- The Default User rank can not be deleted anymore.
  - This will prevent admin from deleting all ranks except admin and giving all new users the admin rank by default.

We should probably allow admin to _choose_ which rank should be the default user rank, but for now I figured this was an easy and quick way to fix this without adding more to the database. :)