### PR TITLE
fix: suppress irrelevant/duplicate security advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,9 @@
             "advisories": {
                 "ignore-id": {
                     "PKSA-mdq4-51ck-6kdq": "Hotfixed using custom sanitization middleware.",
-                    "PKSA-8qx3-n5y5-vvnd": "Resolved in laravel/framework 10.48.23. Do not use wildcard validation with files in Laravel v8/Lorekeeper v2."
+                    "PKSA-8qx3-n5y5-vvnd": "Resolved in laravel/framework 10.48.23. Do not use wildcard validation with files in Laravel v8/Lorekeeper v2.",
+                    "PKSA-3r5d-mb8f-1qw9": "Hotfixed using custom sanitization middleware, duplicate of PKSA-mdq4-51ck-6kdq",
+                    "PKSA-m5cs-t1y6-qpcs": "Lorekeeper core does not use temporary signed URLs from the storage driver. Avoid using temporary signed urls as part of custom changes."
                 }
             }
         }


### PR DESCRIPTION
Here we go again...

- [PKSA-3r5d-mb8f-1qw9](https://packagist.org/security-advisories/PKSA-3r5d-mb8f-1qw9): Literally just the vulnerability we already patched in #1493 but with different affected versions (still us)
- [PKSA-m5cs-t1y6-qpcs](https://github.com/advisories/GHSA-crmm-hgp2-wgrp): As far as I can tell this only applies to temporary signed urls from the Storage driver. I think we literally only use the Storage driver like a tiny bit in develop, so it's completely irrelevant to us. If we make a shift to the Storage driver fully in the future then it might be a problem? But at that point we'll probably be at a patched version of Laravel.

Also, just to note, the composer.lock will need to be updated for the merge into v3 and above.