### PR TITLE
fix(world): Item Page/Entry consistency with Separate Trait Page

### DIFF
--- a/app/Models/Item/Item.php
+++ b/app/Models/Item/Item.php
@@ -194,7 +194,7 @@ class Item extends Model {
      * @return string
      */
     public function getDisplayNameAttribute() {
-        return '<a href="'.$this->url.'" class="display-item">'.$this->name.'</a>';
+        return '<a href="'.$this->idUrl.'" class="display-item">'.$this->name.'</a>';
     }
 
     /**

--- a/resources/views/world/_item_entry.blade.php
+++ b/resources/views/world/_item_entry.blade.php
@@ -9,8 +9,9 @@
                 @if (!$item->is_released)
                     <i class="fas fa-eye-slash mr-1"></i>
                 @endif
-                <a href="{{ $item->idUrl }}">
-                    {!! $item->name !!}
+                {!! $item->displayName !!}
+                <a href="{{ $item->url }}" class="world-entry-search text-muted">
+                    <i class="fa-solid fa-filter" data-toggle="tooltip" title="Search in Encyclopedia"></i>
                 </a>
             </h1>
         @else
@@ -19,8 +20,8 @@
                     <i class="fas fa-eye-slash mr-1"></i>
                 @endif
                 {!! $item->displayName !!}
-                <a href="{{ $item->idUrl }}" class="world-entry-search text-muted">
-                    <i class="fas fa-search"></i>
+                <a href="{{ $item->url }}" class="world-entry-search text-muted">
+                    <i class="fa-solid fa-filter" data-toggle="tooltip" title="Search in Encyclopedia"></i>
                 </a>
             </h3>
         @endif

--- a/resources/views/world/item_page.blade.php
+++ b/resources/views/world/item_page.blade.php
@@ -32,8 +32,9 @@
                                     @if (!$item->is_released)
                                         <i class="fas fa-eye-slash mr-1"></i>
                                     @endif
-                                    <a href="{{ $item->idUrl }}">
-                                        {!! $item->name !!}
+                                    {!! $item->displayName !!}
+                                    <a href="{{ $item->url }}" class="world-entry-search text-muted">
+                                        <i class="fa-solid fa-filter" data-toggle="tooltip" title="Search in Encyclopedia"></i>
                                     </a>
                                 </h1>
                                 <div class="row">


### PR DESCRIPTION
Changes to make the Item page/entry consistent to the new Separate Trait page update.

DisplayName now uses the idUrl, and the magnifying glass icon has been replaced by a filter icon, with accompanying tooltip, linking to the World search.