### PR TITLE
feat(prompts): change character prompt limits to be based on attached characters

### DIFF
--- a/app/Http/Controllers/Admin/SubmissionController.php
+++ b/app/Http/Controllers/Admin/SubmissionController.php
@@ -67,10 +67,11 @@ class SubmissionController extends Controller {
         $prompt = $submission->prompt;
 
         if ($prompt->limit_character) {
-            $limit = $prompt->limit * Character::visible()->where('is_myo_slot', 0)->where('user_id', $submission->user_id)->count();
+            $count = $prompt->getCount($submission->user, $submission->characters->pluck('character'));
         } else {
-            $limit = $prompt->limit;
+            $count = $prompt->getCount($submission->user);
         }
+        $limit = $prompt->limit;
 
         return view('admin.submissions.submission', [
             'submission'       => $submission,
@@ -86,7 +87,7 @@ class SubmissionController extends Controller {
             'currencies'          => Currency::where('is_user_owned', 1)->orderBy('name')->pluck('name', 'id'),
             'tables'              => LootTable::orderBy('name')->pluck('name', 'id'),
             'raffles'             => Raffle::where('rolled_at', null)->where('is_active', 1)->orderBy('name')->pluck('name', 'id'),
-            'count'               => $prompt->getCount($submission->user),
+            'count'               => $count,
             'limit'               => $limit,
         ] : []));
     }

