### PR TITLE
feat(prompts): show loot table rolls, fix character loot table rewards

### DIFF
--- a/app/Helpers/AssetHelpers.php
+++ b/app/Helpers/AssetHelpers.php
@@ -285,6 +285,28 @@ function parseAssetData($array, $isCharacter = false) {
 }
 
 /**
+ * Creates an asset array directly from dataReadyAssets, without needing to parse it first.
+ *
+ * @param array $array
+ * @param mixed $isCharacter
+ *
+ * @return array
+ */
+function createAssetsFromData($array, $isCharacter = false) {
+    $assets = createAssetsArray($isCharacter);
+    foreach ($array as $key => $contents) {
+        $model = getAssetModelString($key);
+        if ($model) {
+            foreach ($contents as $id => $quantity) {
+                addAsset($assets, $model::find($id), $quantity['quantity'] ?? $quantity);
+            }
+        }
+    }
+
+    return $assets;
+}
+
+/**
  * Returns if two asset arrays are identical.
  *
  * @param array $first
@@ -329,14 +351,20 @@ function compareAssetArrays($first, $second, $isCharacter = false, $absQuantitie
  * @param App\Models\User\User $recipient
  * @param string               $logType
  * @param string               $data
+ * @param mixed                $lootRolls
  *
  * @return array
  */
