### PR TITLE
refactor: make object relationship on limit model polymorphic

### DIFF
--- a/app/Models/Limit/Limit.php
+++ b/app/Models/Limit/Limit.php
@@ -34,7 +34,7 @@ class Limit extends Model {
      * get the object of this type.
      */
     public function object() {
-        return $this->belongsTo($this->object_model, 'object_id');
+        return $this->morphTo(__FUNCTION__, 'object_model', 'object_id');
     }
 
     /**


### PR DESCRIPTION
[Apparently, this is simply a drop-in change, who knew!](https://laravel.com/docs/10.x/eloquent-relationships#morph-one-to-one-key-conventions)

Not sure if this strictly _improves_ anything, since this isn't really anything that would benefit from eager loading... we rarely call $limit->object, lol. But it's good practice, I think.