### PR TITLE
fix(Admin): Features 'Without Subtype' filter

### DIFF
--- a/app/Http/Controllers/Admin/Data/FeatureController.php
+++ b/app/Http/Controllers/Admin/Data/FeatureController.php
@@ -184,7 +184,7 @@ class FeatureController extends Controller {
         }
         if (isset($data['subtype_id']) && $data['subtype_id'] != 'none') {
             if ($data['subtype_id'] == 'withoutOption') {
-                $query->subtypes->isEmpty();
+                $query->doesntHave('subtypes');
             } else {
                 $query->whereHas('subtypes', function ($query) use ($data) {
                     $query->where('subtype_id', $data['subtype_id']);


### PR DESCRIPTION
In the admin section, this filter gives a 500. Since the Encyclopedia version _works_ instead of 500'ing, I figured I'd copy paste that.. spoilers: It works.