### PR TITLE
fix(design updates): delete related models when deleting design update

### DIFF
--- a/app/Console/Commands/FixDeletedDesignUpdates.php
+++ b/app/Console/Commands/FixDeletedDesignUpdates.php
@@ -3,8 +3,6 @@
 namespace App\Console\Commands;
 
 use App\Models\Character\CharacterDesignUpdate;
-use App\Models\Character\CharacterFeature;
-use App\Models\Shop\ShopStockCost;
 use Illuminate\Console\Command;
 
 class FixDeletedDesignUpdates extends Command {

--- a/app/Console/Commands/FixDeletedDesignUpdates.php
+++ b/app/Console/Commands/FixDeletedDesignUpdates.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Character\CharacterDesignUpdate;
+use App\Models\Character\CharacterFeature;
+use App\Models\Shop\ShopStockCost;
+use Illuminate\Console\Command;
+
+class FixDeletedDesignUpdates extends Command {
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'fix-deleted-design-updates';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Fixes features and creators orphaned by deleted design updates.';
+
+    /**
+     * Create a new command instance.
+     */
+    public function __construct() {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle() {
+        $deletedUpdates = CharacterDesignUpdate::onlyTrashed()->get();
+
+        foreach($deletedUpdates as $update) {
+            if($update->rawFeatures->count()) {
+                $update->rawFeatures()->delete();
+                $this->info('Update #'. $update->id . ': Deleted orphaned features');
+            }
+            if($update->artists->count()) {
+                $update->artists()->delete();
+                $this->info('Update #'. $update->id . ': Deleted orphaned artists');
+            }
+            if($update->designers->count()) {
+                $update->designers()->delete();
+                $this->info('Update #'. $update->id . ': Deleted orphaned designers');
+            }
+        }
+
+        $this->info('Success!');
+    }
+}

--- a/app/Console/Commands/FixDeletedDesignUpdates.php
+++ b/app/Console/Commands/FixDeletedDesignUpdates.php
@@ -35,18 +35,18 @@ class FixDeletedDesignUpdates extends Command {
     public function handle() {
         $deletedUpdates = CharacterDesignUpdate::onlyTrashed()->get();
 
-        foreach($deletedUpdates as $update) {
-            if($update->rawFeatures->count()) {
+        foreach ($deletedUpdates as $update) {
+            if ($update->rawFeatures->count()) {
                 $update->rawFeatures()->delete();
-                $this->info('Update #'. $update->id . ': Deleted orphaned features');
+                $this->info('Update #'.$update->id.': Deleted orphaned features');
             }
-            if($update->artists->count()) {
+            if ($update->artists->count()) {
                 $update->artists()->delete();
-                $this->info('Update #'. $update->id . ': Deleted orphaned artists');
+                $this->info('Update #'.$update->id.': Deleted orphaned artists');
             }
-            if($update->designers->count()) {
+            if ($update->designers->count()) {
                 $update->designers()->delete();
-                $this->info('Update #'. $update->id . ': Deleted orphaned designers');
+                $this->info('Update #'.$update->id.': Deleted orphaned designers');
             }
         }
 

--- a/app/Services/DesignUpdateManager.php
+++ b/app/Services/DesignUpdateManager.php
@@ -913,6 +913,9 @@ class DesignUpdateManager extends Service {
             }
 
             // Delete the request
+            $request->features()->delete();
+            $request->designers()->delete();
+            $request->artists()->delete();
             $request->delete();
 
             return $this->commitReturn(true);

--- a/app/Services/DesignUpdateManager.php
+++ b/app/Services/DesignUpdateManager.php
@@ -913,7 +913,7 @@ class DesignUpdateManager extends Service {
             }
 
             // Delete the request
-            $request->features()->delete();
+            $request->rawFeatures()->delete();
             $request->designers()->delete();
             $request->artists()->delete();
             $request->delete();


### PR DESCRIPTION
Small fix I've been meaning to PR for a while -- currently, when a design update is deleted, the attached CharacterFeatures and CharacterImageCreators are orphaned in the database. This frequently causes problems when trying to delete a trait, because it will think that the trait is still attached to something.

Also includes a console command, `fix-deleted-design-updates`, to remove any pre-existing orphans.