-function fillUserAssets($assets, $sender, $recipient, $logType, $data) {
+function fillUserAssets($assets, $sender, $recipient, $logType, $data, &$lootRolls = []) {
     // Roll on any loot tables
     if (isset($assets['loot_tables'])) {
         foreach ($assets['loot_tables'] as $table) {
-            $assets = mergeAssetsArrays($assets, $table['asset']->roll($table['quantity']));
+            $lootRoll = $table['asset']->roll($table['quantity']);
+            $lootRolls[$recipient->id][] = [
+                'table'   => $table['asset']->id,
+                'results' => $lootRoll,
+            ];
+            $assets = mergeAssetsArrays($assets, $lootRoll);
         }
         unset($assets['loot_tables']);
     }
@@ -516,10 +544,11 @@ function canTradeAsset($type, $asset) {
  * @param string                         $logType
  * @param string                         $data
  * @param mixed|null                     $submitter
+ * @param mixed                          $lootRolls
  *
  * @return array
  */
-function fillCharacterAssets($assets, $sender, $recipient, $logType, $data, $submitter = null) {
+function fillCharacterAssets($assets, $sender, $recipient, $logType, $data, $submitter, &$lootRolls = []) {
     if (!config('lorekeeper.extensions.character_reward_expansion.default_recipient') && $recipient->user) {
         $item_recipient = $recipient->user;
     } else {
@@ -529,7 +558,12 @@ function fillCharacterAssets($assets, $sender, $recipient, $logType, $data, $sub
     // Roll on any loot tables
     if (isset($assets['loot_tables'])) {
         foreach ($assets['loot_tables'] as $table) {
-            $assets = mergeAssetsArrays($assets, $table['asset']->roll($table['quantity']));
+            $lootRoll = $table['asset']->roll($table['quantity']);
+            $lootRolls[$recipient->id][] = [
+                'table'   => $table['asset']->id,
+                'results' => $lootRoll,
+            ];
+            $assets = mergeAssetsArrays($assets, $lootRoll);
         }
         unset($assets['loot_tables']);
     }

--- a/app/Helpers/AssetHelpers.php
+++ b/app/Helpers/AssetHelpers.php
@@ -548,7 +548,7 @@ function canTradeAsset($type, $asset) {
  *
  * @return array
  */
-function fillCharacterAssets($assets, $sender, $recipient, $logType, $data, $submitter, &$lootRolls = []) {
+function fillCharacterAssets($assets, $sender, $recipient, $logType, $data, $submitter = null, &$lootRolls = []) {
     if (!config('lorekeeper.extensions.character_reward_expansion.default_recipient') && $recipient->user) {
         $item_recipient = $recipient->user;
     } else {

--- a/app/Http/Controllers/Admin/SubmissionController.php
+++ b/app/Http/Controllers/Admin/SubmissionController.php
@@ -74,6 +74,7 @@ class SubmissionController extends Controller {
         $limit = $prompt->limit;
 
         return view('admin.submissions.submission', [
+            'prompt'           => $prompt,
             'submission'       => $submission,
             'inventory'        => $inventory,
             'rewardsData'      => isset($submission->data['rewards']) ? parseAssetData($submission->data['rewards']) : null,

--- a/app/Models/Loot/LootTable.php
+++ b/app/Models/Loot/LootTable.php
@@ -148,12 +148,13 @@ class LootTable extends Model {
     /**
      * Rolls on the loot table and consolidates the rewards.
      *
-     * @param int $quantity
+     * @param int   $quantity
+     * @param mixed $isCharacter
      *
      * @return \Illuminate\Support\Collection
      */
-    public function roll($quantity = 1) {
-        $rewards = createAssetsArray();
+    public function roll($quantity = 1, $isCharacter = false) {
+        $rewards = createAssetsArray($isCharacter);
 
         $loot = $this->loot;
         $totalWeight = 0;
@@ -182,11 +183,23 @@ class LootTable extends Model {
             if ($result) {
                 // If this is chained to another loot table, roll on that table
                 if ($result->rewardable_type == 'LootTable') {
-                    $rewards = mergeAssetsArrays($rewards, $result->reward->roll($result->quantity));
+                    $rewards = mergeAssetsArrays(
+                        $rewards,
+                        $result->reward->roll($result->quantity),
+                        $isCharacter
+                    );
                 } elseif ($result->rewardable_type == 'ItemCategory' || $result->rewardable_type == 'ItemCategoryRarity') {
-                    $rewards = mergeAssetsArrays($rewards, $this->rollCategory($result->rewardable_id, $result->quantity, ($result->data['criteria'] ?? null), ($result->data['rarity'] ?? null)));
+                    $rewards = mergeAssetsArrays(
+                        $rewards,
+                        $this->rollCategory($result->rewardable_id, $result->quantity, ($result->data['criteria'] ?? null), ($result->data['rarity'] ?? null)),
+                        $isCharacter
+                    );
                 } elseif ($result->rewardable_type == 'ItemRarity') {
-                    $rewards = mergeAssetsArrays($rewards, $this->rollRarityItem($result->quantity, $result->data['criteria'], $result->data['rarity']));
+                    $rewards = mergeAssetsArrays(
+                        $rewards,
+                        $this->rollRarityItem($result->quantity, $result->data['criteria'], $result->data['rarity']),
+                        $isCharacter
+                    );
                 } else {
                     addAsset($rewards, $result->reward, $result->quantity);
                 }

--- a/app/Services/SubmissionManager.php
+++ b/app/Services/SubmissionManager.php
@@ -467,7 +467,10 @@ class SubmissionManager extends Service {
             ];
 
             // Distribute user rewards
-            if (!$rewards = fillUserAssets($rewards, $user, $submission->user, $promptLogType, $promptData)) {
+            // $lootRolls keyed by id which is technically unneccessary for submissions,
+            // but is useful for situations where multiple users are receiving rewards and for consistent implementation
+            $lootRolls = [];
+            if (!$rewards = fillUserAssets($rewards, $user, $submission->user, $promptLogType, $promptData, $lootRolls)) {
                 throw new \Exception('Failed to distribute rewards to user.');
             }
 
@@ -507,11 +510,12 @@ class SubmissionManager extends Service {
             $submission->characters()->delete();
 
             // Distribute character rewards
+            $characterLootRolls = [];
             foreach ($characters as $c) {
                 // Users might not pass in clean arrays (may contain redundant data) so we need to clean that up
                 $assets = $this->processRewards($data + ['character_id' => $c->id, 'currencies' => $currencies, 'items' => $items, 'tables' => $tables], true);
 
-                if (!$assets = fillCharacterAssets($assets, $user, $c, $promptLogType, $promptData, $submission->user)) {
+                if (!$assets = fillCharacterAssets($assets, $user, $c, $promptLogType, $promptData, $submission->user, $characterLootRolls)) {
                     throw new \Exception('Failed to distribute rewards to character.');
                 }
 
@@ -545,9 +549,13 @@ class SubmissionManager extends Service {
                 'staff_id'              => $user->id,
                 'status'                => 'Approved',
                 'data'                  => [
-                    'user'                  => $addonData,
-                    'rewards'               => getDataReadyAssets($rewards),
-                    'gallery_submission_id' => $submission->data['gallery_submission_id'] ?? null,
+                    'user'                   => $addonData,
+                    'rewards'                => getDataReadyAssets($rewards),
+                    'gallery_submission_id'  => $submission->data['gallery_submission_id'] ?? null,
+                    'loot_rolls'             => [
+                        'user'       => $lootRolls[$submission->user_id] ?? [],
+                        'characters' => $characterLootRolls,
+                    ],
                 ], // list of rewards
             ]);
 

--- a/database/migrations/2026_08_09_221623_increase_submissions_data_column_limit.php
+++ b/database/migrations/2026_08_09_221623_increase_submissions_data_column_limit.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void {
+        //
+        Schema::table('submissions', function (Blueprint $table) {
+            $table->json('data')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void {
+        //
+        Schema::table('submissions', function (Blueprint $table) {
+            $table->string('data')->change();
+        });
+    }
+};

--- a/resources/views/admin/submissions/submission.blade.php
+++ b/resources/views/admin/submissions/submission.blade.php
@@ -120,7 +120,14 @@
                 </div>
             @endif
             @foreach ($submission->characters()->whereRelation('character', 'deleted_at', null)->get() as $character)
-                @include('widgets._character_select_entry', ['characterCurrencies' => $characterCurrencies, 'items' => $items, 'tables' => $tables, 'character' => $character, 'expanded_rewards' => $expanded_rewards])
+                @include('widgets._character_select_entry', [
+                    'characterCurrencies' => $characterCurrencies,
+                    'items' => $items,
+                    'tables' => $tables,
+                    'character' => $character,
+                    'expanded_rewards' => $expanded_rewards,
+                    'showLootTables' => true,
+                ])
             @endforeach
         </div>
         <div class="text-right mb-3">

--- a/resources/views/home/_submission_content.blade.php
+++ b/resources/views/home/_submission_content.blade.php
@@ -7,7 +7,6 @@
 
 </h1>
 
-
 <div class="card mb-3" style="clear:both;">
     <div class="card-body">
         <div class="row mb-2 no-gutters">
@@ -81,6 +80,19 @@
     <div class="card mb-3">
         <div class="card-header h2">Rewards</div>
         <div class="card-body">
+            @if (isset($submission->data['loot_rolls']['user']) && array_filter($submission->data['loot_rolls']['user']))
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <h4>Loot Rolls</h4>
+                        @foreach ($submission->data['loot_rolls']['user'] as $rolls)
+                            <div>
+                                Rolled on {!! \App\Models\Loot\LootTable::find($rolls['table'])->displayName !!} and received:
+                                {!! createRewardsString(createAssetsFromData($rolls['results']), true) !!}
+                            </div>
+                        @endforeach
+                    </div>
+                </div>
+            @endif
             <table class="table table-sm">
                 <thead class="thead-light">
                     <tr>
@@ -121,6 +133,19 @@
                         <div class="submission-character-info-content">
                             <h3 class="mb-2 submission-character-info-header"><a href="{{ $character->character->url }}">{{ $character->character->fullName }}</a></h3>
                             <div class="submission-character-info-body">
+                                @if (isset($submission->data['loot_rolls']['characters'][$character->character->id]))
+                                    <div class="card mb-3">
+                                        <div class="card-body">
+                                            <h5>Loot Rolls</h5>
+                                            @foreach ($submission->data['loot_rolls']['characters'][$character->character->id] as $rolls)
+                                                <div>
+                                                    Rolled on {!! \App\Models\Loot\LootTable::find($rolls['table'])->displayName !!} and received:
+                                                    {!! createRewardsString(createAssetsFromData($rolls['results']), true) !!}
+                                                </div>
+                                            @endforeach
+                                        </div>
+                                    </div>
+                                @endif
                                 @if (array_filter(parseAssetData($character->data)))
                                     <table class="table table-sm mb-0">
                                         <thead class="thead-light">
@@ -133,7 +158,7 @@
                                             @foreach (parseAssetData($character->data) as $key => $type)
                                                 @foreach ($type as $asset)
                                                     <tr>
-                                                        <td>{!! $asset['asset']->displayName !!} ({!! ucfirst($key) !!})</td>
+                                                        <td>{!! $asset['asset']->displayName !!} ({!! ucwords(str_replace('_', ' ', $key)) !!})</td>
                                                         <td>{{ $asset['quantity'] }}</td>
                                                     </tr>
                                                 @endforeach

--- a/resources/views/widgets/_character_select.blade.php
+++ b/resources/views/widgets/_character_select.blade.php
@@ -51,7 +51,6 @@
     </div>
     <table>
         <tr class="character-reward-row">
-
             @if ($expanded_rewards)
                 <td>
                     {!! Form::select('character_rewardable_type[]', ['Item' => 'Item', 'Currency' => 'Currency'] + (isset($showLootTables) && $showLootTables ? ['LootTable' => 'Loot Table'] : []), null, [

--- a/resources/views/widgets/_character_select_entry.blade.php
+++ b/resources/views/widgets/_character_select_entry.blade.php
@@ -55,7 +55,7 @@
                                                 'placeholder' => 'Select Currency',
                                             ]) !!}</div>
                                             <div class="character-items  {{ $reward->rewardable_type == 'Item' ? 'show' : 'hide' }}">{!! Form::select('character_rewardable_id[' . $character->character_id . '][]', $items, $reward->rewardable_type == 'Item' ? $reward->rewardable_id : null, ['class' => 'form-control character-item-id', 'placeholder' => 'Select Item']) !!}</div>
-                                            <div class="character-tables {{ $reward->rewardable_type == 'Loot Table' ? 'show' : 'hide' }}">{!! Form::select('character_rewardable_id[' . $character->character_id . '][]', $tables, $reward->rewardable_type == 'Loot Table' ? $reward->rewardable_id : null, [
+                                            <div class="character-tables {{ $reward->rewardable_type == 'LootTable' ? 'show' : 'hide' }}">{!! Form::select('character_rewardable_id[' . $character->character_id . '][]', $tables, $reward->rewardable_type == 'LootTable' ? $reward->rewardable_id : null, [
                                                 'class' => 'form-control character-table-id',
                                                 'placeholder' => 'Select Loot Table',
                                             ]) !!}</div>


### PR DESCRIPTION
- Displays the reward that a specific loot table gives
- Fixes character loot table rewards ("Loot Table" vs "LootTable")
- Fixes character loot table rolls (incorrect asset creation)
- Updates submission `data` table to be json to allow for longer strings
<img width="1351" height="703" alt="image" src="https://github.com/user-attachments/assets/3a218b8f-96f1-4da3-b89a-08308613224d" />
<img width="1477" height="808" alt="image" src="https://github.com/user-attachments/assets/a7548754-5787-430a-890e-aa9e808bae99" />
