### PR TITLE
fix: trade logic now catches for characters

### DIFF
--- a/app/Http/Controllers/Admin/HomeController.php
+++ b/app/Http/Controllers/Admin/HomeController.php
@@ -25,7 +25,7 @@ class HomeController extends Controller {
      */
     public function getIndex() {
         $openTransfersQueue = Settings::get('open_transfers_queue');
-        $openTradesQueue = Settings::get('open_trades_queue');
+        $openTradesQueue = Settings::get('open_trades_queue') || $openTransfersQueue;
         $galleryRequireApproval = Settings::get('gallery_submissions_require_approval');
         $galleryCurrencyAwards = Settings::get('gallery_submissions_reward_currency');
 

--- a/app/Services/TradeManager.php
+++ b/app/Services/TradeManager.php
@@ -395,7 +395,7 @@ class TradeManager extends Service {
             }
 
             if ($trade->is_sender_trade_confirmed && $trade->is_recipient_trade_confirmed) {
-                if ((!Settings::get('open_trades_queue') || !(Settings::get('open_transfers_queue')) && (isset($trade->data['sender']['characters']) || isset($trade->data['recipient']['characters'])))) {
+                if ( (!Settings::get('open_trades_queue')) && (!isset($trade->data['sender']['characters']) && !isset($trade->data['recipient']['characters'])) || (!Settings::get('open_transfers_queue')) && (isset($trade->data['sender']['characters'])) )  {
                     // Distribute the trade attachments
                     $this->creditAttachments($trade);
 


### PR DESCRIPTION
In reference to #1491 , this should fix the issue of trade filter not being enough.
Now it should:
- auto-complete trade if trade setting is 0 and there's no character in either sender or recipient slot
- auto-complete trade if transfer setting is 0 and there's a character in the trade

It does leave the scenario of trades moderated but transfer auto approved wonky, but I feel allowing this (where filtering thru trade themselves might be trickier) is better than the reverse, especially as trades don't only contain characters but all allowable items.

I've also modified the admin panel to display trades depending on its setting or transfer, meaning even if trades are auto-modded, in the case of transfer being manual it won't hide from Admins.