### PR TITLE
Feat(world): Separate Trait Page/Entry

### DIFF
--- a/app/Http/Controllers/WorldController.php
+++ b/app/Http/Controllers/WorldController.php
@@ -470,6 +470,25 @@ class WorldController extends Controller {
     }
 
     /**
+     * Shows an individual trait's page.
+     *
+     * @param int $id
+     *
+     * @return \Illuminate\Contracts\Support\Renderable
+     */
+    public function getFeature($id) {
+        $$feature = Feature::visible(Auth::user() ?? null)->where('id', $id)->with('species', 'subtypes', 'rarity')->first();
+
+        if (!$feature) {
+            abort(404);
+        }
+
+        return view('world.feature_page', [
+            'feature' => $feature,
+        ]);
+    }
+
+    /**
      * Provides a single trait's description html for use in a modal.
      *
      * @param mixed $id

--- a/app/Models/Feature/Feature.php
+++ b/app/Models/Feature/Feature.php
@@ -259,7 +259,6 @@ class Feature extends Model {
         return url('world/traits?name='.$this->name);
     }
 
-
     /**
      * Gets the URL of the individual trait's page, by ID.
      *

--- a/app/Models/Feature/Feature.php
+++ b/app/Models/Feature/Feature.php
@@ -207,7 +207,7 @@ class Feature extends Model {
      * @return string
      */
     public function getDisplayNameAttribute() {
-        return '<a href="'.$this->url.'" class="display-trait">'.$this->name.'</a>'.($this->rarity ? ' ('.$this->rarity->displayName.')' : '');
+        return '<a href="'.$this->idUrl.'" class="display-trait">'.$this->name.'</a>'.($this->rarity ? ' ('.$this->rarity->displayName.')' : '');
     }
 
     /**
@@ -257,6 +257,16 @@ class Feature extends Model {
      */
     public function getUrlAttribute() {
         return url('world/traits?name='.$this->name);
+    }
+
+
+    /**
+     * Gets the URL of the individual trait's page, by ID.
+     *
+     * @return string
+     */
+    public function getIdUrlAttribute() {
+        return url('world/traits/'.$this->id);
     }
 
     /**

--- a/config/lorekeeper/extensions.php
+++ b/config/lorekeeper/extensions.php
@@ -140,6 +140,9 @@ return [
 
     // Unmerge Item Page and Item Entry - Speedy
     'unmerge_item_page_and_entry' => 0, // If enabled, uses the html on world/item_page.blade.php instead of the include that links to world/_item_entry.blade.php
+    
+    // Unmerge Trait Page and Trait Entry - Speedy
+    'unmerge_feature_page_and_entry' => 0, // If enabled, uses the html on world/feature_page.blade.php instead of the include that links to world/_feature_entry.blade.php
 
     // Show Species-only traits in dropdown - Speedy
     'show_exclusively_species_traits_in_dropdown' => 0, // If enabled, will only show traits from the associated species as well as traits that aren't species-limited in the dropdown menus.

--- a/config/lorekeeper/extensions.php
+++ b/config/lorekeeper/extensions.php
@@ -140,7 +140,7 @@ return [
 
     // Unmerge Item Page and Item Entry - Speedy
     'unmerge_item_page_and_entry' => 0, // If enabled, uses the html on world/item_page.blade.php instead of the include that links to world/_item_entry.blade.php
-    
+
     // Unmerge Trait Page and Trait Entry - Speedy
     'unmerge_feature_page_and_entry' => 0, // If enabled, uses the html on world/feature_page.blade.php instead of the include that links to world/_feature_entry.blade.php
 

--- a/resources/views/world/_feature_entry.blade.php
+++ b/resources/views/world/_feature_entry.blade.php
@@ -8,15 +8,33 @@
     @endif
     <div class="{{ $feature->has_image ? 'col-md-9' : 'col-12' }}">
         <x-admin-edit title="Trait" :object="$feature" />
-        <h3>
-            @if (!$feature->is_visible)
-                <i class="fas fa-eye-slash mr-1"></i>
-            @endif
-            {!! $feature->displayName !!}
-            <a href="{{ $feature->searchUrl }}" class="world-entry-search text-muted">
-                <i class="fas fa-search"></i>
-            </a>
-        </h3>
+        @if (isset($isPage) && $isPage)
+            <h1>
+                @if (!$feature->is_visible)
+                    <i class="fas fa-eye-slash mr-1"></i>
+                @endif
+                {!! $feature->displayName !!}
+                <a href="{{ $feature->url }}" class="world-entry-search text-muted">
+                    <i class="fa-solid fa-filter" data-toggle="tooltip" title="Search in Encyclopedia"></i>
+                </a>
+                <a href="{{ $feature->searchUrl }}" class="world-entry-search text-muted">
+                    <i class="fas fa-search" data-toggle="tooltip" title="Search in Masterlist"></i>
+                </a>
+            </h1>
+        @else
+            <h3>
+                @if (!$feature->is_visible)
+                    <i class="fas fa-eye-slash mr-1"></i>
+                @endif
+                {!! $feature->displayName !!}
+                <a href="{{ $feature->url }}" class="world-entry-search text-muted">
+                    <i class="fa-solid fa-filter" data-toggle="tooltip" title="Search in Encyclopedia"></i>
+                </a>
+                <a href="{{ $feature->searchUrl }}" class="world-entry-search text-muted">
+                    <i class="fas fa-search" data-toggle="tooltip" title="Search in Masterlist"></i>
+                </a>
+            </h3>
+        @endif
         @if ($feature->feature_category_id)
             <div>
                 <strong>Category:</strong> {!! $feature->category->displayName !!}

--- a/resources/views/world/feature_page.blade.php
+++ b/resources/views/world/feature_page.blade.php
@@ -1,0 +1,74 @@
+@extends('world.layout')
+
+@section('world-title')
+    {{ $feature->name }}
+@endsection
+
+@section('meta-img')
+    {{ $feature->imageUrl }}
+@endsection
+
+@section('meta-desc')
+    {!! isset($feature->category) && $feature->category ? '(Category: ' . $feature->category->name . ')' : '' !!} {!! isset($feature->rarity) && $feature->rarity ? '(Rarity: ' . $feature->rarity . ')' : '' !!} {!! substr(strip_tags($feature->description), 0, 200) !!} {!! isset($feature->uses) && $feature->uses ? '(Uses: ' . $feature->uses . ')' : '' !!}
+@endsection
+
+@section('content')
+    {!! breadcrumbs(['World' => 'world', 'Items' => 'world/items', $feature->name => $feature->idUrl]) !!}
+
+    <div class="row">
+        <div class="col-sm">
+        </div>
+        <div class="col-lg-6 col-lg-10">
+            <div class="card mb-3">
+                <div class="card-body">
+                    @if (config('lorekeeper.extensions.unmerge_feature_page_and_entry'))
+                        <div class="row world-entry">
+                            @if ($feature->has_image)
+                                <div class="col-md-3 world-entry-image">
+                                    <a href="{{ $feature->imageUrl }}" data-lightbox="entry" data-title="{{ $feature->name }}">
+                                        <img src="{{ $feature->imageUrl }}" class="world-entry-image" alt="{{ $feature->name }}" />
+                                    </a>
+                                </div>
+                            @endif
+                            <div class="{{ $feature->has_image ? 'col-md-9' : 'col-12' }}">
+                                <x-admin-edit title="Trait" :object="$feature" />
+                                <h3>
+                                    @if (!$feature->is_visible)
+                                        <i class="fas fa-eye-slash mr-1"></i>
+                                    @endif
+                                    {!! $feature->displayName !!}
+                                    <a href="{{ $feature->url }}" class="world-entry-search text-muted">
+                                        <i class="fa-solid fa-filter" data-toggle="tooltip" title="Search in Encyclopedia"></i>
+                                    </a>
+                                    <a href="{{ $feature->searchUrl }}" class="world-entry-search text-muted">
+                                        <i class="fas fa-search" data-toggle="tooltip" title="Search in Masterlist"></i>
+                                    </a>
+                                </h3>
+                                @if ($feature->feature_category_id)
+                                    <div>
+                                        <strong>Category:</strong> {!! $feature->category->displayName !!}
+                                    </div>
+                                @endif
+                                @if ($feature->species_id)
+                                    <div>
+                                        <strong>Species:</strong> {!! $feature->species->displayName !!}
+                                        @if (count($feature->getSubtypes(Auth::User() ?? null)))
+                                            ({!! $feature->displaySubtypes(Auth::User() ?? null) !!})
+                                        @endif
+                                    </div>
+                                @endif
+                                <div class="world-entry-text parsed-text">
+                                    {!! $feature->parsed_description !!}
+                                </div>
+                            </div>
+                        </div>
+                    @else
+                        @include('world._feature_entry', ['feature' => $feature, 'isPage' => true])
+                    @endif
+                </div>
+            </div>
+        </div>
+        <div class="col-sm">
+        </div>
+    </div>
+@endsection

--- a/routes/lorekeeper/browse.php
+++ b/routes/lorekeeper/browse.php
@@ -117,6 +117,7 @@ Route::group(['prefix' => 'world'], function () {
     Route::get('items/{id}', 'WorldController@getItem');
     Route::get('trait-categories', 'WorldController@getFeatureCategories');
     Route::get('traits', 'WorldController@getFeatures');
+    Route::get('traits/{id}', 'WorldController@getFeature');
     Route::get('traits/modal/{id}', 'WorldController@getFeatureDetail')->where(['id' => '[0-9]+']);
     Route::get('character-categories', 'WorldController@getCharacterCategories');
 });


### PR DESCRIPTION
Adds a separate trait page, based on id.

Just like with items, I've added an extension switch to separate the trait page and entry, for those who may have wanted it. :)

DisplayName now uses the idUrl instead of the World search. Also, added a filter icon for the World search. The magnifying glass retains it's function as search on the masterlist. Both now have a tooltip explaining the difference.