--- a/app/Models/Prompt/Prompt.php
+++ b/app/Models/Prompt/Prompt.php
@@ -334,11 +334,11 @@ class Prompt extends Model {
      */
     public function getCount($user, $characters = null) {
         // filter the submissions by hour/day/week/etc and returns count
-        if($characters && count($characters)) {
+        if ($characters && count($characters)) {
             $ids = $characters->pluck('id');
             $submissions = Submission::submitted($this->id, $user->id)->whereHas('characters', function ($q) use ($ids) {
-                    $q->whereIn('character_id', $ids);
-                })->get();
+                $q->whereIn('character_id', $ids);
+            })->get();
         } else {
             $submissions = Submission::submitted($this->id, $user->id)->get();
         }

--- a/app/Models/Prompt/Prompt.php
+++ b/app/Models/Prompt/Prompt.php
@@ -334,7 +334,7 @@ class Prompt extends Model {
      */
     public function getCount($user, $characters = null) {
         // filter the submissions by hour/day/week/etc and returns count
-        if($characters && count($characters)) {
+        if ($characters && count($characters)) {
             $ids = $characters->pluck('id');
             $submissions = Submission::submitted($this->id, $user->id)->where(function ($query) use ($ids) {
                 $query->whereHas('characters', function ($q) use ($ids) {

--- a/app/Models/Prompt/Prompt.php
+++ b/app/Models/Prompt/Prompt.php
@@ -328,20 +328,32 @@ class Prompt extends Model {
      * Get an array of how many prompts the user has completed in general.
      *
      * @param mixed $user
+     * @param mixed $characters
      *
      * @return array
      */
-    public function getCount($user) {
+    public function getCount($user, $characters = null) {
         // filter the submissions by hour/day/week/etc and returns count
-        $count['all'] = Submission::submitted($this->id, $user->id)->count();
-        $count['Hour'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->startOfHour())->count();
-        $count['Day'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->startOfDay())->count();
-        $count['Week'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->startOfWeek())->count();
-        $count['BiWeekly'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->subWeeks(2))->count();
-        $count['Month'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->startOfMonth())->count();
-        $count['BiMonthly'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->subMonths(2))->count();
-        $count['Quarter'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->subMonths(3))->count();
-        $count['Year'] = Submission::submitted($this->id, $user->id)->where('created_at', '>=', now()->startOfYear())->count();
+        if($characters && count($characters)) {
+            $ids = $characters->pluck('id');
+            $submissions = Submission::submitted($this->id, $user->id)->where(function ($query) use ($ids) {
+                $query->whereHas('characters', function ($q) use ($ids) {
+                    $q->whereIn('character_id', $ids);
+                });
+            })->get();
+        } else {
+            $submissions = Submission::submitted($this->id, $user->id)->get();
+        }
+
+        $count['all'] = $submissions->count();
+        $count['Hour'] = $submissions->where('created_at', '>=', now()->startOfHour())->count();
+        $count['Day'] = $submissions->where('created_at', '>=', now()->startOfDay())->count();
+        $count['Week'] = $submissions->where('created_at', '>=', now()->startOfWeek())->count();
+        $count['BiWeekly'] = $submissions->where('created_at', '>=', now()->subWeeks(2))->count();
+        $count['Month'] = $submissions->where('created_at', '>=', now()->startOfMonth())->count();
+        $count['BiMonthly'] = $submissions->where('created_at', '>=', now()->subMonths(2))->count();
+        $count['Quarter'] = $submissions->where('created_at', '>=', now()->subMonths(3))->count();
+        $count['Year'] = $submissions->where('created_at', '>=', now()->startOfYear())->count();
 
         return $count;
     }

--- a/app/Models/Prompt/Prompt.php
+++ b/app/Models/Prompt/Prompt.php
@@ -334,13 +334,11 @@ class Prompt extends Model {
      */
     public function getCount($user, $characters = null) {
         // filter the submissions by hour/day/week/etc and returns count
-        if ($characters && count($characters)) {
+        if($characters && count($characters)) {
             $ids = $characters->pluck('id');
-            $submissions = Submission::submitted($this->id, $user->id)->where(function ($query) use ($ids) {
-                $query->whereHas('characters', function ($q) use ($ids) {
+            $submissions = Submission::submitted($this->id, $user->id)->whereHas('characters', function ($q) use ($ids) {
                     $q->whereIn('character_id', $ids);
-                });
-            })->get();
+                })->get();
         } else {
             $submissions = Submission::submitted($this->id, $user->id)->get();
         }

--- a/app/Services/PromptService.php
+++ b/app/Services/PromptService.php
@@ -362,10 +362,6 @@ class PromptService extends Service {
             unset($data['remove_image']);
         }
 
-        if (!isset($data['limit_character'])) {
-            $data['limit_character'] = null;
-        }
-
         return $data;
     }
 
@@ -401,6 +397,10 @@ class PromptService extends Service {
                 $this->deleteImage($prompt->imagePath, $prompt->imageFileName);
             }
             unset($data['remove_image']);
+        }
+
+        if (!isset($data['limit_character'])) {
+            $data['limit_character'] = null;
         }
 
         return $data;

--- a/app/Services/SubmissionManager.php
+++ b/app/Services/SubmissionManager.php
@@ -66,14 +66,16 @@ class SubmissionManager extends Service {
                 if ($prompt->limit) {
                     // check that the user hasn't hit the prompt submission limit
                     // filter the submissions by hour/day/week/etc and count
-                    $count = $prompt->getCount($user);
 
-                    // if limit by character is on... multiply by # of chars. otherwise, don't
+                    // if limit by character is on, filter submission count by attached characters. otherwise, don't
                     if ($prompt->limit_character) {
-                        $limit = $prompt->limit * Character::visible()->where('is_myo_slot', 0)->where('user_id', $user->id)->count();
+                        $characters = Character::myo(0)->visible()->whereIn('slug', $data['slug'])->get();
+                        $count = $prompt->getCount($user, $characters);
                     } else {
-                        $limit = $prompt->limit;
+                        $count = $prompt->getCount($user);
                     }
+                    $limit = $prompt->limit;
+
                     // if limit by time period is on
                     if ($prompt->limit_period) {
                         if ($count[$prompt->limit_period] >= $limit) {
@@ -170,14 +172,16 @@ class SubmissionManager extends Service {
                 ) {
                     // check that the user hasn't hit the prompt submission limit
                     // filter the submissions by hour/day/week/etc and count
-                    $count = $prompt->getCount($user);
 
-                    // if limit by character is on... multiply by # of chars. otherwise, don't
+                    // if limit by character is on, filter submission count by attached characters. otherwise, don't
                     if ($prompt->limit_character) {
-                        $limit = $prompt->limit * Character::visible()->where('is_myo_slot', 0)->where('user_id', $user->id)->count();
+                        $characters = Character::myo(0)->visible()->whereIn('slug', $data['slug'])->get();
+                        $count = $prompt->getCount($user, $characters);
                     } else {
-                        $limit = $prompt->limit;
+                        $count = $prompt->getCount($user);
                     }
+                    $limit = $prompt->limit;
+
                     // if limit by time period is on
                     if ($prompt->limit_period) {
                         if ($count[$prompt->limit_period] >= $limit) {

--- a/resources/views/admin/prompts/create_edit_prompt.blade.php
+++ b/resources/views/admin/prompts/create_edit_prompt.blade.php
@@ -97,9 +97,7 @@
         <div class="card-body">
             <h3>Submission Limits</h3>
             <p>Limit the number of times a user can submit. Leave blank to allow endless submissions.</p>
-            <p>Set a number into number of submissions. This will be applied for all time if you leave period blank, or per time period (ex: once a month, twice a week) if selected.</p>
-            <p>If you turn 'per character' on, then the number of submissions multiplies per character (ex: if you can submit twice a month per character and you own three characters, that's 6 submissions) HOWEVER it will not keep track of which
-                characters are being submitted due to conflicts arising in character cameos. A user will be able to submit those full 6 times with just one character...!</p>
+            <p><strong>Setting a number will allow to a user to submit that many times to this prompt.</strong> This will be applied for all time if you leave period blank, or per time period (ex: once a month, twice a week) if selected.</p>
             <div class="row">
                 <div class="col-md-6 form-group">
                     {!! Form::label('limit', 'Number of Submissions (Optional)') !!} {!! add_help('Enter a number to limit how many times a user can submit. Leave blank to allow endless submissions.') !!}
@@ -110,9 +108,15 @@
                     {!! Form::select('limit_period', $limit_periods, $prompt->limit_period, ['class' => 'form-control', 'data-name' => 'limit_period']) !!}
                 </div>
             </div>
+            <div class="alert alert-info">
+                <strong>If you turn 'per character' on, then a user will be able to submit that many times per character.</strong> On submissions with multiple characters, it will check for the number of times <em>any</em> of those characters have been attached to a submission.
+                <br />
+                <br />
+                For example: If Character A is in 1 submission and Character B is in 2 submissions, then the "previous submission count" on a submission with <em>both</em> characters will total 3.
+            </div>
             <div class="form-group">
                 {!! Form::checkbox('limit_character', 1, $prompt->limit_character, ['class' => 'form-check-input', 'data-toggle' => 'toggle']) !!}
-                {!! Form::label('limit_character', 'Per Character', ['class' => 'form-check-label ml-3']) !!} {!! add_help('If turned on, they can submit once per character they own on the masterlist.') !!}
+                {!! Form::label('limit_character', 'Per Character', ['class' => 'form-check-label ml-3']) !!} {!! add_help('If turned on, the limit will apply per attached character, rather than per user.') !!}
             </div>
         </div>
     </div>

--- a/resources/views/admin/prompts/create_edit_prompt.blade.php
+++ b/resources/views/admin/prompts/create_edit_prompt.blade.php
@@ -109,7 +109,8 @@
                 </div>
             </div>
             <div class="alert alert-info">
-                <strong>If you turn 'per character' on, then a user will be able to submit that many times per character.</strong> On submissions with multiple characters, it will check for the number of times <em>any</em> of those characters have been attached to a submission.
+                <strong>If you turn 'per character' on, then a user will be able to submit that many times per character.</strong> On submissions with multiple characters, it will check for the number of times <em>any</em> of those characters have been
+                attached to a submission.
                 <br />
                 <br />
                 For example: If Character A is in 1 submission and Character B is in 2 submissions, then the "previous submission count" on a submission with <em>both</em> characters will total 3.

--- a/resources/views/admin/submissions/submission.blade.php
+++ b/resources/views/admin/submissions/submission.blade.php
@@ -36,7 +36,13 @@
                 </div>
                 <div class="row">
                     <div class="col-md-2 col-4">
-                        <h5>Previous Submissions {!! add_help('This is the number of times the user has submitted this prompt before, pending or approved.') !!}</h5>
+                        <h5>
+                            @if($prompt->limit_character)
+                                Previous Submissions{!! add_help('This is the number of times the user has submitted this prompt before with the attached characters, pending or approved.') !!}
+                            @else
+                                Previous Submissions{!! add_help('This is the number of times the user has submitted this prompt before, pending or approved.') !!}
+                            @endif
+                        </h5>
                     </div>
                     <div class="col-md-10 col-8">
                         <div class="row text-center">

--- a/resources/views/admin/submissions/submission.blade.php
+++ b/resources/views/admin/submissions/submission.blade.php
@@ -37,7 +37,7 @@
                 <div class="row">
                     <div class="col-md-2 col-4">
                         <h5>
-                            @if($prompt->limit_character)
+                            @if ($prompt->limit_character)
                                 Previous Submissions{!! add_help('This is the number of times the user has submitted this prompt before with the attached characters, pending or approved.') !!}
                             @else
                                 Previous Submissions{!! add_help('This is the number of times the user has submitted this prompt before, pending or approved.') !!}

--- a/resources/views/home/_prompt.blade.php
+++ b/resources/views/home/_prompt.blade.php
@@ -12,8 +12,7 @@
             @endif
             <div class="{{ $prompt->limit ? 'text-danger' : '' }}">
                 <p>{{ $prompt->limit ? 'Users can submit this prompt ' . $prompt->limit . ' time(s)' : 'Users can submit this prompt an unlimited number of times' }}
-                    {{ $prompt->limit_period ? ' per ' . strtolower($prompt->limit_period) : '' }}
-                    {{ $prompt->limit_character ? ' per character' : '' }}.</p>
+                    {{ $prompt->limit_period ? ' per ' . strtolower($prompt->limit_period) : '' }}{{ $prompt->limit_character ? ' per character' : '' }}.</p>
             </div>
         @else
             <p>These are the default rewards for this prompt. The actual rewards you receive may be edited by a staff member during the approval process.</p>
@@ -21,13 +20,12 @@
                 <p>You have completed this prompt <strong>{{ $count['all'] }}</strong> time{{ $count['all'] == 1 ? '' : 's' }} overall.</p>
                 @if ($prompt->limit)
                     <p>You have already submitted this prompt {{ $prompt->limit_period ? $count[$prompt->limit_period] : $count['all'] }} out of {{ $prompt->limit }} times
-                        {{ $prompt->limit_period ? 'for this ' . strtolower($prompt->limit_period) : '' }}.
+                        {{ $prompt->limit_period ? 'for this ' . strtolower($prompt->limit_period) : '' }}{{ $prompt->limit_character ? ' across all characters' : '' }}.
                 @endif
             @endif
             <div class="{{ $prompt->limit ? 'text-danger' : '' }}">
                 <p>{{ $prompt->limit ? 'You can submit this prompt ' . $prompt->limit . ' time(s)' : 'You can submit this prompt an unlimited number of times' }}
-                    {{ $prompt->limit_period ? ' per ' . strtolower($prompt->limit_period) : '' }}
-                    {{ $prompt->limit_character ? ' per character' : '' }}.</p>
+                    {{ $prompt->limit_period ? ' per ' . strtolower($prompt->limit_period) : '' }}{{ $prompt->limit_character ? ' per character' : '' }}.</p>
             </div>
         @endif
         <table class="table table-sm mb-0">


### PR DESCRIPTION
Currently, prompt limits that are set "per character" are basically just "have you submitted this prompt more times than the number of characters you own". This change actually checks how many times a prompt has been submitted with the specific attached character(s).

Also some minor formatting fixes/a small bug with setting a prompt to be character based at all.

(In case you're wondering what's up with the if statement in `admin/submissions/submission.blade.php`, it's because if you don't shove the add_help directly next to the word "Submission" then it adds a linebreak and looks bad, lol. Same with some of the tweaks in `_prompt.blade.php`.)